### PR TITLE
ATO-1777: Setup PagerDuty alarms in orch

### DIFF
--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -20,6 +20,20 @@ const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
     account = runbookSplit[0];
   }
   var description = descriptionAndAccount[0];
+  if (snsMessage.AlarmName.includes("pagerduty")) {
+    if (snsMessage.NewStateValue === "ALARM") {
+      description =
+        description +
+        "\n\nThis has triggered a PagerDuty alert for the following service:" +
+        "\n<https://governmentdigitalservice.pagerduty.com/service-directory/P5V7FN6|GOV.UK One Login - Orchestration - P1>";
+    }
+    if (snsMessage.NewStateValue === "OK") {
+      description =
+        description +
+        "\n\nThis has resolved the associated PagerDuty alert for the following service:" +
+        "\n<https://governmentdigitalservice.pagerduty.com/service-directory/P5V7FN6|GOV.UK One Login - Orchestration - P1>";
+    }
+  }
   var fields = [
     {
       title: "Status",
@@ -65,7 +79,8 @@ const buildMessageRequest = async function (
     "integration",
     "production",
   ].includes(process.env.DEPLOY_ENVIRONMENT);
-  const isPagerDutyAlarm = snsMessage.AlarmDescription.includes("PagerDuty");
+  const isEnabledForProd = process.env.DEPLOY_ENVIRONMENT === "production";
+  const isPagerDutyAlarm = snsMessage.AlarmName.includes("pagerduty");
   if (isPagerDutyAlarm && isEnabledForProd) {
     body.channel =
       process.env.SLACK_CHANNEL_ID ||

--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -65,7 +65,12 @@ const buildMessageRequest = async function (
     "integration",
     "production",
   ].includes(process.env.DEPLOY_ENVIRONMENT);
-  if (isNotBuildEnv) {
+  const isPagerDutyAlarm = snsMessage.AlarmDescription.includes("PagerDuty");
+  if (isPagerDutyAlarm && isEnabledForProd) {
+    body.channel =
+      process.env.SLACK_CHANNEL_ID ||
+      (await getParameter("pagerduty-slack-channel-id"));
+  } else if (isNotBuildEnv) {
     body.channel =
       process.env.SLACK_CHANNEL_ID ||
       (await getParameter(

--- a/template.yaml
+++ b/template.yaml
@@ -6431,6 +6431,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-channel-id"
                 - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-hook-url"
+                - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/pagerduty-slack-channel-id"
       Events:
         SNS:
           Type: SNS
@@ -6506,6 +6507,16 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
+  PagerDutySNSSubscription:
+    Condition: IsProduction
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub
+        - "{{resolve:secretsmanager:${SecretArn}:SecretString:integrationURL}}"
+        - SecretArn: !Ref PagerDutyUrlSecret
+      Protocol: https
+      RawMessageDelivery: false
+      TopicArn: !Ref PagerDutyEvents
   #endregion
   #region OrchAuthCode DynamoDB Table
 

--- a/template.yaml
+++ b/template.yaml
@@ -7562,6 +7562,32 @@ Resources:
             Period: 600
             Stat: Sum
             Unit: Count
+
+  DocAppHandbackPagerDutyAlarm:
+    Condition: IsProduction
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref PagerDutyEvents
+      OKActions:
+        - !Ref PagerDutyEvents
+      AlarmDescription: !Sub "50 or more errors have occurred in the ${Environment} Doc app callback handback lambdas.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
+      AlarmName: !Sub ${Environment}-pagerduty-doc-app-handback-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 50
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          ReturnData: true
+          MetricStat:
+            Metric:
+              MetricName: !Sub ${Environment}-doc-app-callback-count
+              Namespace: LambdaErrorsNamespace
+            Period: 600
+            Stat: Sum
+            Unit: Count
   #endregion
 
 Outputs:

--- a/template.yaml
+++ b/template.yaml
@@ -7534,8 +7534,10 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref PagerDutyEvents
+        - !Ref OrchProdSlackEvents
       OKActions:
         - !Ref PagerDutyEvents
+        - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "50 or more errors have occurred in the ${Environment} IPV handback lambdas.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       AlarmName: !Sub ${Environment}-pagerduty-ipv-handback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -7581,8 +7583,10 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref PagerDutyEvents
+        - !Ref OrchProdSlackEvents
       OKActions:
         - !Ref PagerDutyEvents
+        - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "50 or more errors have occurred in the ${Environment} Doc app callback handback lambdas.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       AlarmName: !Sub ${Environment}-pagerduty-doc-app-handback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/template.yaml
+++ b/template.yaml
@@ -6458,7 +6458,55 @@ Resources:
       SourceArn: !Ref OrchProdSlackEvents
 
   #endregion
+  #region PagerDuty events
 
+  PagerDutyEvents:
+    Condition: IsProduction
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub "PagerDuty events for ${Environment}"
+      TopicName: !Sub ${Environment}-pagerduty-alerts
+      KmsMasterKeyId: !GetAtt PagerDutyEventsKey.Arn
+
+  PagerDutyEventsKey:
+    Condition: IsProduction
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Key used to encrypt PagerDuty events topic
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: !Sub logs.${AWS::Region}.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+          - Effect: Allow
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: "*"
+            Condition:
+              StringEquals:
+                AWS:SourceAccount: !Ref AWS::AccountId
+
+  #endregion
   #region OrchAuthCode DynamoDB Table
 
   OrchAuthCodeTableEncryptionKey:
@@ -7467,6 +7515,53 @@ Resources:
             Stat: Average
   #endregion
 
+  # region PagerDuty alarms
+  IpvHandbackPagerDutyAlarm:
+    Condition: IsProduction
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref PagerDutyEvents
+      OKActions:
+        - !Ref PagerDutyEvents
+      AlarmDescription: !Sub "50 or more errors have occurred in the ${Environment} IPV handback lambdas.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
+      AlarmName: !Sub ${Environment}-pagerduty-ipv-handback-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 50
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          ReturnData: true
+          Expression: (m1 + m2 + m3)
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: !Sub ${Environment}-ipv-callback-count
+              Namespace: LambdaErrorsNamespace
+            Period: 600
+            Stat: Sum
+            Unit: Count
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: !Sub ${Environment}-spot-response-count
+              Namespace: LambdaErrorsNamespace
+            Period: 600
+            Stat: Sum
+            Unit: Count
+        - Id: m3
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: !Sub ${Environment}-auth-code-count
+              Namespace: LambdaErrorsNamespace
+            Period: 600
+            Stat: Sum
+            Unit: Count
   #endregion
 
 Outputs:


### PR DESCRIPTION
### Wider context of change

We currently have pagerduty alarms configured in auth, but not in orch.  We should move the pagerduty alarms that are orch-related into orch too.

### What’s changed

This PR creates 2 new cloudwatch alarms:
- One will alarm if more than 20 errors appear in the IPV callback handler and SPOT response handler over 10 mins. 
- One will alarm if more than 20 errors appear in the DocApp callback handler over 10 mins.

Both these alarms are configured to publish the alarm event on a new SNS topic: `${Environment}-pagerduty-alerts `. There is also a subscription to this topic configured in the template file, which uses the PagerDuty URL defined in a secret. 

These alarms will only be created if the environment is production and there is a `pagerDutySecretId` defined in the environment configuration for production. This secret should have a key of `integrationURL` and a value of the PagerDuty integration URL

These alarms will also send a slack notification to the channel configured in the `pagerdury-slack-channel-id` SSM parameter. This is already set in production.

### Manual testing

Have tested this in dev by observing alerts appearing in the PagerDuty dashboard. Once the alarms were triggered, the alert appeared in the dashboard.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
