### PR TITLE
ATO-1609: add secret for test client

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -134,6 +134,21 @@ Conditions:
           - Fn::Equals:
               - !Ref SubEnvironment
               - none
+  ProvisionTestClientSecret:
+    !Or [
+      !And [
+        !Condition UseSubEnvironment,
+        !Or [
+          !Equals [!Ref SubEnvironment, "authdev1"],
+          !Equals [!Ref SubEnvironment, "authdev2"],
+        ],
+      ],
+      !Or [
+        !Equals [!Ref Environment, "dev"],
+        !Equals [!Ref Environment, "build"],
+        !Equals [!Ref Environment, "staging"],
+      ],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -1985,3 +2000,28 @@ Resources:
               Resource:
                 - !Sub arn:aws:s3:::${Environment}-smoke-test-sms-codes
                 - !Sub arn:aws:s3:::${Environment}-smoke-test-sms-codes/*
+
+  TestClientEmailAllowListSecretEncryptionKey:
+    Condition: ProvisionTestClientSecret
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for test client email allow list
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+
+  TestClientEmailAllowListSecret:
+    Condition: ProvisionTestClientSecret
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub
+        - /${Env}/test-client-email-allow-list
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsKeyId: !GetAtt TestClientEmailAllowListSecretEncryptionKey.Arn

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -71,7 +71,7 @@ locals {
   experian_phone_check_sqs_queue_id           = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_id
   experian_phone_check_sqs_queue_policy_arn   = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_policy_arn
   id_reverification_state_key_arn             = data.terraform_remote_state.shared.outputs.id_reverification_state_key_arn
-  secure_pipelines_environment                = var.environment == "authdev3" ? "dev" : var.environment
+  secure_pipelines_environment                = var.environment == "sandpit" ? "dev" : var.environment
 
   slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
   aws_account_alias         = data.terraform_remote_state.shared.outputs.aws_account_alias

--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -71,4 +71,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size = "cache.t2.micro"
+redis_node_size      = "cache.t2.micro"
+test_clients_enabled = true

--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -71,5 +71,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size      = "cache.t2.micro"
-test_clients_enabled = true
+redis_node_size              = "cache.t2.micro"
+provision_test_client_secret = true

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -70,5 +70,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size      = "cache.t2.micro"
-test_clients_enabled = true
+redis_node_size              = "cache.t2.micro"
+provision_test_client_secret = true

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -70,4 +70,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size = "cache.t2.micro"
+redis_node_size      = "cache.t2.micro"
+test_clients_enabled = true

--- a/ci/terraform/shared/authdev3.tfvars
+++ b/ci/terraform/shared/authdev3.tfvars
@@ -73,4 +73,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size = "cache.t2.micro"
+redis_node_size      = "cache.t2.micro"
+test_clients_enabled = true

--- a/ci/terraform/shared/authdev3.tfvars
+++ b/ci/terraform/shared/authdev3.tfvars
@@ -73,5 +73,5 @@ new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing
-redis_node_size      = "cache.t2.micro"
-test_clients_enabled = true
+redis_node_size              = "cache.t2.micro"
+provision_test_client_secret = true

--- a/ci/terraform/shared/build.tfvars
+++ b/ci/terraform/shared/build.tfvars
@@ -16,6 +16,6 @@ di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/s
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size      = "cache.t2.small"
-provision_dynamo     = false
-test_clients_enabled = true
+redis_node_size              = "cache.t2.small"
+provision_dynamo             = false
+provision_test_client_secret = true

--- a/ci/terraform/shared/build.tfvars
+++ b/ci/terraform/shared/build.tfvars
@@ -16,5 +16,6 @@ di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/s
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size  = "cache.t2.small"
-provision_dynamo = false
+redis_node_size      = "cache.t2.small"
+provision_dynamo     = false
+test_clients_enabled = true

--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -13,4 +13,4 @@ new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"
 
 # App Specific
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
-test_clients_enabled                 = true
+provision_test_client_secret         = true

--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -13,3 +13,4 @@ new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"
 
 # App Specific
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
+test_clients_enabled                 = true

--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -17,5 +17,6 @@ dlq_alarm_threshold                  = 999999
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size  = "cache.t2.small"
-provision_dynamo = false
+redis_node_size      = "cache.t2.small"
+provision_dynamo     = false
+test_clients_enabled = false

--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -17,6 +17,6 @@ dlq_alarm_threshold                  = 999999
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size      = "cache.t2.small"
-provision_dynamo     = false
-test_clients_enabled = false
+redis_node_size              = "cache.t2.small"
+provision_dynamo             = false
+provision_test_client_secret = false

--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -18,6 +18,6 @@ dlq_alarm_threshold                  = 999999
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size      = "cache.m4.xlarge"
-provision_dynamo     = false
-test_clients_enabled = false
+redis_node_size              = "cache.m4.xlarge"
+provision_dynamo             = false
+provision_test_client_secret = false

--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -18,5 +18,6 @@ dlq_alarm_threshold                  = 999999
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size  = "cache.m4.xlarge"
-provision_dynamo = false
+redis_node_size      = "cache.m4.xlarge"
+provision_dynamo     = false
+test_clients_enabled = false

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -69,3 +69,5 @@ enforce_code_signing = false
 
 # Sizing
 redis_node_size = "cache.t2.micro"
+
+test_clients_enabled = true

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -70,4 +70,4 @@ enforce_code_signing = false
 # Sizing
 redis_node_size = "cache.t2.micro"
 
-test_clients_enabled = true
+provision_test_client_secret = true

--- a/ci/terraform/shared/secrets-manager.tf
+++ b/ci/terraform/shared/secrets-manager.tf
@@ -1,0 +1,22 @@
+resource "aws_kms_key" "test_client_secret_key" {
+  count                   = var.provision_test_client_secret ? 1 : 0
+  description             = "KMS key for encrypting the test client secret"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.key_policy.json
+
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  key_usage                = "ENCRYPT_DECRYPT"
+}
+
+resource "aws_kms_alias" "test_client_secret_key_alias" {
+  count         = var.provision_test_client_secret ? 1 : 0
+  name          = "alias/${var.environment}-test-client-secret-encryption-key"
+  target_key_id = aws_kms_key.test_client_secret_key[0].id
+}
+
+resource "aws_secretsmanager_secret" "test_client_email_allow_list" {
+  count      = var.provision_test_client_secret ? 1 : 0
+  name       = "/${var.environment}/test-client-email-allow-list"
+  kms_key_id = aws_kms_alias.test_client_secret_key_alias[0].target_key_id
+}

--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -17,6 +17,6 @@ di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/s
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size      = "cache.m4.xlarge"
-provision_dynamo     = false
-test_clients_enabled = true
+redis_node_size              = "cache.m4.xlarge"
+provision_dynamo             = false
+provision_test_client_secret = true

--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -17,5 +17,6 @@ di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/s
 orch_stub_deployed                   = false
 
 # Sizing
-redis_node_size  = "cache.m4.xlarge"
-provision_dynamo = false
+redis_node_size      = "cache.m4.xlarge"
+provision_dynamo     = false
+test_clients_enabled = true

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -171,7 +171,7 @@ variable "new_auth_privatesub_cidr_blocks" {
   description = "New Auth equivalent environment private subnets"
 }
 
-variable "test_clients_enabled" {
+variable "provision_test_client_secret" {
   type    = bool
   default = false
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -170,3 +170,8 @@ variable "new_auth_privatesub_cidr_blocks" {
   default     = []
   description = "New Auth equivalent environment private subnets"
 }
+
+variable "test_clients_enabled" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
### Wider context of change:
We are aiming to move the test client lists into secrets manager and out of the client registry - so this does the first step of this - provisioning an empty secret which we will populate manually.

### What’s changed:
- Adds feature flagged infra for creating a new secret 
- Also added the new secret in the cloudformation - not sure how to test this so will defer to someone from Auth

### Manual testing:
- Deployed to sandpit and saw infra created
- Set flag to false for sandpit and saw that the resources were destroyed on re-deployment. 
- Once merged I will need to manually deploy these changes to all the dev environments. Once deployed to all envs I will need to manually update each value.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
