### PR TITLE
BAU: Bump aws sdk v2 to version 2.32.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: "idea"
 
 ext {
     dependencyVersions = [
-        aws_sdk_v2_version: "2.31.61",
+        aws_sdk_v2_version: "2.32.10",
         aws_lambda_core_version: "1.3.0",
         aws_lambda_events_version: "3.16.1",
         gson: "2.13.1",

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/DynamoExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/DynamoExtension.java
@@ -30,7 +30,7 @@ public abstract class DynamoExtension extends BaseAwsResourceExtension
     public void beforeAll(ExtensionContext context) throws Exception {
         dynamoDB =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(REGION))
                         .endpointOverride(URI.create(DYNAMO_ENDPOINT))
                         .build();
@@ -41,7 +41,7 @@ public abstract class DynamoExtension extends BaseAwsResourceExtension
     protected void createInstance() {
         dynamoDB =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(REGION))
                         .endpointOverride(URI.create(DYNAMO_ENDPOINT))
                         .build();

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/KmsKeyExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/KmsKeyExtension.java
@@ -41,7 +41,7 @@ public class KmsKeyExtension extends BaseAwsResourceExtension implements BeforeA
                 KmsClient.builder()
                         .endpointOverride(URI.create(LOCALSTACK_ENDPOINT))
                         .region(Region.of(REGION))
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .build();
 
         keyAlias =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/DynamoClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/DynamoClientHelper.java
@@ -13,7 +13,7 @@ public class DynamoClientHelper {
     public static DynamoDbClient createDynamoClient(ConfigurationService configurationService) {
         var dynamoDbClientBuilder =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(configurationService.getAwsRegion()));
         configurationService
                 .getDynamoEndpointURI()

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
@@ -32,14 +32,14 @@ public class KmsConnectionService {
             this.kmsClient =
                     KmsClient.builder()
                             .endpointOverride(URI.create(localstackEndpointUri.get()))
-                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .region(Region.of(awsRegion))
                             .build();
         } else {
             this.kmsClient =
                     KmsClient.builder()
                             .region(Region.of(awsRegion))
-                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .build();
         }
         warmUp(tokenSigningKeyId);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
@@ -30,7 +30,7 @@ public abstract class DynamoExtension extends BaseAwsResourceExtension
     public void beforeAll(ExtensionContext context) throws Exception {
         dynamoDB =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(REGION))
                         .endpointOverride(URI.create(DYNAMO_ENDPOINT))
                         .build();
@@ -41,7 +41,7 @@ public abstract class DynamoExtension extends BaseAwsResourceExtension
     protected void createInstance() {
         dynamoDB =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(REGION))
                         .endpointOverride(URI.create(DYNAMO_ENDPOINT))
                         .build();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
@@ -43,7 +43,7 @@ public class KmsKeyExtension extends BaseAwsResourceExtension implements BeforeA
                 KmsClient.builder()
                         .endpointOverride(URI.create(LOCALSTACK_ENDPOINT))
                         .region(Region.of(REGION))
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .build();
 
         keyAlias =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
@@ -13,7 +13,7 @@ public class DynamoClientHelper {
     public static DynamoDbClient createDynamoClient(ConfigurationService configurationService) {
         var dynamoDbClientBuilder =
                 DynamoDbClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(configurationService.getAwsRegion()));
         configurationService
                 .getDynamoEndpointUri()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -32,14 +32,14 @@ public class KmsConnectionService {
             this.kmsClient =
                     KmsClient.builder()
                             .endpointOverride(URI.create(localstackEndpointUri.get()))
-                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .region(Region.of(awsRegion))
                             .build();
         } else {
             this.kmsClient =
                     KmsClient.builder()
                             .region(Region.of(awsRegion))
-                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .build();
         }
         warmUp(tokenSigningKeyId);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -25,7 +25,7 @@ public class LambdaInvokerService implements LambdaInvoker {
     public LambdaInvokerService(ConfigurationService configurationService) {
         this.lambdaClient =
                 LambdaClient.builder()
-                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .region(Region.of(configurationService.getAwsRegion()))
                         .build();
     }


### PR DESCRIPTION
### What’s changed

Dependabot couldn't do this automatically because there's a static constructor `DefaultCredentialsProvider.create()` we are currently using that has been deprecated. This PR uses the builder method for `DefaultCredentialsProvider` to create an instance of it, then bumps the AWS SDK version to 2.32.10.

### Manual testing

Tested in authdev3 and performed a few different journeys, all worked fine.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

