### PR TITLE
AUT-4569: Emit notification metrics

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
@@ -1,5 +1,6 @@
 package uk.gov.di.accountmanagement.entity;
 
+import uk.gov.di.authentication.shared.entity.NotifiableType;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -7,60 +8,76 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.util.EnumMap;
 import java.util.Map;
 
-public enum NotificationType implements TemplateAware {
+public enum NotificationType implements TemplateAware, NotifiableType {
     VERIFY_EMAIL(
             "AM_VERIFY_EMAIL_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "AM_VERIFY_EMAIL_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "AM_VERIFY_EMAIL_TEMPLATE_ID_CY")),
+            false),
     EMAIL_UPDATED(
             "EMAIL_UPDATED_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "EMAIL_UPDATED_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "EMAIL_UPDATED_TEMPLATE_ID_CY")),
+            false),
     DELETE_ACCOUNT(
             "DELETE_ACCOUNT_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "DELETE_ACCOUNT_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "DELETE_ACCOUNT_TEMPLATE_ID_CY")),
+            false),
     PHONE_NUMBER_UPDATED(
             "PHONE_NUMBER_UPDATED_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "PHONE_NUMBER_UPDATED_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "PHONE_NUMBER_UPDATED_TEMPLATE_ID_CY")),
+            false),
     VERIFY_PHONE_NUMBER(
             "AM_VERIFY_PHONE_NUMBER_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "AM_VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "AM_VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY")),
+            true),
     PASSWORD_UPDATED(
             "PASSWORD_UPDATED_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "PASSWORD_UPDATED_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "PASSWORD_UPDATED_TEMPLATE_ID_CY")),
+            false),
     BACKUP_METHOD_ADDED(
             "BACKUP_METHOD_ADDED_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "BACKUP_METHOD_ADDED_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "BACKUP_METHOD_ADDED_TEMPLATE_ID_CY")),
+            false),
     BACKUP_METHOD_REMOVED(
             "BACKUP_METHOD_REMOVED_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "BACKUP_METHOD_REMOVED_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "BACKUP_METHOD_REMOVED_TEMPLATE_ID_CY")),
+            false),
     CHANGED_AUTHENTICATOR_APP(
             "CHANGED_AUTHENTICATOR_APP_TEMPLATE_ID",
-            new EnumMap<>(
-                    Map.of(SupportedLanguage.CY, "CHANGED_AUTHENTICATOR_APP_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "CHANGED_AUTHENTICATOR_APP_TEMPLATE_ID_CY")),
+            false),
     CHANGED_DEFAULT_MFA(
             "CHANGED_DEFAULT_MFA_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "CHANGED_DEFAULT_MFA_TEMPLATE_ID_CY"))),
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "CHANGED_DEFAULT_MFA_TEMPLATE_ID_CY")),
+            false),
     SWITCHED_MFA_METHODS(
             "SWITCHED_MFA_METHODS_TEMPLATE_ID",
-            new EnumMap<>(Map.of(SupportedLanguage.CY, "SWITCHED_MFA_METHODS_TEMPLATE_ID_CY")));
+            new EnumMap<>(Map.of(SupportedLanguage.CY, "SWITCHED_MFA_METHODS_TEMPLATE_ID_CY")),
+            false),
+    ;
 
     private final String templateName;
+    private final boolean isForPhoneNumber;
 
     private EnumMap<SupportedLanguage, String> languageSpecificTemplates =
             new EnumMap<>(SupportedLanguage.class);
 
-    NotificationType(String templateName) {
-        this.templateName = templateName;
-    }
-
     NotificationType(
-            String templateName, EnumMap<SupportedLanguage, String> languageSpecificTemplates) {
-        this(templateName);
+            String templateName,
+            EnumMap<SupportedLanguage, String> languageSpecificTemplates,
+            boolean isForPhoneNumber) {
+        this.templateName = templateName;
         this.languageSpecificTemplates = languageSpecificTemplates;
+        this.isForPhoneNumber = isForPhoneNumber;
     }
 
     @Override
     public String getTemplateId(ConfigurationService configurationService) {
         return configurationService.getNotifyTemplateId(templateName);
+    }
+
+    @Override
+    public boolean isForPhoneNumber() {
+        return isForPhoneNumber;
     }
 
     String getTemplateName(SupportedLanguage language) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -33,6 +34,7 @@ import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.ERROR_SENDI
 import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.ERROR_WHEN_MAPPING_MESSAGE_FROM_QUEUE_TO_A_NOTIFY_REQUEST;
 import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.TEXT_HAS_BEEN_SENT_USING_NOTIFY;
 import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.UNEXPECTED_ERROR_SENDING_NOTIFICATION;
