### PR TITLE
ATO-1868: Refactor and rename orch KeyPairHelper

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -33,7 +33,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserI
 import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -75,7 +75,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
-    private final KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+    private final KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
     public static final String ENCODED_DEVICE_INFORMATION =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -75,7 +75,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
-    private final KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private final KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
     public static final String ENCODED_DEVICE_INFORMATION =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -61,8 +61,6 @@ import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -98,6 +96,7 @@ import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -1068,17 +1067,6 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         "code",
                         new AuthorizationCode().getValue()));
         return queryStringParameters;
-    }
-
-    private static KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 
     protected static class TestConfigurationService extends IntegrationTestConfigurationService {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -53,14 +53,11 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.HttpCookie;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.HashMap;
@@ -102,6 +99,7 @@ import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.as
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -111,8 +109,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String AM_CLIENT_ID = "am-test-client";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PASSWORD = "password";
-    private static final KeyPair RP_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
-    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
+    private static final KeyPair RP_KEY_PAIR = generateRsaKeyPair();
+    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = generateRsaKeyPair();
     private static final String AUTH_PUBLIC_ENCRYPTION_KEY =
             "-----BEGIN PUBLIC KEY-----\n"
                     + Base64.getMimeEncoder()
@@ -2316,17 +2314,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var signer = new RSASSASigner(RP_KEY_PAIR.getPrivate());
         signedJWT.sign(signer);
         return signedJWT;
-    }
-
-    private static KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 
     private static String getClientSessionId(APIGatewayProxyResponseEvent response) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -53,7 +53,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.HttpCookie;
 import java.net.URI;
@@ -111,8 +111,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String AM_CLIENT_ID = "am-test-client";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PASSWORD = "password";
-    private static final KeyPair RP_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
-    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
+    private static final KeyPair RP_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
+    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
     private static final String AUTH_PUBLIC_ENCRYPTION_KEY =
             "-----BEGIN PUBLIC KEY-----\n"
                     + Base64.getMimeEncoder()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -111,8 +111,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String AM_CLIENT_ID = "am-test-client";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PASSWORD = "password";
-    private static final KeyPair RP_KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final KeyPair RP_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
+    private static final KeyPair AUTH_ENCRYPTION_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
     private static final String AUTH_PUBLIC_ENCRYPTION_KEY =
             "-----BEGIN PUBLIC KEY-----\n"
                     + Base64.getMimeEncoder()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1172,6 +1172,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             List.of(
                                     LevelOfConfidence.MEDIUM_LEVEL.getValue(),
                                     LevelOfConfidence.HMRC200.getValue()))
+                    .withPublicKey(
+                            Base64.getMimeEncoder()
+                                    .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
                     .saveToDynamo();
             handler = new AuthorisationHandler(configuration);
             txmaAuditQueue.clear();
@@ -1343,6 +1346,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             List.of(CORE_IDENTITY_JWT.getValue(), ValidClaims.ADDRESS.getValue()))
                     .withClaims(
                             List.of(CORE_IDENTITY_JWT.getValue(), ValidClaims.ADDRESS.getValue()))
+                    .withPublicKey(
+                            Base64.getMimeEncoder()
+                                    .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
                     .saveToDynamo();
             handler = new AuthorisationHandler(configuration, redisConnectionService);
             txmaAuditQueue.clear();
@@ -1924,6 +1930,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     .withClaims(
                             List.of(CORE_IDENTITY_JWT.getValue(), ValidClaims.ADDRESS.getValue()))
                     .withPkceEnforced(true)
+                    .withPublicKey(
+                            Base64.getMimeEncoder()
+                                    .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
                     .saveToDynamo();
             handler = new AuthorisationHandler(configuration, redisConnectionService);
             txmaAuditQueue.clear();
@@ -2174,6 +2183,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 LevelOfConfidence.MEDIUM_LEVEL.getValue(),
                                 LevelOfConfidence.HMRC200.getValue()))
                 .withClaims(List.of(CORE_IDENTITY_JWT.getValue(), ValidClaims.ADDRESS.getValue()))
