### PR TITLE
AUT-4210: Enhance update-email API specification and mock support

### DIFF
--- a/account-management-api/api-contract/README.md
+++ b/account-management-api/api-contract/README.md
@@ -137,4 +137,50 @@ http DELETE :8080/v1/mfa-methods/delete-when-mfa-method-not-found/id
 
 http DELETE :8080/v1/mfa-methods/delete-when-cannot-delete-default-priority-mfa-method/id
 
+#########################################################################################################
+# UPDATE EMAIL
+#########################################################################################################
+
+# POST 204 success response
+http POST :8080/update-email \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk" \
+  replacementEmailAddress="new.user@example.gov.uk" \
+  otp="123456"
+
+# POST 400 error responses
+http POST :8080/update-email/invalid-otp \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk" \
+  replacementEmailAddress="new.user@example.gov.uk" \
+  otp="000000"
+
+http POST :8080/update-email/invalid-email-format \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk" \
+  replacementEmailAddress="invalid-email" \
+  otp="123456"
+
+http POST :8080/update-email/email-addresses-match \
+  Content-Type:application/json \
+  existingEmailAddress="same.user@example.gov.uk" \
+  replacementEmailAddress="same.user@example.gov.uk" \
+  otp="123456"
+
+http POST :8080/update-email/account-with-email-exists \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk" \
+  replacementEmailAddress="existing.user@example.gov.uk" \
+  otp="123456"
+
+http POST :8080/update-email/account-does-not-exist \
+  Content-Type:application/json \
+  existingEmailAddress="nonexistent.user@example.gov.uk" \
+  replacementEmailAddress="new.user@example.gov.uk" \
+  otp="123456"
+
+http POST :8080/update-email/missing-parameters \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk"
+
 ```

--- a/account-management-api/api-contract/README.md
+++ b/account-management-api/api-contract/README.md
@@ -183,4 +183,11 @@ http POST :8080/update-email/missing-parameters \
   Content-Type:application/json \
   existingEmailAddress="old.user@example.gov.uk"
 
+# POST 403 error response
+http POST :8080/update-email/email-address-denied \
+  Content-Type:application/json \
+  existingEmailAddress="old.user@example.gov.uk" \
+  replacementEmailAddress="denied.user@example.gov.uk" \
+  otp="123456"
+
 ```

--- a/account-management-api/api-contract/mock/rest-plugin-config.yaml
+++ b/account-management-api/api-contract/mock/rest-plugin-config.yaml
@@ -22,3 +22,68 @@ resources:
     method: GET
     response:
       statusCode: 500
+  # Update Email Mock Endpoints
+  - path: "/update-email"
+    method: POST
+    response:
+      statusCode: 204
+  - path: "/update-email/invalid-otp"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1020,
+          "message": "Invalid OTP code"
+        }
+  - path: "/update-email/invalid-email-format"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1004,
+          "message": "Email address is in an incorrect format"
+        }
+  - path: "/update-email/email-addresses-match"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1019,
+          "message": "Email addresses are the same"
+        }
+  - path: "/update-email/account-with-email-exists"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1009,
+          "message": "An account with this email address already exists"
+        }
+  - path: "/update-email/account-does-not-exist"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1010,
+          "message": "An account with this email address does not exist"
+        }
+  - path: "/update-email/missing-parameters"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 400
+      staticData: |
+        {
+          "code": 1001,
+          "message": "Request is missing parameters"
+        }

--- a/account-management-api/api-contract/mock/rest-plugin-config.yaml
+++ b/account-management-api/api-contract/mock/rest-plugin-config.yaml
@@ -87,3 +87,13 @@ resources:
           "code": 1001,
           "message": "Request is missing parameters"
         }
+  - path: "/update-email/email-address-denied"
+    contentType: "application/json"
+    method: POST
+    response:
+      statusCode: 403
+      staticData: |
+        {
+          "code": 1089,
+          "message": "Email address is denied"
+        }

--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -117,6 +117,17 @@ paths:
                   value:
                     code: 1010
                     message: "An account with this email address does not exist"
+        "403":
+          description: Forbidden - Email address is denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmailAddressDenied"
+              examples:
+                update-email-when-email-address-denied:
+                  value:
+                    code: 1089
+                    message: "Email address is denied"
       x-code-samples:
         - lang: shell
           label: cURL request example
@@ -1160,6 +1171,17 @@ components:
           example:
             code: 1010
             message: "An account with this email address does not exist"
+    EmailAddressDenied:
+      allOf:
+        - $ref: "#/components/schemas/SimpleError"
+        - type: object
+          properties:
+            code:
+              type: integer
+              enum: [1089]
+          example:
+            code: 1089
+            message: "Email address is denied"
 
   securitySchemes:
     authorise-access-token:

--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -61,6 +61,74 @@ paths:
         uri: "${endpoint_modules.update-email.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
