### PR TITLE
ATO-1919: Swap to using ICSID from access token

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -25,7 +25,6 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -82,7 +81,6 @@ public class UserInfoHandler
         this.configurationService = configurationService;
         this.userInfoService =
                 new UserInfoService(
-                        new DynamoService(configurationService),
                         new DynamoIdentityService(configurationService),
                         new DynamoClientService(configurationService),
                         new DynamoDocAppCriService(configurationService),
@@ -107,7 +105,6 @@ public class UserInfoHandler
         this.configurationService = configurationService;
         this.userInfoService =
                 new UserInfoService(
-                        new DynamoService(configurationService),
                         new DynamoIdentityService(configurationService),
                         new DynamoClientService(configurationService),
                         new DynamoDocAppCriService(configurationService),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -18,7 +18,6 @@ import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
-import uk.gov.di.orchestration.shared.services.AuthenticationService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -32,7 +31,6 @@ import java.util.Optional;
 
 public class UserInfoService {
     private final AuthenticationUserInfoStorageService userInfoStorageService;
-    private final AuthenticationService authenticationService;
     private final DynamoIdentityService identityService;
     private final DynamoClientService dynamoClientService;
     private final DynamoDocAppCriService dynamoDocAppCriService;
@@ -42,14 +40,12 @@ public class UserInfoService {
     private static final Logger LOG = LogManager.getLogger(UserInfoService.class);
 
     public UserInfoService(
-            AuthenticationService authenticationService,
             DynamoIdentityService identityService,
             DynamoClientService dynamoClientService,
             DynamoDocAppCriService dynamoDocAppCriService,
             CloudwatchMetricsService cloudwatchMetricsService,
             ConfigurationService configurationService,
             AuthenticationUserInfoStorageService userInfoStorageService) {
-        this.authenticationService = authenticationService;
         this.identityService = identityService;
         this.dynamoClientService = dynamoClientService;
         this.dynamoDocAppCriService = dynamoDocAppCriService;
@@ -65,23 +61,7 @@ public class UserInfoService {
             return accessTokenInfo.getSubject();
         } else {
             LOG.info("Calculating internal common subject identifier");
-            var userProfile =
-                    authenticationService.getUserProfileFromSubject(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
-            var internalCommonSubjectIdFromAccessToken =
-                    accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId();
-            var internalCommonSubjetIdFromUserProfile =
-                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                    userProfile,
-                                    configurationService.getInternalSectorURI(),
-                                    authenticationService)
-                            .getValue();
-            LOG.info(
-                    "Is internalCommonSubjectId from user profile equal to one from access token store? {}",
-                    Objects.equals(
-                            internalCommonSubjetIdFromUserProfile,
-                            internalCommonSubjectIdFromAccessToken));
-            return internalCommonSubjetIdFromUserProfile;
+            return accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId();
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -33,7 +33,6 @@ import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
-import uk.gov.di.orchestration.shared.helpers.SaltHelper;
 import uk.gov.di.orchestration.shared.services.AuthenticationService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -60,7 +59,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.*;
+import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
+import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.DRIVING_PERMIT;
+import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
+import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.RETURN_CODE;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class UserInfoServiceTest {
@@ -113,7 +115,6 @@ class UserInfoServiceTest {
     void setUp() {
         userInfoService =
                 new UserInfoService(
-                        authenticationService,
                         identityService,
                         dynamoClientService,
                         dynamoDocAppCriService,
@@ -494,15 +495,7 @@ class UserInfoServiceTest {
         @Test
         void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresent()
                 throws JOSEException {
-            var salt = SaltHelper.generateNewSalt();
-            var expectedCommonSubject =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
             accessToken = createSignedAccessToken(null);
-            var userProfile = generateUserprofile();
-            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                    .thenReturn(userProfile);
-            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
@@ -515,7 +508,7 @@ class UserInfoServiceTest {
 
             var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
 
-            assertThat(subjectForAudit, equalTo(expectedCommonSubject));
+            assertThat(subjectForAudit, equalTo(INTERNAL_PAIRWISE_SUBJECT.getValue()));
         }
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ClientSubjectHelper.java
@@ -38,17 +38,6 @@ public class ClientSubjectHelper {
         }
     }
 
-    public static Subject getSubjectWithSectorIdentifier(
-            UserProfile userProfile,
-            String sectorIdentifierURI,
-            AuthenticationService authenticationService) {
-        return new Subject(
-                calculatePairwiseIdentifier(
-                        userProfile.getSubjectID(),
-                        returnHost(sectorIdentifierURI),
-                        authenticationService.getOrGenerateSalt(userProfile)));
-    }
-
     public static String getSectorIdentifierForClient(
             ClientRegistry client, String internalSectorUri) {
         if (client.isOneLoginService()) {


### PR DESCRIPTION
### Wider context of change

We would like to move away from using the user profile table in orch. We can start by using the access token to get the internal common subject ID (ICSID) instead of calculating this using the user profile.

We merged a PR in last week to log whether these values are the same. Over the weekend there was no logs to show that they were not equal so we can be confident they are the same. 

### What’s changed

This PR swaps to using the ICSID from the access token instead of calculating the ICSID from the user profile. This also means we can remove some now unused helper methods.

### Manual testing

Tested in dev. Did an auth only journey and an identity journey. Both journeys ended with the correct user info subject displayed.

Also did a docapp journey which also finished successfully.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