+import static uk.gov.di.authentication.entity.Application.ONE_LOGIN_HOME;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
@@ -51,14 +53,17 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     private final Json objectMapper = SerializationService.getInstance();
     private final ConfigurationService configurationService;
     private final S3Client s3Client;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
 
     public NotificationHandler(
             NotificationService notificationService,
             ConfigurationService configService,
-            S3Client s3Client) {
+            S3Client s3Client,
+            CloudwatchMetricsService cloudwatchMetricsService) {
         this.notificationService = notificationService;
         this.configurationService = configService;
         this.s3Client = s3Client;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public NotificationHandler() {
@@ -80,6 +85,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
         this.notificationService = new NotificationService(client, configurationService);
         this.s3Client =
                 S3Client.builder().region(Region.of(configurationService.getAwsRegion())).build();
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 
     @Override
@@ -226,8 +232,19 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         notificationService.sendEmail(
                                 destination, per, NotificationType.valueOf(type));
                         LOG.info(EMAIL_HAS_BEEN_SENT_USING_NOTIFY, notificationType);
+                        cloudwatchMetricsService.emitMetricForNotification(
+                                notifyRequest.getNotificationType(),
+                                destination,
+                                false,
+                                ONE_LOGIN_HOME);
                     } catch (NotificationClientException e) {
                         LOG.error(ERROR_SENDING_WITH_NOTIFY, e.getMessage());
+                        cloudwatchMetricsService.emitMetricForNotificationError(
+                                notifyRequest.getNotificationType(),
+                                destination,
+                                false,
+                                ONE_LOGIN_HOME,
+                                e);
                     } catch (RuntimeException e) {
                         LOG.error(
                                 UNEXPECTED_ERROR_SENDING_NOTIFICATION,
@@ -250,8 +267,19 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         notificationService.sendText(
                                 destination, per, NotificationType.valueOf(type));
                         LOG.info(TEXT_HAS_BEEN_SENT_USING_NOTIFY, notificationType);
+                        cloudwatchMetricsService.emitMetricForNotification(
+                                notifyRequest.getNotificationType(),
+                                destination,
+                                false,
+                                ONE_LOGIN_HOME);
                     } catch (NotificationClientException e) {
                         LOG.error(ERROR_SENDING_WITH_NOTIFY, e.getMessage());
+                        cloudwatchMetricsService.emitMetricForNotificationError(
+                                notifyRequest.getNotificationType(),
+                                destination,
+                                false,
+                                ONE_LOGIN_HOME,
+                                e);
                     } catch (RuntimeException e) {
                         LOG.error(
                                 UNEXPECTED_ERROR_SENDING_NOTIFICATION,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.entity.NotificationType.BACKUP_METHOD_ADDED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.BACKUP_METHOD_REMOVED;
@@ -56,6 +58,7 @@ import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.TEXT_HAS_BE
 import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.UNEXPECTED_ERROR_SENDING_NOTIFICATION;
 import static uk.gov.di.accountmanagement.lambda.LogMessageTemplates.WRITING_OTP_TO_S_3_BUCKET;
 import static uk.gov.di.accountmanagement.lambda.NotificationHandler.EXCEPTION_THROWN_WHEN_WRITING_TO_S_3_BUCKET;
+import static uk.gov.di.authentication.entity.Application.ONE_LOGIN_HOME;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class NotificationHandlerTest {
@@ -73,6 +76,8 @@ class NotificationHandlerTest {
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final S3Client s3Client = mock(S3Client.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
     private NotificationHandler handler;
 
     @RegisterExtension
@@ -83,7 +88,10 @@ class NotificationHandlerTest {
     void setUp() {
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
-        handler = new NotificationHandler(notificationService, configService, s3Client);
+        when(configService.getEnvironment()).thenReturn("unit-test");
+        handler =
+                new NotificationHandler(
+                        notificationService, configService, s3Client, cloudwatchMetricsService);
     }
 
     @Test
@@ -115,6 +123,8 @@ class NotificationHandlerTest {
                 hasItem(
                         withMessageContaining(
                                 formatMessage(EMAIL_HAS_BEEN_SENT_USING_NOTIFY, VERIFY_EMAIL))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(VERIFY_EMAIL, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -146,6 +156,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         TEXT_HAS_BEEN_SENT_USING_NOTIFY, VERIFY_PHONE_NUMBER))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -178,6 +191,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         TEXT_HAS_BEEN_SENT_USING_NOTIFY, VERIFY_PHONE_NUMBER))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -208,6 +224,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         TEXT_HAS_BEEN_SENT_USING_NOTIFY, VERIFY_PHONE_NUMBER))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -232,6 +251,9 @@ class NotificationHandlerTest {
                 hasItem(
                         withMessageContaining(
                                 formatMessage(EMAIL_HAS_BEEN_SENT_USING_NOTIFY, EMAIL_UPDATED))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        EMAIL_UPDATED, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -257,6 +279,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, PASSWORD_UPDATED))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        PASSWORD_UPDATED, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -282,6 +307,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, PHONE_NUMBER_UPDATED))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        PHONE_NUMBER_UPDATED, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -305,6 +333,9 @@ class NotificationHandlerTest {
                 hasItem(
                         withMessageContaining(
                                 formatMessage(EMAIL_HAS_BEEN_SENT_USING_NOTIFY, DELETE_ACCOUNT))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        DELETE_ACCOUNT, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -327,6 +358,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, BACKUP_METHOD_ADDED))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        BACKUP_METHOD_ADDED, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -349,6 +383,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, BACKUP_METHOD_REMOVED))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        BACKUP_METHOD_REMOVED, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -373,6 +410,9 @@ class NotificationHandlerTest {
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY,
                                         CHANGED_AUTHENTICATOR_APP))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        CHANGED_AUTHENTICATOR_APP, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -395,6 +435,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, CHANGED_DEFAULT_MFA))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        CHANGED_DEFAULT_MFA, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -417,6 +460,9 @@ class NotificationHandlerTest {
                         withMessageContaining(
                                 formatMessage(
                                         EMAIL_HAS_BEEN_SENT_USING_NOTIFY, SWITCHED_MFA_METHODS))));