+                .withPublicKey(
+                        Base64.getMimeEncoder()
+                                .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
                 .saveToDynamo();
         handler = new AuthorisationHandler(configuration, redisConnectionService);
         txmaAuditQueue.clear();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -52,7 +52,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final String CLIENT_NAME = "some-client-name";
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final Subject SUBJECT = new Subject();
-    private final KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private final KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final String SESSION_ID = "test-session-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -19,7 +19,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -52,7 +52,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final String CLIENT_NAME = "some-client-name";
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final Subject SUBJECT = new Subject();
-    private final KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+    private final KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final String SESSION_ID = "test-session-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -64,7 +64,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
     private static final String RP_REDIRECT_URI = "https://rp-uri/redirect";
     private static final String ORCHESTRATION_REDIRECT_URI = "https://orchestration/redirect";
     private static final String LOGIN_HINT = "joe.bloggs@digital.cabinet-office.gov.uk";
-    private static final KeyPair KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final KeyPair KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
     private static final String publicKey =
             "-----BEGIN PUBLIC KEY-----\n"
                     + Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -25,7 +25,7 @@ import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationT
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -64,7 +64,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
     private static final String RP_REDIRECT_URI = "https://rp-uri/redirect";
     private static final String ORCHESTRATION_REDIRECT_URI = "https://orchestration/redirect";
     private static final String LOGIN_HINT = "joe.bloggs@digital.cabinet-office.gov.uk";
-    private static final KeyPair KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
+    private static final KeyPair KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
     private static final String publicKey =
             "-----BEGIN PUBLIC KEY-----\n"
                     + Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -157,7 +157,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallTokenResourceAndReturnAccessAndRefreshTokenWhenAuthenticatingWithPrivateKeyJwt(
             Optional<String> vtr, String expectedVotClaim, Optional<String> clientId)
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -192,7 +192,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldAllowIssuerUriAsPrivateKeyJwtAudience() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -236,7 +236,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200WithTokensWhenPrivateKeyJwtContainsBothIssuerAndTokenURIAsAudienceList()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -321,7 +321,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturn400WhenClientIdParameterDoesNotMatch() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -348,7 +348,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPublicSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -389,7 +389,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPairwiseSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -429,7 +429,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturnIdentityClaims() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
@@ -478,7 +478,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceAndOnlyReturnAccessTokenWithoutOfflineAccessScope()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         userStore.signUp(TEST_EMAIL, "password-1", new Subject());
         registerClientWithPrivateKeyJwtAuthentication(
@@ -513,7 +513,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         Subject publicSubject = new Subject();
         Subject internalSubject = new Subject();
         Subject internalPairwiseSubject = new Subject();
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         userStore.signUp(TEST_EMAIL, "password-1", internalSubject);
         registerClientWithPrivateKeyJwtAuthentication(
                 keyPair.getPublic(), scope, SubjectType.PAIRWISE);
@@ -572,7 +572,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
         Subject publicSubject = new Subject();
         Subject internalSubject = new Subject();
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         userStore.signUp(TEST_EMAIL, "password-1", internalSubject);
         registerClientWithPrivateKeyJwtAuthentication(
                 keyPair.getPublic(), scope, SubjectType.PAIRWISE);
@@ -661,7 +661,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceUsingPrivateKeyJwtAndWarnWhenClientIdInAuthCodeDoesNotMatchRequest()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -693,7 +693,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceAndWarnWhenPkceValidationFails() throws Exception {
         CodeVerifier invalidCodeVerifier = new CodeVerifier();
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -60,7 +60,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -157,7 +157,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallTokenResourceAndReturnAccessAndRefreshTokenWhenAuthenticatingWithPrivateKeyJwt(
             Optional<String> vtr, String expectedVotClaim, Optional<String> clientId)
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -192,7 +192,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldAllowIssuerUriAsPrivateKeyJwtAudience() throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -236,7 +236,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200WithTokensWhenPrivateKeyJwtContainsBothIssuerAndTokenURIAsAudienceList()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -321,7 +321,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturn400WhenClientIdParameterDoesNotMatch() throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -348,7 +348,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPublicSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -389,7 +389,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPairwiseSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -429,7 +429,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturnIdentityClaims() throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
@@ -478,7 +478,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceAndOnlyReturnAccessTokenWithoutOfflineAccessScope()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         userStore.signUp(TEST_EMAIL, "password-1", new Subject());
         registerClientWithPrivateKeyJwtAuthentication(
@@ -513,7 +513,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         Subject publicSubject = new Subject();
         Subject internalSubject = new Subject();
         Subject internalPairwiseSubject = new Subject();
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         userStore.signUp(TEST_EMAIL, "password-1", internalSubject);
         registerClientWithPrivateKeyJwtAuthentication(
                 keyPair.getPublic(), scope, SubjectType.PAIRWISE);
@@ -572,7 +572,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
         Subject publicSubject = new Subject();
         Subject internalSubject = new Subject();
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         userStore.signUp(TEST_EMAIL, "password-1", internalSubject);
         registerClientWithPrivateKeyJwtAuthentication(
                 keyPair.getPublic(), scope, SubjectType.PAIRWISE);
@@ -661,7 +661,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceUsingPrivateKeyJwtAndWarnWhenClientIdInAuthCodeDoesNotMatchRequest()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -693,7 +693,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceAndWarnWhenPkceValidationFails() throws Exception {
         CodeVerifier invalidCodeVerifier = new CodeVerifier();
-        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
+        KeyPair keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
+import static uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper.generateRsaKeyPair;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -58,7 +58,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
         updateRequest.setPublicKeySource(expectedPublicKeySource);
         var expectedPublicKey =
                 Base64.getMimeEncoder()
-                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded());
+                        .encodeToString(generateRsaKeyPair().getPublic().getEncoded());
         updateRequest.setPublicKey(expectedPublicKey);
         var expectedScopes = List.of("openid", "email");
         updateRequest.setScopes(expectedScopes);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -24,8 +24,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper.generateRsaKeyPair;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -48,9 +48,6 @@ import uk.gov.di.orchestration.sharedtest.helper.TestClockHelper;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
@@ -74,6 +71,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.ipv.services.IPVAuthorisationService.STATE_STORAGE_PREFIX;
 import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class IPVAuthorisationServiceTest {
 
@@ -465,16 +463,5 @@ class IPVAuthorisationServiceTest {
     private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
         encryptedJWT.decrypt(new RSADecrypter(privateKey));
         return encryptedJWT.getPayload().toSignedJWT();
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.text.ParseException;
@@ -46,7 +46,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -72,7 +72,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenVTRClaimIsPresent() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -111,7 +111,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenClaimsClaimIsPresentAsString()
             throws JOSEException, ParseException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -143,7 +143,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenClaimsClaimIsPresentAsJson()
             throws JOSEException, ParseException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 JWTClaimsSet.parse(
@@ -203,7 +203,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenUILocalesClaimIsPresent()
             throws JOSEException, LangTagException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var uiLocales = "cy";
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("ui_locales", uiLocales).build();
@@ -232,7 +232,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsString()
             throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", "123").build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -260,7 +260,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsInteger()
             throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", 123).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -287,7 +287,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenLoginHintClaimPresent() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("login_hint", "test@email.com").build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -317,7 +317,7 @@ class RequestObjectToAuthRequestHelperTest {
         var codeChallenge = "aCodeChallenge";
         var codeChallengeMethod = CodeChallengeMethod.S256.getValue();
 
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -355,7 +355,7 @@ class RequestObjectToAuthRequestHelperTest {
         var codeChallenge = "aCodeChallenge";
         var codeChallengeMethod = CodeChallengeMethod.S256;
 
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -410,7 +410,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldRetrieveRpSidFromRequestObject() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var rpSid = "test-rp-sid";
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("rp_sid", rpSid).build();
@@ -439,7 +439,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldSuccessfullyParseAnAuthOnlyRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -46,7 +46,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -72,7 +72,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenVTRClaimIsPresent() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -111,7 +111,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenClaimsClaimIsPresentAsString()
             throws JOSEException, ParseException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -143,7 +143,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenClaimsClaimIsPresentAsJson()
             throws JOSEException, ParseException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 JWTClaimsSet.parse(
@@ -203,7 +203,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenUILocalesClaimIsPresent()
             throws JOSEException, LangTagException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var uiLocales = "cy";
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("ui_locales", uiLocales).build();
@@ -232,7 +232,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsString()
             throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", "123").build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -260,7 +260,7 @@ class RequestObjectToAuthRequestHelperTest {
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsInteger()
             throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", 123).build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -287,7 +287,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenLoginHintClaimPresent() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("login_hint", "test@email.com").build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -317,7 +317,7 @@ class RequestObjectToAuthRequestHelperTest {
         var codeChallenge = "aCodeChallenge";
         var codeChallengeMethod = CodeChallengeMethod.S256.getValue();
 
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -355,7 +355,7 @@ class RequestObjectToAuthRequestHelperTest {
         var codeChallenge = "aCodeChallenge";
         var codeChallengeMethod = CodeChallengeMethod.S256;
 
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)
@@ -410,7 +410,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldRetrieveRpSidFromRequestObject() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var rpSid = "test-rp-sid";
         var jwtClaimsSet = getClaimsSetBuilder(scope).claim("rp_sid", rpSid).build();
@@ -439,7 +439,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldSuccessfullyParseAnAuthOnlyRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 getClaimsSetBuilder(scope)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -800,7 +800,7 @@ class AuthCodeHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -56,8 +56,8 @@ import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.util.Base64;
@@ -800,7 +800,7 @@ class AuthCodeHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -89,9 +89,9 @@ import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.net.URLDecoder;
@@ -214,7 +214,7 @@ class AuthorisationHandlerTest {
     private static final Boolean IS_ONE_LOGIN = false;
     private static final Boolean IS_COOKIE_CONSENT_SHARED = false;
     private static final String RP_SERVICE_TYPE = "MANDATORY";
-    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
+    private static final KeyPair RSA_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
     private static final ECKey EC_SIGNING_KEY = generateECSigningKey();
 
     static {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -214,7 +214,7 @@ class AuthorisationHandlerTest {
     private static final Boolean IS_ONE_LOGIN = false;
     private static final Boolean IS_COOKIE_CONSENT_SHARED = false;
     private static final String RP_SERVICE_TYPE = "MANDATORY";
-    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
     private static final ECKey EC_SIGNING_KEY = generateECSigningKey();
 
     static {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -1687,7 +1687,7 @@ public class TokenHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -71,8 +71,8 @@ import uk.gov.di.orchestration.shared.services.TokenValidationService;
 import uk.gov.di.orchestration.shared.validation.TokenClientAuthValidator;
 import uk.gov.di.orchestration.shared.validation.TokenClientAuthValidatorFactory;
 import uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -1687,7 +1687,7 @@ public class TokenHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.generateRsaKeyPair();
+        var keyPair = KeyPairUtils.generateRsaKeyPair();
         Scope scope = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -72,14 +72,11 @@ import uk.gov.di.orchestration.shared.validation.TokenClientAuthValidator;
 import uk.gov.di.orchestration.shared.validation.TokenClientAuthValidatorFactory;
 import uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
-import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -114,6 +111,7 @@ import static uk.gov.di.orchestration.shared.entity.CustomScopeValue.DOC_CHECKIN
 import static uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper.generateIDToken;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 public class TokenHandlerTest {
 
@@ -1675,19 +1673,8 @@ public class TokenHandlerTest {
                 .build();
     }
 
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException();
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
-    }
-
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairUtils.generateRsaKeyPair();
+        var keyPair = generateRsaKeyPair();
         Scope scope = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -48,8 +48,6 @@ import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -74,6 +72,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class OrchestrationAuthorizationServiceTest {
 
@@ -369,17 +368,6 @@ class OrchestrationAuthorizationServiceTest {
     private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
         encryptedJWT.decrypt(new RSADecrypter(privateKey));
         return encryptedJWT.getPayload().toSignedJWT();
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 
     private SdkBytes getHashSdkBytes(String jwtMessage) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -36,9 +36,6 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -59,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class QueryParamsAuthorizeValidatorTest {
 
@@ -860,16 +858,5 @@ class QueryParamsAuthorizeValidatorTest {
         channelOpt.ifPresent(channel -> authRequestBuilder.customParameter("channel", channel));
 
         return authRequestBuilder.build();
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -38,7 +38,7 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -88,7 +88,7 @@ class RequestObjectAuthorizeValidatorTest {
     @BeforeEach
     void setup() {
         when(oidcApi.authorizeURI()).thenReturn(OIDC_BASE_AUTHORIZE_URI);
-        keyPair = KeyPairHelper.generateRsaKeyPair();
+        keyPair = KeyPairUtils.generateRsaKeyPair();
         validator =
                 new RequestObjectAuthorizeValidator(
                         configurationService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -38,12 +38,9 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -63,6 +60,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.oidc.helper.RequestObjectTestHelper.generateSignedJWT;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class RequestObjectAuthorizeValidatorTest {
 
@@ -88,7 +86,7 @@ class RequestObjectAuthorizeValidatorTest {
     @BeforeEach
     void setup() {
         when(oidcApi.authorizeURI()).thenReturn(OIDC_BASE_AUTHORIZE_URI);
-        keyPair = KeyPairUtils.generateRsaKeyPair();
+        keyPair = generateRsaKeyPair();
         validator =
                 new RequestObjectAuthorizeValidator(
                         configurationService,
@@ -842,11 +840,8 @@ class RequestObjectAuthorizeValidatorTest {
 
     @Test
     void shouldThrowWhenUnableToValidateRequestJwtSignature()
-            throws JOSEException,
-                    NoSuchAlgorithmException,
-                    ClientSignatureValidationException,
-                    JwksException {
-        var keyPair2 = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+            throws JOSEException, ClientSignatureValidationException, JwksException {
+        var keyPair2 = generateRsaKeyPair();
         var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().build();
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair2));
         doThrow(new RuntimeException())

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -88,7 +88,7 @@ class RequestObjectAuthorizeValidatorTest {
     @BeforeEach
     void setup() {
         when(oidcApi.authorizeURI()).thenReturn(OIDC_BASE_AUTHORIZE_URI);
-        keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        keyPair = KeyPairHelper.generateRsaKeyPair();
         validator =
                 new RequestObjectAuthorizeValidator(
                         configurationService,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -18,7 +18,7 @@ import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.util.Base64;
 import java.util.List;
@@ -110,8 +110,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
         private List<String> scopes = singletonList("openid");
         private String publicKey =
                 Base64.getMimeEncoder()
-                        .encodeToString(
-                                KeyPairHelper.generateRsaKeyPair().getPublic().getEncoded());
+                        .encodeToString(KeyPairUtils.generateRsaKeyPair().getPublic().getEncoded());
         private List<String> postLogoutRedirectUris =
                 singletonList("http://localhost/post-redirect-logout");
         private String backChannelLogoutUri = "http://example.com";

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -111,7 +111,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
         private String publicKey =
                 Base64.getMimeEncoder()
                         .encodeToString(
-                                KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPublic().getEncoded());
+                                KeyPairHelper.generateRsaKeyPair().getPublic().getEncoded());
         private List<String> postLogoutRedirectUris =
                 singletonList("http://localhost/post-redirect-logout");
         private String backChannelLogoutUri = "http://example.com";

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/KeyPairHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/KeyPairHelper.java
@@ -4,25 +4,18 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
-import static java.util.Objects.isNull;
-
 public class KeyPairHelper {
 
     private KeyPairHelper() {}
 
-    private static KeyPair cachedKeyPair = null;
-
-    public static final KeyPair GENERATE_RSA_KEY_PAIR() {
-        if (isNull(KeyPairHelper.cachedKeyPair)) {
-            KeyPairGenerator kpg;
-            try {
-                kpg = KeyPairGenerator.getInstance("RSA");
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException();
-            }
-            kpg.initialize(2048);
-            KeyPairHelper.cachedKeyPair = kpg.generateKeyPair();
+    public static KeyPair GENERATE_RSA_KEY_PAIR() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
         }
-        return KeyPairHelper.cachedKeyPair;
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/KeyPairHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/KeyPairHelper.java
@@ -8,7 +8,7 @@ public class KeyPairHelper {
 
     private KeyPairHelper() {}
 
-    public static KeyPair GENERATE_RSA_KEY_PAIR() {
+    public static KeyPair generateRsaKeyPair() {
         KeyPairGenerator kpg;
         try {
             kpg = KeyPairGenerator.getInstance("RSA");

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/utils/KeyPairUtils.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/utils/KeyPairUtils.java
@@ -1,12 +1,12 @@
-package uk.gov.di.orchestration.sharedtest.helper;
+package uk.gov.di.orchestration.sharedtest.utils;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
-public class KeyPairHelper {
+public class KeyPairUtils {
 
-    private KeyPairHelper() {}
+    private KeyPairUtils() {}
 
     public static KeyPair generateRsaKeyPair() {
         KeyPairGenerator kpg;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
@@ -26,8 +26,6 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.state.UserContext;
 
 import java.net.URI;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +34,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class DocAppUserHelperTest {
 
@@ -66,7 +65,7 @@ class DocAppUserHelperTest {
     @ParameterizedTest
     @MethodSource("clientTypes")
     void shouldReturnFalseIfRequestObjectDoesNotContainDocAppScope(ClientType clientType)
-            throws NoSuchAlgorithmException, JOSEException {
+            throws JOSEException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)
@@ -94,7 +93,7 @@ class DocAppUserHelperTest {
     }
 
     @Test
-    void shouldReturnFalseIfClientIsNotAppClient() throws NoSuchAlgorithmException, JOSEException {
+    void shouldReturnFalseIfClientIsNotAppClient() throws JOSEException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)
@@ -113,8 +112,7 @@ class DocAppUserHelperTest {
     }
 
     @Test
-    void shouldReturnTrueIfClientIsDocCheckingAppUser()
-            throws NoSuchAlgorithmException, JOSEException {
+    void shouldReturnTrueIfClientIsDocCheckingAppUser() throws JOSEException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)
@@ -133,8 +131,7 @@ class DocAppUserHelperTest {
     }
 
     @Test
-    void shouldReturnTrueIfClientIsDocCheckingAppUserWithSubject()
-            throws NoSuchAlgorithmException, JOSEException {
+    void shouldReturnTrueIfClientIsDocCheckingAppUserWithSubject() throws JOSEException {
 
         JWTClaimsSet.Builder claimsSetBuilder = getBaseJWTClaimsSetBuilder();
 
@@ -148,8 +145,7 @@ class DocAppUserHelperTest {
     }
 
     @Test
-    void shouldReturnFalsIfClientIsDocCheckingAppUserWithoutSubject()
-            throws NoSuchAlgorithmException, JOSEException {
+    void shouldReturnFalsIfClientIsDocCheckingAppUserWithoutSubject() throws JOSEException {
 
         JWTClaimsSet.Builder claimsSetBuilder = getBaseJWTClaimsSetBuilder();
 
@@ -212,9 +208,8 @@ class DocAppUserHelperTest {
         return authRequestBuilder.build();
     }
 
-    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
-            throws NoSuchAlgorithmException, JOSEException {
-        var keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet) throws JOSEException {
+        var keyPair = generateRsaKeyPair();
         var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
         var signer = new RSASSASigner(keyPair.getPrivate());

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelperTest.java
@@ -46,7 +46,7 @@ class ClientSubjectHelperTest {
 
     @BeforeEach
     void setUp() {
-        keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        keyPair = KeyPairHelper.generateRsaKeyPair();
         when(authenticationService.getOrGenerateSalt(userProfile))
                 .thenReturn(SaltHelper.generateNewSalt());
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelperTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.services.AuthenticationService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.security.KeyPair;
 import java.time.LocalDateTime;
@@ -46,7 +46,7 @@ class ClientSubjectHelperTest {
 
     @BeforeEach
     void setUp() {
-        keyPair = KeyPairHelper.generateRsaKeyPair();
+        keyPair = KeyPairUtils.generateRsaKeyPair();
         when(authenticationService.getOrGenerateSalt(userProfile))
                 .thenReturn(SaltHelper.generateNewSalt());
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/DocAppSubjectIdHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/DocAppSubjectIdHelperTest.java
@@ -107,7 +107,7 @@ class DocAppSubjectIdHelperTest {
         }
         var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSetBuilder.build());
-        var signer = new RSASSASigner(KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPrivate());
+        var signer = new RSASSASigner(KeyPairHelper.generateRsaKeyPair().getPrivate());
         signedJWT.sign(signer);
         var authRequest =
                 new AuthenticationRequest.Builder(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/DocAppSubjectIdHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/DocAppSubjectIdHelperTest.java
@@ -16,7 +16,7 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.util.List;
@@ -107,7 +107,7 @@ class DocAppSubjectIdHelperTest {
         }
         var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSetBuilder.build());
-        var signer = new RSASSASigner(KeyPairHelper.generateRsaKeyPair().getPrivate());
+        var signer = new RSASSASigner(KeyPairUtils.generateRsaKeyPair().getPrivate());
         signedJWT.sign(signer);
         var authRequest =
                 new AuthenticationRequest.Builder(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
@@ -5,7 +5,6 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -32,8 +31,6 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
@@ -46,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class ClientSignatureValidationServiceTest {
 
@@ -70,7 +68,7 @@ class ClientSignatureValidationServiceTest {
         when(oidcAPI.tokenURI()).thenReturn(TOKEN_URI);
         when(oidcAPI.getIssuerURI()).thenReturn(OIDC_BASE_URI);
         when(configurationService.fetchRpPublicKeyFromJwksEnabled()).thenReturn(true);
-        keyPair = generateKeyPair();
+        keyPair = generateRsaKeyPair();
     }
 
     @Nested
@@ -128,7 +126,7 @@ class ClientSignatureValidationServiceTest {
 
         @Test
         void shouldThrowExceptionWhenValidatingInvalidSignedJWT() {
-            var keyPair2 = generateKeyPair();
+            var keyPair2 = generateRsaKeyPair();
             var signedJWT = generateSignedJWT(keyPair2.getPrivate());
 
             assertThrows(
@@ -138,7 +136,7 @@ class ClientSignatureValidationServiceTest {
 
         @Test
         void shouldThrowExceptionWhenValidatingInvalidPrivateKeyJWT() {
-            var keyPair2 = generateKeyPair();
+            var keyPair2 = generateRsaKeyPair();
             var privateKeyJWT = generatePrivateKeyJWT(keyPair2.getPrivate());
 
             assertThrows(
@@ -204,7 +202,7 @@ class ClientSignatureValidationServiceTest {
 
         @Test
         void shouldThrowExceptionWhenValidatingInvalidSignedJWT() {
-            var keyPair2 = generateKeyPair();
+            var keyPair2 = generateRsaKeyPair();
             InvokeResponse response = generateFetchJwksLambdaValidResponse(keyPair2.getPublic());
             when(lambdaClient.invoke((InvokeRequest) ArgumentMatchers.any())).thenReturn(response);
             var signedJWT = generateSignedJWT(keyPair.getPrivate());
@@ -216,7 +214,7 @@ class ClientSignatureValidationServiceTest {
 
         @Test
         void shouldThrowExceptionWhenValidatingInvalidPrivateKeyJWT() {
-            var keyPair2 = generateKeyPair();
+            var keyPair2 = generateRsaKeyPair();
             InvokeResponse response = generateFetchJwksLambdaValidResponse(keyPair2.getPublic());
             when(lambdaClient.invoke((InvokeRequest) ArgumentMatchers.any())).thenReturn(response);
             var privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
@@ -270,16 +268,6 @@ class ClientSignatureValidationServiceTest {
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static KeyPair generateKeyPair() {
-        KeyPairGenerator keyPairGenerator;
-        try {
-            keyPairGenerator = KeyPairGenerator.getInstance(KeyType.RSA.getValue());
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        return keyPairGenerator.generateKeyPair();
     }
 
     private InvokeResponse generateFetchJwksLambdaValidResponse(PublicKey publicKey) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -37,9 +37,6 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
@@ -60,6 +57,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
 import static uk.gov.di.orchestration.shared.services.DocAppAuthorisationService.STATE_STORAGE_PREFIX;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class DocAppAuthorisationServiceTest {
 
@@ -320,16 +318,5 @@ class DocAppAuthorisationServiceTest {
     private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
         encryptedJWT.decrypt(new RSADecrypter(privateKey));
         return encryptedJWT.getPayload().toSignedJWT();
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -22,7 +22,7 @@ import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -51,7 +51,7 @@ class PrivateKeyJwtClientAuthValidatorTest {
     private OidcAPI oidcAPI = mock(OidcAPI.class);
     private static final URI OIDC_TOKEN_URL = URI.create("https://example.com/token");
     private static final ClientID CLIENT_ID = new ClientID();
-    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
+    private static final KeyPair RSA_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
     private PrivateKeyJwtClientAuthValidator privateKeyJwtClientAuthValidator;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -51,7 +51,7 @@ class PrivateKeyJwtClientAuthValidatorTest {
     private OidcAPI oidcAPI = mock(OidcAPI.class);
     private static final URI OIDC_TOKEN_URL = URI.create("https://example.com/token");
     private static final ClientID CLIENT_ID = new ClientID();
-    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
     private PrivateKeyJwtClientAuthValidator privateKeyJwtClientAuthValidator;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -22,12 +22,9 @@ import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import java.net.URI;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Optional;
@@ -42,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class PrivateKeyJwtClientAuthValidatorTest {
 
@@ -51,7 +49,7 @@ class PrivateKeyJwtClientAuthValidatorTest {
     private OidcAPI oidcAPI = mock(OidcAPI.class);
     private static final URI OIDC_TOKEN_URL = URI.create("https://example.com/token");
     private static final ClientID CLIENT_ID = new ClientID();
-    private static final KeyPair RSA_KEY_PAIR = KeyPairUtils.generateRsaKeyPair();
+    private static final KeyPair RSA_KEY_PAIR = generateRsaKeyPair();
     private PrivateKeyJwtClientAuthValidator privateKeyJwtClientAuthValidator;
 
     @BeforeEach
@@ -248,16 +246,5 @@ class PrivateKeyJwtClientAuthValidatorTest {
                 new PrivateKeyJWT(claimsSet, algorithm, RSA_KEY_PAIR.getPrivate(), null, null);
         var privateKeyParams = privateKeyJWT.toParameters();
         return URLUtils.serializeParameters(privateKeyParams);
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
@@ -37,7 +37,7 @@ class TokenClientAuthValidatorFactoryTest {
                 new PrivateKeyJWT(
                         claimsSet,
                         JWSAlgorithm.RS256,
-                        KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPrivate(),
+                        KeyPairHelper.generateRsaKeyPair().getPrivate(),
                         null,
                         null);
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
@@ -12,7 +12,7 @@ import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
@@ -37,7 +37,7 @@ class TokenClientAuthValidatorFactoryTest {
                 new PrivateKeyJWT(
                         claimsSet,
                         JWSAlgorithm.RS256,
-                        KeyPairHelper.generateRsaKeyPair().getPrivate(),
+                        KeyPairUtils.generateRsaKeyPair().getPrivate(),
                         null,
                         null);
 


### PR DESCRIPTION
### Wider context of change

This helper class had a few problems: 
- It has a public static method for generating key pairs, which is named like a static constant using  `UPPER_SNAKE_CASE` instead of `camelCase`, which is inconsistent with other public static methods 
- The method for generating key pairs caches the first key it generates, then reuses this key if multiple calls are made to this method. This functionality wasnt actually used anywhere, and it means that for some tests like `AuthorisationIntegrationTest`, its using the same key for the RP signing key and the internal auth encryption key - which is unrealistic. It’s also hard to tell if the right key is being used!
- There are a lot of cases where an identical method to generate the key pair is defined locally in tests.

### What’s changed

This PR removes the key caching functionality of this helper class, so that every call to generateRsaKeyPair() is a unique key pair. As a result of this, the helper class was stateless, so I've also renamed it to `KeyPairUtils` and moved it into the `utils` package.  

Finally, i've searched for duplicate method definitions of `generateRsaKeyPair` in the orch test code and replaced them with using the `KeyPairUtils` static method.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

