### PR TITLE
BAU: Improve DeprecationChecker

### DIFF
--- a/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
+++ b/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
@@ -123,6 +123,10 @@ public class DeprecationChecker {
     static List<String> checkEnumRemovals(String filePath, String oldContent, String newContent) {
         List<String> violations = new ArrayList<>();
 
+        if (oldContent.equals(newContent)) {
+            return violations;
+        }
+
         try {
             JavaParser parser = new JavaParser();
             Optional<CompilationUnit> oldUnit = parser.parse(oldContent).getResult();

--- a/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
+++ b/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
@@ -336,6 +336,23 @@ class DeprecationCheckerTest {
 
             assertTrue(violations.isEmpty());
         }
+
+        @Test
+        void shouldReturnEmptyWhenContentIsIdentical() {
+            String content =
+                    """
+                package com.example;
+                public enum TestEnum {
+                    CONSTANT_A,
+                    CONSTANT_B
+                }
+                """;
+
+            List<String> violations =
+                    DeprecationChecker.checkEnumRemovals("TestEnum.java", content, content);
+
+            assertTrue(violations.isEmpty());
+        }
     }
 
     @Nested

--- a/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
+++ b/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
@@ -43,7 +43,7 @@ class DeprecationCheckerTest {
                 var config = DeprecationChecker.loadConfig();
 
                 assertEquals("origin/main", config.baseBranch);
-                assertTrue(config.enums.isEmpty());
+                assertTrue(config.enumFiles.isEmpty());
             } finally {
                 System.setProperty("user.dir", originalDir);
             }
@@ -59,7 +59,7 @@ class DeprecationCheckerTest {
                         """
                     {
                         "baseBranch": "origin/develop",
-                        "enums": ["com.example.TestEnum"]
+                        "enumFiles": ["src/TestEnum.java"]
                     }
                     """);
 
@@ -68,7 +68,7 @@ class DeprecationCheckerTest {
                 var config = DeprecationChecker.loadConfig();
 
                 assertEquals("origin/develop", config.baseBranch);
-                assertEquals(Set.of("com.example.TestEnum"), config.enums);
+                assertEquals(Set.of("src/TestEnum.java"), config.enumFiles);
             } finally {
                 System.setProperty("user.dir", originalDir);
             }
@@ -79,7 +79,7 @@ class DeprecationCheckerTest {
             String originalDir = System.getProperty("user.dir");
             try {
                 Path configFile = tempDir.resolve("deprecation-config.json");
-                Files.writeString(configFile, "{\"enums\": [\"test\"]}");
+                Files.writeString(configFile, "{\"enumFiles\": [\"test.java\"]}");
                 System.setProperty("user.dir", tempDir.toString());
 
                 var config = DeprecationChecker.loadConfig();
@@ -100,7 +100,7 @@ class DeprecationCheckerTest {
 
                 var config = DeprecationChecker.loadConfig();
 
-                assertTrue(config.enums.isEmpty());
+                assertTrue(config.enumFiles.isEmpty());
             } finally {
                 System.setProperty("user.dir", originalDir);
             }
@@ -111,7 +111,8 @@ class DeprecationCheckerTest {
     class PerformCheck {
         @Test
         void shouldReturnEmptyListWhenBaseBranchNotFound() throws Exception {
-            var config = new DeprecationChecker.Config("nonexistent-branch", Set.of());
+            var config =
+                    new DeprecationChecker.Config("nonexistent-branch", Set.of("TestEnum.java"));
 
             var violations = DeprecationChecker.performCheck(config);
 
@@ -120,7 +121,7 @@ class DeprecationCheckerTest {
 
         @Test
         void shouldCallCheckEnumRemovalsAndReturnViolations() throws Exception {
-            var config = new DeprecationChecker.Config("origin/main", Set.of());
+            var config = new DeprecationChecker.Config("origin/main", Set.of("TestEnum.java"));
 
             try (MockedStatic<DeprecationChecker> mockStatic =
                             mockStatic(DeprecationChecker.class, Mockito.CALLS_REAL_METHODS);
@@ -141,9 +142,6 @@ class DeprecationCheckerTest {
                                     })) {
 
                 mockStatic
-                        .when(DeprecationChecker::getAllJavaFiles)
-                        .thenReturn(java.util.List.of("TestEnum.java"));
-                mockStatic
                         .when(
                                 () ->
                                         DeprecationChecker.getCommitedFileContent(
@@ -156,61 +154,13 @@ class DeprecationCheckerTest {
                         .when(
                                 () ->
                                         DeprecationChecker.checkEnumRemovals(
-                                                "TestEnum.java",
-                                                "old content",
-                                                "new content",
-                                                Set.of()))
+                                                "TestEnum.java", "old content", "new content"))
                         .thenReturn(java.util.List.of("violation found"));
 
                 var violations = DeprecationChecker.performCheck(config);
 
                 assertEquals(1, violations.size());
                 assertEquals("violation found", violations.get(0));
-            }
-        }
-    }
-
-    @Nested
-    class GetAllJavaFiles {
-        @Test
-        void shouldFindJavaFiles(@TempDir Path tempDir) throws IOException {
-            String originalDir = System.getProperty("user.dir");
-            try {
-                System.setProperty("user.dir", tempDir.toString());
-                Files.writeString(tempDir.resolve("Test.java"), "class Test {}");
-                Files.createDirectories(tempDir.resolve("src"));
-                Files.writeString(tempDir.resolve("src/Main.java"), "class Main {}");
-                Files.writeString(tempDir.resolve("README.md"), "# README");
-
-                var javaFiles = DeprecationChecker.getAllJavaFiles();
-
-                assertEquals(2, javaFiles.size());
-                assertTrue(javaFiles.contains("Test.java"));
-                assertTrue(javaFiles.contains("src/Main.java"));
-            } finally {
-                System.setProperty("user.dir", originalDir);
-            }
-        }
-
-        @Test
-        void shouldExcludeBuildDirectories(@TempDir Path tempDir) throws IOException {
-            String originalDir = System.getProperty("user.dir");
-            try {
-                System.setProperty("user.dir", tempDir.toString());
-                Files.createDirectories(tempDir.resolve("build"));
-                Files.writeString(tempDir.resolve("build/Generated.java"), "class Generated {}");
-                Files.createDirectories(tempDir.resolve("target"));
-                Files.writeString(tempDir.resolve("target/Compiled.java"), "class Compiled {}");
-                Files.createDirectories(tempDir.resolve(".gradle"));
-                Files.writeString(tempDir.resolve(".gradle/Cache.java"), "class Cache {}");
-                Files.writeString(tempDir.resolve("Valid.java"), "class Valid {}");
-
-                var javaFiles = DeprecationChecker.getAllJavaFiles();
-
-                assertEquals(1, javaFiles.size());
-                assertTrue(javaFiles.contains("Valid.java"));
-            } finally {
-                System.setProperty("user.dir", originalDir);
             }
         }
     }
@@ -320,11 +270,7 @@ class DeprecationCheckerTest {
                 """;
 
             List<String> violations =
-                    DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java",
-                            oldContent,
-                            newContent,
-                            Set.of("com.example.TestEnum"));
+                    DeprecationChecker.checkEnumRemovals("TestEnum.java", oldContent, newContent);
 
             assertTrue(violations.isEmpty());
         }
@@ -349,11 +295,7 @@ class DeprecationCheckerTest {
                 """;
 
             List<String> violations =
-                    DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java",
-                            oldContent,
-                            newContent,
-                            Set.of("com.example.TestEnum"));
+                    DeprecationChecker.checkEnumRemovals("TestEnum.java", oldContent, newContent);
 
             assertEquals(1, violations.size());
             assertTrue(violations.get(0).contains("CONSTANT_B"));
@@ -363,7 +305,7 @@ class DeprecationCheckerTest {
         void shouldReturnEmptyWhenOldContentUnparseable() {
             List<String> violations =
                     DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java", "invalid java", "public enum Test {}", Set.of());
+                            "TestEnum.java", "invalid java", "public enum Test {}");
 
             assertTrue(violations.isEmpty());
         }
@@ -372,36 +314,7 @@ class DeprecationCheckerTest {
         void shouldReturnEmptyWhenNewContentUnparseable() {
             List<String> violations =
                     DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java", "public enum Test {}", "invalid java", Set.of());
-
-            assertTrue(violations.isEmpty());
-        }
-
-        @Test
-        void shouldSkipEnumNotInTargetSet() {
-            String oldContent =
-                    """
-                package com.example;
-                public enum TestEnum {
-                    CONSTANT_A,
-                    CONSTANT_B
-                }
-                """;
-
-            String newContent =
-                    """
-                package com.example;
-                public enum TestEnum {
-                    CONSTANT_A
-                }
-                """;
-
-            List<String> violations =
-                    DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java",
-                            oldContent,
-                            newContent,
-                            Set.of("com.example.OtherEnum"));
+                            "TestEnum.java", "public enum Test {}", "invalid java");
 
             assertTrue(violations.isEmpty());
         }
@@ -419,11 +332,7 @@ class DeprecationCheckerTest {
             String newContent = "package com.example;";
 
             List<String> violations =
-                    DeprecationChecker.checkEnumRemovals(
-                            "TestEnum.java",
-                            oldContent,
-                            newContent,
-                            Set.of("com.example.TestEnum"));
+                    DeprecationChecker.checkEnumRemovals("TestEnum.java", oldContent, newContent);
 
             assertTrue(violations.isEmpty());
         }

--- a/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
+++ b/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
@@ -376,4 +376,35 @@ class DeprecationCheckerTest {
             assertTrue(DeprecationChecker.isDeprecated(constant));
         }
     }
+
+    @Nested
+    class FindMergeBase {
+        @Test
+        void shouldReturnMergeBaseWhenFound() {
+            Repository mockRepo = mock(Repository.class);
+            ObjectId commit1 = ObjectId.fromString("1234567890123456789012345678901234567890");
+            ObjectId commit2 = ObjectId.fromString("abcdef1234567890123456789012345678901234");
+            ObjectId mergeBaseId = ObjectId.fromString("fedcba0987654321098765432109876543210987");
+
+            RevCommit mockCommit1 = mock(RevCommit.class);
+            RevCommit mockCommit2 = mock(RevCommit.class);
+            RevCommit mockMergeBase = mock(RevCommit.class);
+
+            when(mockMergeBase.getId()).thenReturn(mergeBaseId);
+
+            try (MockedConstruction<RevWalk> mockRevWalkConstruction =
+                    mockConstruction(
+                            RevWalk.class,
+                            (mock, context) -> {
+                                when(mock.parseCommit(commit1)).thenReturn(mockCommit1);
+                                when(mock.parseCommit(commit2)).thenReturn(mockCommit2);
+                                when(mock.next()).thenReturn(mockMergeBase);
+                            })) {
+
+                ObjectId result = DeprecationChecker.findMergeBase(mockRepo, commit1, commit2);
+
+                assertEquals(mergeBaseId, result);
+            }
+        }
+    }
 }

--- a/deprecation-config.json
+++ b/deprecation-config.json
@@ -1,15 +1,15 @@
 {
   "baseBranch": "origin/main",
-  "enums": [
-    "uk.gov.di.authentication.shared.entity.CodeRequestType",
-    "uk.gov.di.authentication.shared.entity.CountType",
-    "uk.gov.di.authentication.shared.entity.CredentialTrustLevel",
-    "uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType",
-    "uk.gov.di.authentication.shared.entity.EmailCheckResultStatus",
-    "uk.gov.di.authentication.shared.entity.ErrorResponse",
-    "uk.gov.di.authentication.shared.entity.JourneyType",
-    "uk.gov.di.authentication.shared.entity.LevelOfConfidence",
-    "uk.gov.di.authentication.shared.entity.MFAMethodType",
-    "uk.gov.di.authentication.shared.entity.PriorityIdentifier"
+  "enumFiles": [
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/CountType.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStatus.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethodType.java",
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/PriorityIdentifier.java"
   ]
 }


### PR DESCRIPTION
## What

Optimises the DeprecationChecker by:

• Only checking protected files instead of all Java files for better performance
• Skipping checks when file content is identical to avoid unnecessary processing
• Comparing against merge base with main to prevent false positives when branches aren't rebased after new enum values are added to main

These changes make the deprecation checker more efficient and eliminate false violations that occur when PRs haven't been rebased against the latest main branch.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

<!-- UCD Re