+      description: "Updates a user's email address. Before calling this endpoint, you must first call the /send-otp-notification endpoint with notificationType 'VERIFY_EMAIL' to send an OTP to the new email address. The user must verify the new email address with the OTP before the update can be completed. Email notifications will be sent to both the old and new email addresses confirming the change."
+      summary: Updates a user's email address
+      operationId: "update-email"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEmailRequest"
+            examples:
+              update-email-request:
+                summary: Update user email address
+                value:
+                  existingEmailAddress: "old.user@example.gov.uk"
+                  replacementEmailAddress: "new.user@example.gov.uk"
+                  otp: "123456"
+        required: true
+      responses:
+        "204":
+          description: Email address successfully updated. Confirmation emails sent to both old and new addresses.
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/RequestIsMissingParameters"
+                  - $ref: "#/components/schemas/InvalidOTPCode"
+                  - $ref: "#/components/schemas/InvalidEmailFormat"
+                  - $ref: "#/components/schemas/EmailAddressesMatch"
+                  - $ref: "#/components/schemas/AccountWithEmailExists"
+                  - $ref: "#/components/schemas/AccountDoesNotExist"
+              examples:
+                update-email-when-request-is-missing-parameters:
+                  value:
+                    code: 1001
+                    message: "Request is missing parameters"
+                update-email-when-invalid-otp-code:
+                  value:
+                    code: 1020
+                    message: "Invalid OTP code"
+                update-email-when-invalid-email-format:
+                  value:
+                    code: 1004
+                    message: "Email address is in an incorrect format"
+                update-email-when-email-addresses-match:
+                  value:
+                    code: 1019
+                    message: "Email addresses are the same"
+                update-email-when-account-with-email-exists:
+                  value:
+                    code: 1009
+                    message: "An account with this email address already exists"
+                update-email-when-account-does-not-exist:
+                  value:
+                    code: 1010
+                    message: "An account with this email address does not exist"
+      x-code-samples:
+        - lang: shell
+          label: cURL request example
+          source: |
+            curl -X POST "https://localhost:8080/update-email" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer <YOUR_ACCESS_TOKEN>" \
+              -d '{
+                "existingEmailAddress": "old.user@example.gov.uk",
+                "replacementEmailAddress": "new.user@example.gov.uk",
+                "otp": "123456"
+              }'
   /delete-account:
     post:
       security:
@@ -1021,14 +1089,77 @@ components:
             code:
               type: integer
               enum: [1084]
-    UserAccountSuspended:
+    UpdateEmailRequest:
+      required:
+        - existingEmailAddress
+        - replacementEmailAddress
+        - otp
+      type: object
+      properties:
+        existingEmailAddress:
+          type: string
+          format: email
+          description: The user's current email address
+          example: "old.user@example.gov.uk"
+        replacementEmailAddress:
+          type: string
+          format: email
+          description: The user's new email address
+          example: "new.user@example.gov.uk"
+        otp:
+          type: string
+          pattern: "^[0-9]{6}$"
+          description: The 6-digit OTP code sent to the new email address
+          example: "123456"
+      example:
+        existingEmailAddress: "old.user@example.gov.uk"
+        replacementEmailAddress: "new.user@example.gov.uk"
+        otp: "123456"
+
+    InvalidEmailFormat:
       allOf:
         - $ref: "#/components/schemas/SimpleError"
         - type: object
           properties:
             code:
               type: integer
-              enum: [1083]
+              enum: [1004]
+          example:
+            code: 1004
+            message: "Email address is in an incorrect format"
+    EmailAddressesMatch:
+      allOf:
+        - $ref: "#/components/schemas/SimpleError"
+        - type: object
+          properties:
+            code:
+              type: integer
+              enum: [1019]
+          example:
+            code: 1019
+            message: "Email addresses are the same"
+    AccountWithEmailExists:
+      allOf:
+        - $ref: "#/components/schemas/SimpleError"
+        - type: object
+          properties:
+            code:
+              type: integer
+              enum: [1009]
+          example:
+            code: 1009
+            message: "An account with this email address already exists"
+    AccountDoesNotExist:
+      allOf:
+        - $ref: "#/components/schemas/SimpleError"
+        - type: object
+          properties:
+            code:
+              type: integer
+              enum: [1010]
+          example:
+            code: 1010
+            message: "An account with this email address does not exist"
 
   securitySchemes:
     authorise-access-token:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -111,7 +111,8 @@ public enum ErrorResponse {
     NO_USER_PROFILE_FOR_EMAIL(1085, "Email from request does not have a user profile"),
     USER_DOES_NOT_HAVE_ACCOUNT(1086, "Email from request does not have any user credentials"),
     FAILED_TO_RAISE_AUDIT_EVENT(1087, "Failed to raise an audit event"),
-    STORAGE_LAYER_ERROR(1088, "Error retrieving account details");
+    STORAGE_LAYER_ERROR(1088, "Error retrieving account details"),
+    EMAIL_ADDRESS_DENIED(1089, "Email address is denied");
 
     private int code;
 


### PR DESCRIPTION
## What

Updates the update-email OpenAPI documentation and Imposter mock support to match the current implementation and upcoming changes for email blocks.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.