### PR TITLE
ATO-1903: Remove internalSubjectId from access token store and refresh token store

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -524,10 +524,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         SignedJWT signedJWT = generateSignedRefreshToken(scope, publicSubject);
         RefreshToken refreshToken = new RefreshToken(signedJWT.serialize());
         RefreshTokenStore tokenStore =
-                new RefreshTokenStore(
-                        refreshToken.getValue(),
-                        internalSubject.getValue(),
-                        internalPairwiseSubject.getValue());
+                new RefreshTokenStore(refreshToken.getValue(), internalPairwiseSubject.getValue());
         redis.addToRedis(
                 REFRESH_TOKEN_PREFIX + signedJWT.getJWTClaimsSet().getJWTID(),
                 objectMapper.writeValueAsString(tokenStore),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -561,7 +561,6 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String redisResponse = redis.getFromRedis(REFRESH_TOKEN_PREFIX + jwtId);
         RefreshTokenStore refreshTokenStore =
                 objectMapper.readValue(redisResponse, RefreshTokenStore.class);
-        assertEquals(refreshTokenStore.getInternalSubjectId(), internalSubject.getValue());
         assertEquals(
                 refreshTokenStore.getInternalPairwiseSubjectId(),
                 internalPairwiseSubject.getValue());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -146,10 +146,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
                 new AccessTokenStore(
-                        accessToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
-                        JOURNEY_ID);
+                        accessToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID);
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
@@ -394,10 +391,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
                 new AccessTokenStore(
-                        accessToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
-                        JOURNEY_ID);
+                        accessToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
                 objectMapper.writeValueAsString(accessTokenStore),
@@ -426,10 +420,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
                 new AccessTokenStore(
-                        accessToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
-                        JOURNEY_ID);
+                        accessToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID);
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + APP_CLIENT_ID + "." + DOC_APP_PUBLIC_SUBJECT,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallenge;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
@@ -390,7 +391,6 @@ public class TokenHandler
         OIDCTokenResponse tokenResponse =
                 tokenService.generateRefreshTokenResponse(
                         clientId,
-                        new Subject(tokenStore.getInternalSubjectId()),
                         scopes,
                         rpPairwiseSubject,
                         new Subject(tokenStore.getInternalPairwiseSubjectId()),
@@ -479,20 +479,22 @@ public class TokenHandler
             tokenResponse =
                     segmentedFunctionCall(
                             "generateTokenResponse",
-                            () ->
-                                    tokenService.generateTokenResponse(
-                                            clientRegistry.getClientID(),
-                                            clientDocAppSubjectId,
-                                            authRequest.getScope(),
-                                            additionalTokenClaims,
-                                            clientDocAppSubjectId,
-                                            clientDocAppSubjectId,
-                                            finalClaimsRequest,
-                                            true,
-                                            signingAlgorithm,
-                                            clientSessionId,
-                                            vot,
-                                            null));
+                            () -> {
+                                String clientID = clientRegistry.getClientID();
+                                Scope authRequestScopes = authRequest.getScope();
+                                return tokenService.generateTokenResponse(
+                                        clientID,
+                                        authRequestScopes,
+                                        additionalTokenClaims,
+                                        clientDocAppSubjectId,
+                                        clientDocAppSubjectId,
+                                        finalClaimsRequest,
+                                        true,
+                                        signingAlgorithm,
+                                        clientSessionId,
+                                        vot,
+                                        null);
+                            });
         } else {
             UserProfile userProfile =
                     dynamoService.getUserProfileByEmail(authCodeExchangeData.getEmail());
@@ -522,7 +524,6 @@ public class TokenHandler
                             () ->
                                     tokenService.generateTokenResponse(
                                             clientRegistry.getClientID(),
-                                            new Subject(userProfile.getSubjectID()),
                                             authRequest.getScope(),
                                             additionalTokenClaims,
                                             rpPairwiseSubject,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -238,9 +238,9 @@ public class TokenHandlerTest {
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
         setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
@@ -249,7 +249,7 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         AUTH_TIME))
                 .thenReturn(tokenResponse);
 
@@ -311,9 +311,9 @@ public class TokenHandlerTest {
         setupClientSessions(
                 authCode, authenticationRequest.toParameters(), vtr, "a-different-client-id", null);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
@@ -322,7 +322,7 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         AUTH_TIME))
                 .thenReturn(tokenResponse);
 
@@ -375,9 +375,9 @@ public class TokenHandlerTest {
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
         setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
@@ -386,7 +386,7 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.RS256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         AUTH_TIME))
                 .thenReturn(tokenResponse);
 
