### PR TITLE
ATO-1867 refactor callback validation

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -184,15 +184,15 @@ public class DocAppCallbackHandler
                                 input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(
-                                noSessionEntity.getClientSession().getAuthRequestParams());
+                                noSessionEntity.orchClientSession().getAuthRequestParams());
                 return generateAuthenticationErrorResponse(
                         authRequest,
-                        noSessionEntity.getErrorObject(),
+                        noSessionEntity.errorObject(),
                         true,
                         TxmaAuditUser.user()
-                                .withGovukSigninJourneyId(noSessionEntity.getClientSessionId())
+                                .withGovukSigninJourneyId(noSessionEntity.clientSessionId())
                                 .withUserId(
-                                        noSessionEntity.getClientSession().getDocAppSubjectId()));
+                                        noSessionEntity.orchClientSession().getDocAppSubjectId()));
             }
             var sessionId = sessionCookiesIds.getSessionId();
             var clientSessionId = sessionCookiesIds.getClientSessionId();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationError.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationError.java
@@ -1,9 +1,0 @@
-package uk.gov.di.authentication.ipv.entity;
-
-public record IpvCallbackValidationError(
-        String errorCode, String errorDescription, boolean isSessionInvalidation) {
-
-    public IpvCallbackValidationError(String errorCode, String errorDescription) {
-        this(errorCode, errorDescription, false);
-    }
-}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationResult.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationResult.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.ipv.entity;
+
+public record IpvCallbackValidationResult(boolean isValid, FailureCode failureCode) {
+    // TODO: Does this make sense?
+    public static String GENERIC_CALLBACK_ERROR_DESCRIPTION =
+            "Invalid authentication response received, a new authentication request may be successful";
+
+    public IpvCallbackValidationResult(boolean isValid) {
+        this(isValid, null);
+    }
+
+    public enum FailureCode {
+        EMPTY_CALLBACK,
+        OAUTH_ERROR,
+        SESSION_INVALIDATION,
+        MISSING_STATE,
+        INVALID_STATE,
+        MISSING_AUTH_CODE,
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -202,13 +202,13 @@ public class IPVCallbackHandler
                                 input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(
-                                noSessionEntity.getClientSession().getAuthRequestParams());
+                                noSessionEntity.orchClientSession().getAuthRequestParams());
                 attachLogFieldToLogs(CLIENT_ID, authRequest.getClientID().getValue());
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(
                         authRequest,
-                        noSessionEntity.getErrorObject(),
+                        noSessionEntity.errorObject(),
                         true,
-                        noSessionEntity.getClientSessionId(),
+                        noSessionEntity.clientSessionId(),
                         AuditService.UNKNOWN);
             }
             var sessionId = sessionCookiesIds.getSessionId();
@@ -246,16 +246,16 @@ public class IPVCallbackHandler
                             AuthenticationRequest.parse(
                                     mismatchedEntity
                                             .get()
-                                            .getClientSession()
+                                            .orchClientSession()
                                             .getAuthRequestParams());
                     attachLogFieldToLogs(
                             CLIENT_ID, authRequestFromStateDerivedRP.getClientID().getValue());
 
                     return ipvCallbackHelper.generateAuthenticationErrorResponse(
                             authRequestFromStateDerivedRP,
-                            mismatchedEntity.get().getErrorObject(),
+                            mismatchedEntity.get().errorObject(),
                             false,
-                            mismatchedEntity.get().getClientSessionId(),
+                            mismatchedEntity.get().clientSessionId(),
                             AuditService.UNKNOWN);
                 }
             }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
-import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationResult;
 import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
@@ -379,8 +379,9 @@ class IPVCallbackHandlerTest {
 
         when(responseService.validateResponse(anyMap(), anyString()))
                 .thenReturn(
-                        Optional.of(
-                                new IpvCallbackValidationError("session_invalidated", null, true)));
+                        new IpvCallbackValidationResult(
+                                false,
+                                IpvCallbackValidationResult.FailureCode.SESSION_INVALIDATION));
 
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("state", STATE.getValue());
@@ -603,7 +604,8 @@ class IPVCallbackHandlerTest {
                                                 CLIENT_NAME)
                                         .withRpPairwiseId(TEST_RP_PAIRWISE_ID)));
 
-        when(responseService.validateResponse(anyMap(), anyString())).thenReturn(Optional.empty());
+        when(responseService.validateResponse(anyMap(), anyString()))
+                .thenReturn(new IpvCallbackValidationResult(true));
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
@@ -795,7 +797,7 @@ class IPVCallbackHandlerTest {
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(generateClientRegistryNoClaims()));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
-                .thenReturn(Optional.empty());
+                .thenReturn(new IpvCallbackValidationResult(true));
 
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
         request.setQueryStringParameters(responseHeaders);