+        verify(cloudwatchMetricsService)
+                .emitMetricForNotification(
+                        SWITCHED_MFA_METHODS, TEST_EMAIL_ADDRESS, false, ONE_LOGIN_HOME);
     }
 
     @Test
@@ -445,6 +491,7 @@ class NotificationHandlerTest {
                                 formatMessage(
                                         NOTIFY_TEST_DESTINATION_USED_WRITING_TO_S3_BUCKET,
                                         VERIFY_PHONE_NUMBER))));
+        verifyNoInteractions(cloudwatchMetricsService);
     }
 
     @Test
@@ -473,6 +520,7 @@ class NotificationHandlerTest {
                                 formatMessage(
                                         NOT_WRITING_TO_BUCKET_AS_NOT_OTP_NOTIFICATION,
                                         EMAIL_UPDATED))));
+        verifyNoInteractions(cloudwatchMetricsService);
     }
 
     @Test
@@ -505,6 +553,7 @@ class NotificationHandlerTest {
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining(formatMessage(WRITING_OTP_TO_S_3_BUCKET, "654321"))));
+        verifyNoInteractions(cloudwatchMetricsService);
     }
 
     @Test
@@ -544,6 +593,7 @@ class NotificationHandlerTest {
                                         EXCEPTION_THROWN_WHEN_WRITING_TO_S_3_BUCKET,
                                         "s3 failed",
                                         s3failException))));
+        verifyNoInteractions(cloudwatchMetricsService);
     }
 
     @Test
