### PR TITLE
Ato 1746/remove cloudformation doc app policy usage

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1682,8 +1682,6 @@ Resources:
             - true
             - false
       Policies:
-        - !Ref DocAppCredentialTableReadAccessPolicy
-        - !Ref DocAppCredentialTableWriteAccessPolicy
         - !Ref OrchDocAppCredentialTableReadAccessPolicy
         - !Ref OrchDocAppCredentialTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -3556,7 +3554,6 @@ Resources:
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
-        - !Ref DocAppCredentialTableReadAccessPolicy
         - !Ref OrchDocAppCredentialTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref AuthUserInfoTableReadAccessPolicy


### PR DESCRIPTION
### Wider context of change

Migrate doc app table from Auth to Orch

### What’s changed

Remove old policies usages in lambdas


### Manual testing

Deployed to Dev