@@ -862,9 +864,8 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(generateClientRegistryNoClaims()));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        errorObject.getCode(), redirectUriErrorMessage)));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.OAUTH_ERROR));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(COOKIE, buildCookieString()));
@@ -898,9 +899,8 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(generateClientRegistryNoClaims()));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        errorObject.getCode(), redirectUriErrorMessage)));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.OAUTH_ERROR));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(COOKIE, buildCookieString()));
@@ -975,7 +975,7 @@ class IPVCallbackHandlerTest {
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(clientRegistry));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
-                .thenReturn(Optional.empty());
+                .thenReturn(new IpvCallbackValidationResult(true));
         when(ipvTokenService.getToken(AUTH_CODE.getValue())).thenReturn(unsuccessfulTokenResponse);
         when(authUserInfoStorageService.getAuthenticationUserInfo(
                         TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER, CLIENT_SESSION_ID))
@@ -1096,9 +1096,8 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(generateClientRegistryNoClaims()));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        errorObject.getCode(), redirectUriErrorMessage)));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.OAUTH_ERROR));
         var intervention =
                 new AccountIntervention(new AccountInterventionState(true, false, false, false));
         when(accountInterventionService.getAccountIntervention(anyString(), any()))
@@ -1134,7 +1133,7 @@ class IPVCallbackHandlerTest {
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(clientRegistry));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
-                .thenReturn(Optional.empty());
+                .thenReturn(new IpvCallbackValidationResult(true));
         var successfulTokenResponse =
                 new AccessTokenResponse(new Tokens(new BearerAccessToken(), null));
         when(ipvTokenService.getToken(AUTH_CODE.getValue())).thenReturn(successfulTokenResponse);
@@ -1408,7 +1407,7 @@ class IPVCallbackHandlerTest {
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(clientRegistry));
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
-                .thenReturn(Optional.empty());
+                .thenReturn(new IpvCallbackValidationResult(true));
 
         when(ipvTokenService.getToken(AUTH_CODE.getValue())).thenReturn(successfulTokenResponse);
         when(ipvTokenService.sendIpvUserIdentityRequest(any())).thenReturn(userIdentityUserInfo);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -16,7 +16,6 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
@@ -35,7 +34,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationResult;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -163,7 +162,9 @@ class IPVAuthorisationServiceTest {
 
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
-                equalTo(Optional.of(new IpvCallbackValidationError(errorObject.getCode(), null))));
+                equalTo(
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.OAUTH_ERROR)));
     }
 
     @Test
@@ -178,9 +179,9 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        errorObject.getCode(), null, true))));
+                        new IpvCallbackValidationResult(
+                                false,
+                                IpvCallbackValidationResult.FailureCode.SESSION_INVALIDATION)));
     }
 
     @Test
@@ -188,10 +189,8 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "No query parameters present"))));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.EMPTY_CALLBACK)));
     }
 
     @Test
@@ -202,10 +201,8 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "No state param present in Authorisation response"))));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.MISSING_STATE)));
     }
 
     @Test
@@ -216,10 +213,8 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "No code param present in Authorisation response"))));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.MISSING_AUTH_CODE)));
     }
 
     @Test
@@ -233,10 +228,8 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Invalid state param present in Authorisation response"))));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.INVALID_STATE)));
     }
 
     @Test
