### PR TITLE
ATO-1918: Add logging to compare internal subject ID values

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -68,11 +68,20 @@ public class UserInfoService {
             var userProfile =
                     authenticationService.getUserProfileFromSubject(
                             accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
-            return ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                            userProfile,
-                            configurationService.getInternalSectorURI(),
-                            authenticationService)
-                    .getValue();
+            var internalCommonSubjectIdFromAccessToken =
+                    accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId();
+            var internalCommonSubjetIdFromUserProfile =
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                    userProfile,
+                                    configurationService.getInternalSectorURI(),
+                                    authenticationService)
+                            .getValue();
+            LOG.info(
+                    "Is internalCommonSubjectId from user profile equal to one from access token store? {}",
+                    Objects.equals(
+                            internalCommonSubjetIdFromUserProfile,
+                            internalCommonSubjectIdFromAccessToken));
+            return internalCommonSubjetIdFromUserProfile;
         }
     }
 


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from using auth's UserProfile table in orch. In UserInfoHandler, we use the user profile to calculate the internalCommonSubjectIdentifier (ICSID). We already have the ICSID available on the access token info store, so we should be able to swap to using that instead. Before we do that we want to make sure these 2 fields are in sync.

### What’s changed

This PR adds logging to UserInfoService to compare the ICSID calculated from the user profile with the ICSID from the access token info store. 

### Manual testing

Deployed to dev and performed an auth only journey. I saw the log message indicate the fields are equal.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
