### PR TITLE
BAU: Use mock access key adhering to local dynamo restrictions

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -31,9 +31,9 @@ test {
     useJUnitPlatform()
 
     environment "AUDIT_SIGNING_KEY_ALIAS", "alias/local-audit-payload-signing-key-alias"
-    environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_ACCESS_KEY_ID", "mockaccesskey"
     environment "AWS_REGION", "eu-west-2"
-    environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
+    environment "AWS_SECRET_ACCESS_KEY", "mocksecretkey "
     environment "OIDC_API_BASE_URL", "http://localhost"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ ext {
     terraformEnvironment = project.properties["terraformEnvironment"] ?: "localstack"
 
     awsCredentialsEnvironment = terraformEnvironment == "localstack" ? [
-        AWS_ACCESS_KEY_ID: "mock-access-key",
-        AWS_SECRET_ACCESS_KEY: "mock-secret-key",
+        AWS_ACCESS_KEY_ID: "mockaccesskey",
+        AWS_SECRET_ACCESS_KEY: "mocksecretkey",
     ] : [:]
 
     noXray = {

--- a/delivery-receipts-integration-tests/build.gradle
+++ b/delivery-receipts-integration-tests/build.gradle
@@ -22,9 +22,9 @@ dependencies {
 test {
     useJUnitPlatform()
 
-    environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_ACCESS_KEY_ID", "mockaccesskey"
     environment "AWS_REGION", "eu-west-2"
-    environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
+    environment "AWS_SECRET_ACCESS_KEY", "mocksecretkey "
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"
     environment "HEADERS_CASE_INSENSITIVE", "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
     restart: no
     environment:
-      SERVICES: sqs, kms, ssm
+      SERVICES: sqs, sns, kms, ssm
       GATEWAY_LISTEN: 0.0.0.0:45678
       LOCALSTACK_HOST: localhost:45678
       TEST_AWS_ACCOUNT_ID: 123456789012

--- a/echo-int-test-vars.sh
+++ b/echo-int-test-vars.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export AWS_ACCESS_KEY_ID="mock-access-key"
-export AWS_SECRET_ACCESS_KEY="mock-secret-key"
+export AWS_ACCESS_KEY_ID="mockaccesskey"
+export AWS_SECRET_ACCESS_KEY="mocksecretkey"
 
-pushd ci/terraform/oidc >/dev/null
+pushd ci/terraform/oidc > /dev/null
 API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
 export API_GATEWAY_ID
 API_KEY="$(terraform output -raw di-auth-frontend-api-key)"
@@ -15,6 +15,6 @@ FRONTEND_API_KEY="$(terraform output -raw frontend_api_key)"
 export FRONTEND_API_KEY
 export RESET_PASSWORD_URL="http://localhost:3000/reset-password?code="
 export STUB_RELYING_PARTY_REDIRECT_URI="https://rp-build.build.stubs.account.gov.uk/"
-popd >/dev/null
+popd > /dev/null
 
 echo "API_GATEWAY_ID=$API_GATEWAY_ID;AWS_ACCESS_KEY_ID=BOB;AWS_SECRET_ACCESS_KEY=builder;LOGIN_URI=http://localhost:3000/;API_KEY=$API_KEY;FRONTEND_API_GATEWAY_ID=$FRONTEND_API_GATEWAY_ID;FRONTEND_API_KEY=$FRONTEND_API_KEY;STUB_RELYING_PARTY_REDIRECT_URI=$STUB_RELYING_PARTY_REDIRECT_URI;"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -46,9 +46,9 @@ test {
     exclude 'uk/gov/di/authentication/contract/**'
 
     environment "AUDIT_SIGNING_KEY_ALIAS", "alias/local-audit-payload-signing-key-alias"
-    environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_ACCESS_KEY_ID", "mockaccesskey"
     environment "AWS_REGION", "eu-west-2"
-    environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
+    environment "AWS_SECRET_ACCESS_KEY", "mocksecretkey "
     environment "OIDC_API_BASE_URL", "http://localhost"
     environment "DEFAULT_LOGOUT_URI", "http://localhost:3000/signed-out"
     environment "DOMAIN_NAME", "localhost"
@@ -103,12 +103,12 @@ task pactProviderTests (type: Test, group: "verification") {
     systemProperties['pact.provider.version'] = "${System.env.GIT_SHA}"
 
     environment "PROVIDER_UNDER_TEST", "ClientRegistryProvider"
-    environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_ACCESS_KEY_ID", "mockaccesskey"
     environment "AWS_REGION", "eu-west-2"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "REDIS_KEY", "session"
     environment "TRACING_ENABLED", "false"
-    environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
+    environment "AWS_SECRET_ACCESS_KEY", "mocksecretkey "
     environment "OIDC_API_BASE_URL", "http://localhost"
     environment "ENVIRONMENT", "local"
     environment "LOCALSTACK_ENDPOINT", "http://localhost:45678"


### PR DESCRIPTION
## What

- Updated mock access key to be alphanumeric (see https://repost.aws/articles/ARc4hEkF9CRgOrw8kSMe6CwQ/troubleshooting-the-access-key-id-or-security-token-is-invalid-error-after-upgrading-dynamodb-local-to-version-2-0-0-1-23-0-or-greater)
- Updated localstack config to include SNS which is required for orch tests

## How to review

1. Code Review
1. Run integration tests locally

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.