@@ -249,10 +242,8 @@ class IPVAuthorisationServiceTest {
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
-                        Optional.of(
-                                new IpvCallbackValidationError(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Invalid state param present in Authorisation response"))));
+                        new IpvCallbackValidationResult(
+                                false, IpvCallbackValidationResult.FailureCode.INVALID_STATE)));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -606,16 +606,15 @@ public class AuthenticationCallbackHandler
                         input.getQueryStringParameters());
         var authenticationRequest =
                 AuthenticationRequest.parse(
-                        noSessionEntity.getClientSession().getAuthRequestParams());
+                        noSessionEntity.orchClientSession().getAuthRequestParams());
         auditService.submitAuditEvent(
                 OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
                 authenticationRequest.getClientID().getValue(),
-                TxmaAuditUser.user()
-                        .withGovukSigninJourneyId(noSessionEntity.getClientSessionId()));
+                TxmaAuditUser.user().withGovukSigninJourneyId(noSessionEntity.clientSessionId()));
         var errorResponse =
                 new AuthenticationErrorResponse(
                         authenticationRequest.getRedirectionURI(),
-                        noSessionEntity.getErrorObject(),
+                        noSessionEntity.errorObject(),
                         authenticationRequest.getState(),
                         authenticationRequest.getResponseMode());
         return generateApiGatewayProxyResponse(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CrossBrowserEntity.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CrossBrowserEntity.java
@@ -2,30 +2,5 @@ package uk.gov.di.orchestration.shared.entity;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class CrossBrowserEntity {
-
-    private final String clientSessionId;
-    private final ErrorObject errorObject;
-    private final OrchClientSessionItem orchClientSession;
-
-    public CrossBrowserEntity(
-            String clientSessionId,
-            ErrorObject errorObject,
-            OrchClientSessionItem orchClientSession) {
-        this.clientSessionId = clientSessionId;
-        this.errorObject = errorObject;
-        this.orchClientSession = orchClientSession;
-    }
-
-    public String getClientSessionId() {
-        return clientSessionId;
-    }
-
-    public ErrorObject getErrorObject() {
-        return errorObject;
-    }
-
-    public OrchClientSessionItem getClientSession() {
-        return orchClientSession;
-    }
-}
+public record CrossBrowserEntity(
+        String clientSessionId, ErrorObject errorObject, OrchClientSessionItem orchClientSession) {}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
@@ -69,17 +69,16 @@ class CrossBrowserOrchestrationServiceTest {
                 crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(queryParams);
 
         assertThat(
-                noSessionEntity.getErrorObject().getCode(),
-                equalTo(OAuth2Error.ACCESS_DENIED_CODE));
+                noSessionEntity.errorObject().getCode(), equalTo(OAuth2Error.ACCESS_DENIED_CODE));
         assertThat(
-                noSessionEntity.getErrorObject().getDescription(),
+                noSessionEntity.errorObject().getDescription(),
                 equalTo(
                         "Access denied for security reasons, a new authentication request may be successful"));
-        assertThat(noSessionEntity.getClientSessionId(), equalTo(CLIENT_SESSION_ID));
+        assertThat(noSessionEntity.clientSessionId(), equalTo(CLIENT_SESSION_ID));
 
         var authenticationRequest =
                 AuthenticationRequest.parse(
-                        noSessionEntity.getClientSession().getAuthRequestParams());
+                        noSessionEntity.orchClientSession().getAuthRequestParams());
         assertThat(authenticationRequest.getClientID(), equalTo(CLIENT_ID));
         assertThat(authenticationRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
     }
@@ -263,17 +262,17 @@ class CrossBrowserOrchestrationServiceTest {
 
             assertTrue(noSessionEntity.isPresent());
             assertThat(
-                    noSessionEntity.get().getErrorObject().getCode(),
+                    noSessionEntity.get().errorObject().getCode(),
                     equalTo(OAuth2Error.ACCESS_DENIED_CODE));
             assertThat(
-                    noSessionEntity.get().getErrorObject().getDescription(),
+                    noSessionEntity.get().errorObject().getDescription(),
                     equalTo(
                             "Access denied for security reasons, a new authentication request may be successful"));
-            assertThat(noSessionEntity.get().getClientSessionId(), equalTo(CLIENT_SESSION_ID));
+            assertThat(noSessionEntity.get().clientSessionId(), equalTo(CLIENT_SESSION_ID));
 
             var authenticationRequest =
                     AuthenticationRequest.parse(
-                            noSessionEntity.get().getClientSession().getAuthRequestParams());
+                            noSessionEntity.get().orchClientSession().getAuthRequestParams());
             assertThat(authenticationRequest.getClientID(), equalTo(CLIENT_ID));
             assertThat(authenticationRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
         }
@@ -297,17 +296,17 @@ class CrossBrowserOrchestrationServiceTest {
 
             assertTrue(noSessionEntity.isPresent());
             assertThat(
-                    noSessionEntity.get().getErrorObject().getCode(),
+                    noSessionEntity.get().errorObject().getCode(),
                     equalTo(OAuth2Error.ACCESS_DENIED_CODE));
             assertThat(
-                    noSessionEntity.get().getErrorObject().getDescription(),
+                    noSessionEntity.get().errorObject().getDescription(),
                     equalTo(
                             "Access denied for security reasons, a new authentication request may be successful"));
-            assertThat(noSessionEntity.get().getClientSessionId(), equalTo(CLIENT_SESSION_ID));
+            assertThat(noSessionEntity.get().clientSessionId(), equalTo(CLIENT_SESSION_ID));
 
             var authenticationRequest =
                     AuthenticationRequest.parse(
-                            noSessionEntity.get().getClientSession().getAuthRequestParams());
+                            noSessionEntity.get().orchClientSession().getAuthRequestParams());
             assertThat(authenticationRequest.getClientID(), equalTo(CLIENT_ID));
             assertThat(authenticationRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
         }


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
