### PR TITLE
ATO-1883: refactor is return auth time in id token enabled

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -387,7 +387,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 idTokenClaims.getSubject(),
                 equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL)));
-        assertNull(idTokenClaims.getClaim("auth_time"));
+        assertThat(idTokenClaims.getClaim("auth_time"), equalTo(AUTH_TIME));
 
         AuditAssertionsHelper.assertTxmaAuditEventsReceived(
                 txmaAuditQueue, List.of(OIDC_TOKEN_GENERATED));
@@ -428,7 +428,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 idTokenClaims.getSubject(),
                 not(equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL))));
-        assertNull(idTokenClaims.getClaim("auth_time"));
+        assertThat(idTokenClaims.getClaim("auth_time"), equalTo(AUTH_TIME));
 
         AuditAssertionsHelper.assertTxmaAuditEventsReceived(
                 txmaAuditQueue, List.of(OIDC_TOKEN_GENERATED));

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -339,10 +339,5 @@ public class IntegrationTest {
         public boolean supportMaxAgeEnabled() {
             return true;
         }
-
-        @Override
-        public boolean isReturnAuthTimeInIdTokenEnabled() {
-            return false;
-        }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -433,10 +433,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
-    public boolean isReturnAuthTimeInIdTokenEnabled() {
-        return getFlagOrFalse("RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED");
-    }
-
     public boolean isUseIPVJwksEndpointEnabled() {
         return getFlagOrFalse("USE_IPV_JWKS_ENDPOINT");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -247,9 +247,7 @@ public class TokenService {
         idTokenClaims.putAll(additionalTokenClaims);
         if (!isDocAppJourney) {
             idTokenClaims.setClaim("vot", vot);
-            if (configService.isReturnAuthTimeInIdTokenEnabled()) {
-                idTokenClaims.setClaim("auth_time", authTime);
-            }
+            idTokenClaims.setClaim("auth_time", authTime);
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -602,7 +602,8 @@ class TokenServiceTest {
         assertThat(
                 tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
                 is(JOURNEY_ID));
-        assertNull(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("auth_time"));
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("auth_time"),
+                is(AUTH_TIME));
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -81,14 +81,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  IsReturnAuthTimeInIdTokenEnabled:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   IsIntegrationOrProduction:
     !Or [
       !Equals [!Ref Environment, integration],
@@ -1881,10 +1873,6 @@ Resources:
                 ]
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
             - EnableFetchJwks
-            - true
-            - false
-          RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED: !If
-            - IsReturnAuthTimeInIdTokenEnabled
             - true
             - false
           PKCE_ENABLED: !If


### PR DESCRIPTION
### Wider context of change

We have a bunch of feature flags that are always true for all envs. This is starting to remove these flags.

### What’s changed

Removes IsReturnAuthTimeInIdTokenEnabled feature flag.

### Manual testing

TODO: test on dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