@@ -575,13 +625,13 @@ class NotificationHandlerTest {
     }
 
     private static Stream<Arguments> notificationServiceExceptionProvider() {
-        String messageWhenNotifyClientExcpetion =
+        String messageWhenNotifyClientException =
                 formatMessage(
                         ERROR_SENDING_WITH_NOTIFY, TEST_NOTIFICATION_CLIENT_EXCEPTION_MESSAGE);
         return Stream.of(
                 Arguments.of(
                         new NotificationClientException(TEST_NOTIFICATION_CLIENT_EXCEPTION_MESSAGE),
-                        messageWhenNotifyClientExcpetion,
+                        messageWhenNotifyClientException,
                         VERIFY_EMAIL),
                 Arguments.of(
                         new RuntimeException(UNEXPECTED_RUNTIME_EXCEPTION_MESSAGE),
@@ -592,7 +642,7 @@ class NotificationHandlerTest {
                         VERIFY_EMAIL),
                 Arguments.of(
                         new NotificationClientException(TEST_NOTIFICATION_CLIENT_EXCEPTION_MESSAGE),
-                        messageWhenNotifyClientExcpetion,
+                        messageWhenNotifyClientException,
                         VERIFY_PHONE_NUMBER),
                 Arguments.of(
                         new RuntimeException(UNEXPECTED_RUNTIME_EXCEPTION_MESSAGE),
@@ -620,6 +670,16 @@ class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         assertThat(logging.events(), hasItem(withMessageContaining(expectedMessage)));
+
+        if (exception instanceof NotificationClientException) {
+            verify(cloudwatchMetricsService)
+                    .emitMetricForNotificationError(
+                            type,
+                            TEST_PHONE_NUMBER,
+                            false,
+                            ONE_LOGIN_HOME,
+                            (NotificationClientException) exception);
+        }
     }
 
     private SQSEvent generateSQSEvent(String messageBody) {

--- a/shared/src/main/java/uk/gov/di/authentication/entity/Application.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/Application.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.entity;
+
+public enum Application {
+    AUTHENTICATION("Authentication"),
+    ONE_LOGIN_HOME("OneLoginHome");
+
+    private final String value;
+
+    Application(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -13,7 +13,11 @@ public enum CloudwatchMetricDimensions {
     FAILURE_REASON("FailureReason"),
     IPV_RESPONSE("IpvResponse"),
     MFA_METHOD_TYPE("MfaMethodType"),
-    MFA_METHOD_PRIORITY_IDENTIFIER("MfaMethodPriorityIdentifier");
+    MFA_METHOD_PRIORITY_IDENTIFIER("MfaMethodPriorityIdentifier"),
+    APPLICATION("Application"),
+    NOTIFICATION_TYPE("NotificationType"),
+    COUNTRY("Country"),
+    NOTIFICATION_HTTP_ERROR("NotificationHttpError");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -21,7 +21,12 @@ public enum CloudwatchMetrics {
             "AccessTokenServiceConsistentReadQueryAttemptSuccess"),
     USER_SUBMITTED_CREDENTIAL("UserSubmittedCredential"),
     MFA_RESET_IPV_RESPONSE("MfaResetIpvResponse"),
-    MFA_RESET_AUTHORISATION_ERROR("ReverifyAuthorisationError");
+    MFA_RESET_AUTHORISATION_ERROR("ReverifyAuthorisationError"),
+    SMS_NOTIFICATION_SENT("SmsNotificationSent"),
+    EMAIL_NOTIFICATION_SENT("EmailNotificationSent"),
+    SMS_NOTIFICATION_ERROR("SmsNotificationError"),
+    EMAIL_NOTIFICATION_ERROR("EmailNotificationError");
+
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifiableType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifiableType.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.shared.entity;
+
+public interface NotifiableType {
+    public boolean isForPhoneNumber();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -7,7 +7,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.util.HashMap;
 import java.util.Map;
 
-public enum NotificationType implements TemplateAware {
+public enum NotificationType implements TemplateAware, NotifiableType {
     VERIFY_EMAIL(
             "VERIFY_EMAIL_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "VERIFY_EMAIL_TEMPLATE_ID_CY"),
@@ -111,6 +111,7 @@ public enum NotificationType implements TemplateAware {
         return isEmail;
     }
 
+    @Override
     public boolean isForPhoneNumber() {
         return isForPhoneNumber;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -5,17 +5,23 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import uk.gov.di.authentication.entity.Application;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.NotifiableType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.service.notify.NotificationClientException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.valueOf;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.APPLICATION;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.COUNTRY;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.IPV_RESPONSE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.IS_TEST;
@@ -23,15 +29,22 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_PRIORITY_IDENTIFIER;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_REQUIRED;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NOTIFICATION_HTTP_ERROR;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.REQUESTED_LEVEL_OF_CONFIDENCE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_CHECK_DURATION;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_NOTIFICATION_ERROR;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_NOTIFICATION_SENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_AUTHORISATION_ERROR;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_HANDOFF;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_IPV_RESPONSE;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SMS_NOTIFICATION_ERROR;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SMS_NOTIFICATION_SENT;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.authentication.shared.helpers.PhoneNumberHelper.maybeGetCountry;
 
 public class CloudwatchMetricsService {
 
@@ -237,5 +250,64 @@ public class CloudwatchMetricsService {
         dimensions.forEach(dimensionSet::addDimension);
 
         return dimensionSet;
+    }
+
+    public void emitMetricForNotificationError(
+            NotifiableType notificationType,
+            String destination,
+            Boolean isTestDestination,
+            Application application,
+            NotificationClientException notificationClientException) {
+        String metricName;
+        var dimensions =
+                getNotificationBaseMetricDimensions(
+                        notificationType, isTestDestination, application);
+
+        if (notificationType.isForPhoneNumber()) {
+            dimensions.put(COUNTRY.getValue(), maybeGetCountry(destination).orElse("INVALID"));
+            metricName = SMS_NOTIFICATION_ERROR.getValue();
+        } else {
+            metricName = EMAIL_NOTIFICATION_ERROR.getValue();
+        }
+        if (notificationClientException != null) {
+            dimensions.put(
+                    NOTIFICATION_HTTP_ERROR.getValue(),
+                    Integer.toString(notificationClientException.getHttpResult()));
+        }
+        incrementCounter(metricName, dimensions);
+    }
+
+    public void emitMetricForNotification(
+            NotifiableType notificationType,
+            String destination,
+            Boolean isTestDestination,
+            Application application) {
+        String metricName;
+        var dimensions =
+                getNotificationBaseMetricDimensions(
+                        notificationType, isTestDestination, application);
+
+        if (notificationType.isForPhoneNumber()) {
+            dimensions.put(COUNTRY.getValue(), maybeGetCountry(destination).orElse("INVALID"));
+            metricName = SMS_NOTIFICATION_SENT.getValue();
+
+        } else {
+            metricName = EMAIL_NOTIFICATION_SENT.getValue();
+        }
+        incrementCounter(metricName, dimensions);
+    }
+
+    private HashMap<String, String> getNotificationBaseMetricDimensions(
+            NotifiableType notificationType, Boolean isTestDestination, Application application) {
+        return new HashMap<>(
+                Map.of(
+                        ENVIRONMENT.getValue(),
+                        configurationService.getEnvironment(),
+                        APPLICATION.getValue(),
+                        application.getValue(),
+                        NOTIFICATION_TYPE.getValue(),
+                        notificationType.toString(),
+                        IS_TEST.getValue(),
+                        isTestDestination.toString()));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -9,8 +9,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import uk.gov.di.authentication.entity.Application;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Collections;
 import java.util.List;
@@ -136,6 +139,123 @@ class CloudwatchMetricsServiceTest {
                             "BACKUP");
 
             verify(spyService).putEmbeddedValue("MfaMethodOperationCount", 1, expectedDimensions);
+        }
+    }
+
+    @Nested
+    class EmitMetricForNotification {
+        @Test
+        void shouldEmitSmsNotificationSentMetricWithCorrectDimensions() {
+            var spyService =
+                    Mockito.spy(new CloudwatchMetricsService(configurationWithEnvironment("test")));
+
+            spyService.emitMetricForNotification(
+                    NotificationType.VERIFY_PHONE_NUMBER,
+                    "+447700900123",
+                    false,
+                    Application.AUTHENTICATION);
+
+            var expectedDimensions =
+                    Map.of(
+                            "Environment", "test",
+                            "Application", "Authentication",
+                            "NotificationType", "VERIFY_PHONE_NUMBER",
+                            "IsTest", "false",
+                            "Country", "44");
+
+            verify(spyService).incrementCounter("SmsNotificationSent", expectedDimensions);
+        }
+
+        @Test
+        void shouldEmitEmailNotificationSentMetricWithCorrectDimensions() {
+            var spyService =
+                    Mockito.spy(new CloudwatchMetricsService(configurationWithEnvironment("test")));
+
+            spyService.emitMetricForNotification(
+                    NotificationType.VERIFY_EMAIL,
+                    "test@example.com",
+                    true,
+                    Application.ONE_LOGIN_HOME);
+
+            var expectedDimensions =
+                    Map.of(
+                            "Environment", "test",
+                            "Application", "OneLoginHome",
+                            "NotificationType", "VERIFY_EMAIL",
+                            "IsTest", "true");
+
+            verify(spyService).incrementCounter("EmailNotificationSent", expectedDimensions);
+        }
+
+        @Test
+        void shouldEmitSmsNotificationErrorMetricWithHttpError() {
+            var spyService =
+                    Mockito.spy(new CloudwatchMetricsService(configurationWithEnvironment("test")));
+            var notificationException = new NotificationClientException("Error");
+
+            spyService.emitMetricForNotificationError(
+                    NotificationType.MFA_SMS,
+                    "+447700900123",
+                    false,
+                    Application.AUTHENTICATION,
+                    notificationException);
+
+            var expectedDimensions =
+                    Map.of(
+                            "Environment", "test",
+                            "Application", "Authentication",
+                            "NotificationType", "MFA_SMS",
+                            "IsTest", "false",
+                            "Country", "44",
+                            "NotificationHttpError", "400");
+
+            verify(spyService).incrementCounter("SmsNotificationError", expectedDimensions);
+        }
+
+        @Test
+        void shouldEmitEmailNotificationErrorMetricWithHttpError() {
+            var spyService =
+                    Mockito.spy(new CloudwatchMetricsService(configurationWithEnvironment("test")));
+            var notificationException = new NotificationClientException("Error");
+
+            spyService.emitMetricForNotificationError(
+                    NotificationType.RESET_PASSWORD_WITH_CODE,
+                    "test@example.com",
+                    false,
+                    Application.AUTHENTICATION,
+                    notificationException);
+
+            var expectedDimensions =
+                    Map.of(
+                            "Environment", "test",
+                            "Application", "Authentication",
+                            "NotificationType", "RESET_PASSWORD_WITH_CODE",
+                            "IsTest", "false",
+                            "NotificationHttpError", "400");
+
+            verify(spyService).incrementCounter("EmailNotificationError", expectedDimensions);
+        }
+
+        @Test
+        void shouldHandleInvalidPhoneNumberCountry() {
+            var spyService =
+                    Mockito.spy(new CloudwatchMetricsService(configurationWithEnvironment("test")));
+
+            spyService.emitMetricForNotification(
+                    NotificationType.VERIFY_PHONE_NUMBER,
+                    "invalid-phone",
+                    false,
+                    Application.AUTHENTICATION);
+
+            var expectedDimensions =
+                    Map.of(
+                            "Environment", "test",
+                            "Application", "Authentication",
+                            "NotificationType", "VERIFY_PHONE_NUMBER",
+                            "IsTest", "false",
+                            "Country", "INVALID");
+
+            verify(spyService).incrementCounter("SmsNotificationSent", expectedDimensions);
         }
     }
 


### PR DESCRIPTION
## What

Adds two new methods which collectively emit four new metrics when either emails or sms are sent via Notify, and also when client errors happen when sending.

emitMetricForNotification

- SmsNotificationSent
- EmailNotificationSent

emitMetricForNotificationError

- SmsNotificationError
- EmailNotificationError

At the moment Notify metrics are only created on the back of delivery receipts received from Notify (and the networks).  As there is no guarantee that we’ll get a delivery receipt the metrics are not a true reflection of the number of messages actually sent.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a test environment, run some journeys and check that the metrics have been emitted in Cloudwatch.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->



## Related PRs