@@ -451,7 +451,6 @@ public class TokenHandlerTest {
         when(redisConnectionService.popValue(redisKey)).thenReturn(tokenStoreString);
         when(tokenService.generateRefreshTokenResponse(
                         eq(CLIENT_ID),
-                        eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
                         eq(RP_PAIRWISE_SUBJECT),
                         eq(INTERNAL_PAIRWISE_SUBJECT),
@@ -516,7 +515,6 @@ public class TokenHandlerTest {
         when(redisConnectionService.popValue(redisKey)).thenReturn(tokenStoreString);
         when(tokenService.generateRefreshTokenResponse(
                         eq(CLIENT_ID),
-                        eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
                         eq(RP_PAIRWISE_SUBJECT),
                         eq(INTERNAL_PAIRWISE_SUBJECT),
@@ -600,9 +598,9 @@ public class TokenHandlerTest {
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
@@ -611,7 +609,7 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         AUTH_TIME))
                 .thenReturn(tokenResponse);
         setupNoClientSessions();
@@ -793,9 +791,9 @@ public class TokenHandlerTest {
             VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
             setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
             when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+            String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
             when(tokenService.generateTokenResponse(
                             CLIENT_ID,
-                            INTERNAL_SUBJECT,
                             SCOPES,
                             Map.of("nonce", NONCE),
                             RP_PAIRWISE_SUBJECT,
@@ -804,7 +802,7 @@ public class TokenHandlerTest {
                             false,
                             JWSAlgorithm.ES256,
                             CLIENT_SESSION_ID,
-                            lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                            vot,
                             AUTH_TIME))
                     .thenReturn(tokenResponse);
 
@@ -1039,9 +1037,9 @@ public class TokenHandlerTest {
                             authenticationRequest.getCustomParameter("vtr"));
             VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
             setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
+            String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
             when(tokenService.generateTokenResponse(
                             CLIENT_ID,
-                            INTERNAL_SUBJECT,
                             SCOPES,
                             Map.of("nonce", NONCE),
                             RP_PAIRWISE_SUBJECT,
@@ -1050,7 +1048,7 @@ public class TokenHandlerTest {
                             false,
                             JWSAlgorithm.ES256,
                             CLIENT_SESSION_ID,
-                            lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                            vot,
                             AUTH_TIME))
                     .thenReturn(tokenResponse);
 
@@ -1112,9 +1110,9 @@ public class TokenHandlerTest {
             VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
             setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
             when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+            String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
             when(tokenService.generateTokenResponse(
                             CLIENT_ID,
-                            INTERNAL_SUBJECT,
                             SCOPES,
                             Map.of("nonce", NONCE),
                             RP_PAIRWISE_SUBJECT,
@@ -1123,7 +1121,7 @@ public class TokenHandlerTest {
                             false,
                             JWSAlgorithm.ES256,
                             CLIENT_SESSION_ID,
-                            lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                            vot,
                             AUTH_TIME))
                     .thenReturn(tokenResponse);
 
@@ -1250,10 +1248,12 @@ public class TokenHandlerTest {
                 DOC_APP_CLIENT_ID.getValue(),
                 DOC_APP_USER_PUBLIC_SUBJECT);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String clientID = DOC_APP_CLIENT_ID.getValue();
+        Scope authRequestScopes = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
-                        DOC_APP_CLIENT_ID.getValue(),
-                        DOC_APP_USER_PUBLIC_SUBJECT,
-                        new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID),
+                        clientID,
+                        authRequestScopes,
                         Map.of("nonce", NONCE),
                         DOC_APP_USER_PUBLIC_SUBJECT,
                         DOC_APP_USER_PUBLIC_SUBJECT,
@@ -1261,7 +1261,7 @@ public class TokenHandlerTest {
                         true,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         null))
                 .thenReturn(tokenResponse);
 
@@ -1332,7 +1332,6 @@ public class TokenHandlerTest {
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         eq(CLIENT_ID),
-                        eq(INTERNAL_SUBJECT),
                         eq(SCOPES),
                         eq(Map.of("nonce", NONCE)),
                         eq(RP_PAIRWISE_SUBJECT),
@@ -1394,7 +1393,6 @@ public class TokenHandlerTest {
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         eq(CLIENT_ID),
-                        eq(INTERNAL_SUBJECT),
                         eq(SCOPES),
                         eq(Map.of("nonce", NONCE)),
                         eq(RP_PAIRWISE_SUBJECT),
@@ -1449,9 +1447,9 @@ public class TokenHandlerTest {
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
         setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
+        String vot = lowestLevelVtr.retrieveVectorOfTrustForToken();
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
@@ -1460,7 +1458,7 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        vot,
                         AUTH_TIME))
                 .thenReturn(tokenResponse);
 
@@ -1696,7 +1694,6 @@ public class TokenHandlerTest {
         var finalClaimsRequestCaptor = ArgumentCaptor.forClass(OIDCClaimsRequest.class);
         verify(tokenService)
                 .generateTokenResponse(
-                        any(),
                         any(),
                         any(),
                         any(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -440,9 +440,7 @@ public class TokenHandlerTest {
                 .thenReturn(true);
         RefreshTokenStore tokenStore =
                 new RefreshTokenStore(
-                        refreshToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        refreshToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
                         REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))
@@ -504,9 +502,7 @@ public class TokenHandlerTest {
                 .thenReturn(true);
         RefreshTokenStore tokenStore =
                 new RefreshTokenStore(
-                        refreshToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        refreshToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
                         REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -49,7 +49,6 @@ class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private static final String TOKEN = "token";
-    private static final String INTERNAL_SUBJECT_ID = "internal-subject-id";
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
     private static final String JOURNEY_ID = "client-session-id";
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
@@ -80,11 +79,7 @@ class UserInfoHandlerTest {
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());
         when(accessTokenInfo.getAccessTokenStore())
                 .thenReturn(
-                        new AccessTokenStore(
-                                TOKEN,
-                                INTERNAL_SUBJECT_ID,
-                                TEST_INTERNAL_COMMON_SUBJECT_ID,
-                                JOURNEY_ID));
+                        new AccessTokenStore(TOKEN, TEST_INTERNAL_COMMON_SUBJECT_ID, JOURNEY_ID));
         when(configurationService.getEnvironment()).thenReturn("test");
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -55,7 +55,6 @@ class AccessTokenServiceTest {
     private final TokenValidationService tokenValidationService =
             mock(TokenValidationService.class);
     private final DynamoClientService clientService = mock(DynamoClientService.class);
-    private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final String JOURNEY_ID = "client-session-id";
@@ -122,7 +121,6 @@ class AccessTokenServiceTest {
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
                                         accessToken.getValue(),
-                                        INTERNAL_SUBJECT.getValue(),
                                         INTERNAL_PAIRWISE_SUBJECT.getValue(),
                                         JOURNEY_ID)));
 
@@ -131,9 +129,6 @@ class AccessTokenServiceTest {
 
         assertThat(
                 accessTokenInfo.getAccessTokenStore().getToken(), equalTo(accessToken.getValue()));
-        assertThat(
-                accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
-                equalTo(INTERNAL_SUBJECT.getValue()));
         assertThat(accessTokenInfo.getAccessTokenStore().getJourneyId(), equalTo(JOURNEY_ID));
         assertThat(accessTokenInfo.getSubject(), equalTo(SUBJECT.getValue()));
         assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
@@ -152,7 +147,6 @@ class AccessTokenServiceTest {
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
                                         accessToken.getValue(),
-                                        INTERNAL_SUBJECT.getValue(),
                                         INTERNAL_PAIRWISE_SUBJECT.getValue(),
                                         JOURNEY_ID)));
 
@@ -160,9 +154,6 @@ class AccessTokenServiceTest {
 
         assertThat(
                 accessTokenInfo.getAccessTokenStore().getToken(), equalTo(accessToken.getValue()));
-        assertThat(
-                accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
-                equalTo(INTERNAL_SUBJECT.getValue()));
         assertThat(accessTokenInfo.getAccessTokenStore().getJourneyId(), equalTo(JOURNEY_ID));
         assertThat(accessTokenInfo.getSubject(), equalTo(SUBJECT.getValue()));
         assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
@@ -258,7 +249,6 @@ class AccessTokenServiceTest {
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
                                         accessToken.getValue(),
-                                        INTERNAL_SUBJECT.getValue(),
                                         INTERNAL_PAIRWISE_SUBJECT.getValue(),
                                         JOURNEY_ID)));
 
@@ -311,7 +301,6 @@ class AccessTokenServiceTest {
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
                                         createSignedAccessToken(null, false).getValue(),
-                                        INTERNAL_SUBJECT.getValue(),
                                         INTERNAL_PAIRWISE_SUBJECT.getValue(),
                                         JOURNEY_ID)));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -135,10 +135,7 @@ class UserInfoServiceTest {
         accessToken = createSignedAccessToken(null);
         var accessTokenStore =
                 new AccessTokenStore(
-                        accessToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
-                        JOURNEY_ID);
+                        accessToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID);
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
         givenThereIsUserInfo();
@@ -177,10 +174,7 @@ class UserInfoServiceTest {
 
         var accessTokenStore =
                 new AccessTokenStore(
-                        accessToken.getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
-                        JOURNEY_ID);
+                        accessToken.getValue(), INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID);
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
 
@@ -212,7 +206,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -263,7 +256,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -317,7 +309,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -350,7 +341,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -391,7 +381,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -444,7 +433,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =
@@ -467,10 +455,7 @@ class UserInfoServiceTest {
                             CustomScopeValue.DOC_CHECKING_APP.getValue());
             var accessTokenStore =
                     new AccessTokenStore(
-                            accessToken.getValue(),
-                            DOC_APP_SUBJECT.getValue(),
-                            DOC_APP_SUBJECT.getValue(),
-                            JOURNEY_ID);
+                            accessToken.getValue(), DOC_APP_SUBJECT.getValue(), JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -491,7 +476,6 @@ class UserInfoServiceTest {
             var accessTokenStore =
                     new AccessTokenStore(
                             accessToken.getValue(),
-                            INTERNAL_SUBJECT.getValue(),
                             INTERNAL_PAIRWISE_SUBJECT.getValue(),
                             JOURNEY_ID);
             var accessTokenInfo =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
@@ -14,6 +14,12 @@ public class AccessTokenStore {
 
     public AccessTokenStore() {}
 
+    public AccessTokenStore(String token, String internalPairwiseSubjectId, String journeyId) {
+        this.token = token;
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+        this.journeyId = journeyId;
+    }
+
     public AccessTokenStore(
             String token,
             String internalSubjectId,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
@@ -5,11 +5,7 @@ import com.google.gson.annotations.Expose;
 public class AccessTokenStore {
 
     @Expose private String token;
-
-    @Expose private String internalSubjectId;
-
     @Expose private String internalPairwiseSubjectId = "missing";
-
     @Expose private String journeyId = "missing";
 
     public AccessTokenStore() {}
@@ -20,23 +16,8 @@ public class AccessTokenStore {
         this.journeyId = journeyId;
     }
 
-    public AccessTokenStore(
-            String token,
-            String internalSubjectId,
-            String internalPairwiseSubjectId,
-            String journeyId) {
-        this.token = token;
-        this.internalSubjectId = internalSubjectId;
-        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
-        this.journeyId = journeyId;
-    }
-
     public String getToken() {
         return token;
-    }
-
-    public String getInternalSubjectId() {
-        return internalSubjectId;
     }
 
     public String getInternalPairwiseSubjectId() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RefreshTokenStore.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RefreshTokenStore.java
@@ -19,6 +19,11 @@ public class RefreshTokenStore {
 
     public RefreshTokenStore() {}
 
+    public RefreshTokenStore(String refreshToken, String internalPairwiseSubjectId) {
+        this.refreshToken = refreshToken;
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+    }
+
     public RefreshTokenStore(
             String refreshToken, String internalSubjectId, String internalPairwiseSubjectId) {
         this.refreshToken = refreshToken;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RefreshTokenStore.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RefreshTokenStore.java
@@ -10,10 +10,6 @@ public class RefreshTokenStore {
     private String refreshToken;
 
     @Expose
-    @SerializedName("internal_subject_id")
-    private String internalSubjectId;
-
-    @Expose
     @SerializedName("internal_pairwise_subject_id")
     private String internalPairwiseSubjectId = "missing";
 
@@ -22,17 +18,6 @@ public class RefreshTokenStore {
     public RefreshTokenStore(String refreshToken, String internalPairwiseSubjectId) {
         this.refreshToken = refreshToken;
         this.internalPairwiseSubjectId = internalPairwiseSubjectId;
-    }
-
-    public RefreshTokenStore(
-            String refreshToken, String internalSubjectId, String internalPairwiseSubjectId) {
-        this.refreshToken = refreshToken;
-        this.internalSubjectId = internalSubjectId;
-        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
-    }
-
-    public String getInternalSubjectId() {
-        return internalSubjectId;
     }
 
     public String getInternalPairwiseSubjectId() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -83,7 +83,6 @@ public class TokenService {
 
     public OIDCTokenResponse generateTokenResponse(
             String clientID,
-            Subject internalSubject,
             Scope authRequestScopes,
             Map<String, Object> additionalTokenClaims,
             Subject rpPairwiseSubject,
@@ -133,7 +132,6 @@ public class TokenService {
                             () ->
                                     generateAndStoreRefreshToken(
                                             clientID,
-                                            internalSubject,
                                             scopesForToken,
                                             rpPairwiseSubject,
                                             internalPairwiseSubject,
@@ -146,7 +144,6 @@ public class TokenService {
 
     public OIDCTokenResponse generateRefreshTokenResponse(
             String clientID,
-            Subject internalSubject,
             List<String> scopes,
             Subject rpPaiwiseSubject,
             Subject internalPairwiseSubject,
@@ -163,7 +160,6 @@ public class TokenService {
         RefreshToken refreshToken =
                 generateAndStoreRefreshToken(
                         clientID,
-                        internalSubject,
                         scopes,
                         rpPaiwiseSubject,
                         internalPairwiseSubject,
@@ -352,7 +348,6 @@ public class TokenService {
 
     private RefreshToken generateAndStoreRefreshToken(
             String clientId,
-            Subject internalSubject,
             List<String> scopes,
             Subject rpPairwiseSubject,
             Subject internalPairwiseSubject,
@@ -377,10 +372,7 @@ public class TokenService {
 
         String redisKey = REFRESH_TOKEN_PREFIX + jwtId;
         var store =
-                new RefreshTokenStore(
-                        refreshToken.getValue(),
-                        internalSubject.toString(),
-                        internalPairwiseSubject.toString());
+                new RefreshTokenStore(refreshToken.getValue(), internalPairwiseSubject.toString());
         try {
             redisConnectionService.saveWithExpiry(
                     redisKey,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -343,7 +343,6 @@ public class TokenService {
                     objectMapper.writeValueAsString(
                             new AccessTokenStore(
                                     accessToken.getValue(),
-                                    internalSubject.getValue(),
                                     internalPairwiseSubject.getValue(),
                                     journeyId)),
                     configService.getAccessTokenExpiry());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -101,7 +101,6 @@ public class TokenService {
                         () ->
                                 generateAndStoreAccessToken(
                                         clientID,
-                                        internalSubject,
                                         scopesForToken,
                                         rpPairwiseSubject,
                                         internalPairwiseSubject,
@@ -155,7 +154,6 @@ public class TokenService {
         AccessToken accessToken =
                 generateAndStoreAccessToken(
                         clientID,
-                        internalSubject,
                         scopes,
                         rpPaiwiseSubject,
                         internalPairwiseSubject,
@@ -292,7 +290,6 @@ public class TokenService {
 
     private AccessToken generateAndStoreAccessToken(
             String clientId,
-            Subject internalSubject,
             List<String> scopes,
             Subject rpPairwiseSubject,
             Subject internalPairwiseSubject,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -158,7 +158,6 @@ class TokenServiceTest {
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
@@ -176,7 +175,6 @@ class TokenServiceTest {
         RefreshTokenStore refreshTokenStore =
                 new RefreshTokenStore(
                         tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
                         INTERNAL_PAIRWISE_SUBJECT.getValue());
         ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
         verify(redisConnectionService)
@@ -230,7 +228,6 @@ class TokenServiceTest {
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
@@ -267,7 +264,6 @@ class TokenServiceTest {
         RefreshTokenStore refreshTokenStore =
                 new RefreshTokenStore(
                         tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
                         INTERNAL_PAIRWISE_SUBJECT.getValue());
 
         ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
@@ -296,7 +292,6 @@ class TokenServiceTest {
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
@@ -324,7 +319,6 @@ class TokenServiceTest {
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
-                        INTERNAL_SUBJECT,
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -564,7 +564,6 @@ class TokenServiceTest {
         AccessTokenStore accessTokenStore =
                 new AccessTokenStore(
                         tokenResponse.getOIDCTokens().getAccessToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
                         INTERNAL_PAIRWISE_SUBJECT.getValue(),
                         JOURNEY_ID);
         verify(redisConnectionService)


### PR DESCRIPTION
### Wider context of change

We would like to remove the use of user profile in TokenHandler. The user profile was used to get the internalSubjectId to set in the tokenService.generateTokenResponse. The internalSubjectId isn't actually used anywhere, so we can safely remove it.

### What’s changed

This PR removes the `internalSubjectId` field from `AccessTokenStore` and `RefreshTokenStore`. There are quite a few commits in this PR mainly to ensure we do not cause errors (as the `RefreshTokenStore.internalSubjectId` was used to create new access tokens and refresh tokens)

Paired on this with @james-peacock-gds 

### Manual testing

Deployed and tested this in dev. Made a refresh token request and saw new access and refresh tokens were generated and returned to us.

Also tested that users in the middle of a journey when this was deployed were not affected.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
