### PR TITLE
AUT-4580: Implement `StructuredAudit*` for typed events

### DIFF
--- a/audit-events/build.gradle
+++ b/audit-events/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id "java-library"
+    id "jacoco"
+}
+
+group "uk.gov.di.authentication.auditevents"
+version "unspecified"
+
+dependencies {
+    implementation project(":shared")
+    implementation configurations.gson
+
+    compileOnly configurations.lambda
+    runtimeOnly configurations.logging_runtime
+
+    testImplementation project(":shared-test")
+    testImplementation configurations.tests
+    testImplementation configurations.sqs
+    testImplementation configurations.logging_runtime
+    testRuntimeOnly configurations.test_runtime
+}
+
+test {
+    useJUnitPlatform()
+    environment "TRACING_ENABLED", "false"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthEmailFraudCheckBypassed.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthEmailFraudCheckBypassed.java
@@ -1,0 +1,57 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record AuthEmailFraudCheckBypassed(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        User user,
+        Extensions extensions)
+        implements StructuredAuditEvent {
+
+    private static final String EVENT_NAME = "AUTH_EMAIL_FRAUD_CHECK_BYPASSED";
+
+    public AuthEmailFraudCheckBypassed {
+        Objects.requireNonNull(eventName);
+        Objects.requireNonNull(componentId);
+        Objects.requireNonNull(user);
+        Objects.requireNonNull(extensions);
+    }
+
+    public static AuthEmailFraudCheckBypassed create(
+            String clientId, User user, Extensions extensions) {
+        var now = Instant.now();
+        return new AuthEmailFraudCheckBypassed(
+                EVENT_NAME,
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                clientId,
+                ComponentId.AUTH.getValue(),
+                user,
+                extensions);
+    }
+
+    public record User(
+            String userId,
+            String email,
+            String ipAddress,
+            String persistentSessionId,
+            String govukSigninJourneyId) {
+        public User {
+            Objects.requireNonNull(email);
+            Objects.requireNonNull(ipAddress);
+            Objects.requireNonNull(persistentSessionId);
+            Objects.requireNonNull(govukSigninJourneyId);
+        }
+    }
+
+    public record Extensions(String journeyType, long assessmentCheckedAtTimestamp) {
+        public Extensions {
+            Objects.requireNonNull(journeyType);
+        }
+    }
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/ComponentId.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/ComponentId.java
@@ -1,0 +1,15 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+public enum ComponentId {
+    AUTH("AUTH");
+
+    private final String value;
+
+    ComponentId(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/StructuredAuditEvent.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/StructuredAuditEvent.java
@@ -1,0 +1,13 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+public interface StructuredAuditEvent {
+    String eventName();
+
+    long timestamp();
+
+    long eventTimestampMs();
+
+    String clientId();
+
+    String componentId();
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/services/StructuredAuditService.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/services/StructuredAuditService.java
@@ -1,0 +1,50 @@
+package uk.gov.di.authentication.auditevents.services;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+public class StructuredAuditService {
+    private static final Logger LOG = LogManager.getLogger(StructuredAuditService.class);
+
+    public static final String UNKNOWN = "";
+
+    private final AwsSqsClient awsSqsClient;
+    private final Gson gson;
+
+    public StructuredAuditService(ConfigurationService configurationService) {
+        this.awsSqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getTxmaAuditQueueUrl(),
+                        configurationService.getLocalstackEndpointUri());
+        this.gson = createGson();
+    }
+
+    public StructuredAuditService(AwsSqsClient awsSqsClient) {
+        this.awsSqsClient = awsSqsClient;
+        this.gson = createGson();
+    }
+
+    private static Gson createGson() {
+        return new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+    }
+
+    public void submitAuditEvent(StructuredAuditEvent auditEvent) {
+        LOG.info("Sending audit event to SQS: {}", auditEvent.eventName());
+
+        String serializedEvent = serialize(auditEvent);
+        awsSqsClient.send(serializedEvent);
+    }
+
+    private String serialize(StructuredAuditEvent auditEvent) {
+        return gson.toJson(auditEvent);
+    }
+}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/services/StructuredAuditServiceTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/services/StructuredAuditServiceTest.java
@@ -1,0 +1,168 @@
+package uk.gov.di.authentication.auditevents.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StructuredAuditServiceTest {
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(StructuredAuditService.class);
+
+    @Mock private ConfigurationService configurationService;
+
+    @Mock private AwsSqsClient awsSqsClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
+        when(configurationService.getTxmaAuditQueueUrl())
+                .thenReturn("https://queue.amazonaws.com/123456789012/audit-queue");
+        when(configurationService.getLocalstackEndpointUri()).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    class SubmitAuditEvent {
+
+        @Test
+        void shouldSubmitAuditEventAsJsonToSqs() {
+            TestAuditEvent auditEvent =
+                    new TestAuditEvent(
+                            "TEST_EVENT",
+                            1234567890L,
+                            1234567890000L,
+                            CommonTestVariables.CLIENT_ID,
+                            ComponentId.AUTH.getValue(),
+                            new TestAuditEvent.TestUser(
+                                    "user-123",
+                                    CommonTestVariables.EMAIL,
+                                    CommonTestVariables.IP_ADDRESS,
+                                    CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                    CommonTestVariables.CLIENT_SESSION_ID));
+
+            String expectedJson =
+                    """
+                    {
+                      "event_name": "TEST_EVENT",
+                      "timestamp": 1234567890,
+                      "event_timestamp_ms": 1234567890000,
+                      "client_id": "%s",
+                      "component_id": "%s",
+                      "user": {
+                        "user_id": "user-123",
+                        "email": "%s",
+                        "ip_address": "%s",
+                        "persistent_session_id": "%s",
+                        "govuk_signin_journey_id": "%s"
+                      }
+                    }"""
+                            .formatted(
+                                    CommonTestVariables.CLIENT_ID,
+                                    ComponentId.AUTH.getValue(),
+                                    CommonTestVariables.EMAIL,
+                                    CommonTestVariables.IP_ADDRESS,
+                                    CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                    CommonTestVariables.CLIENT_SESSION_ID)
+                            .replaceAll("\\s+", "");
+
+            StructuredAuditService service = new StructuredAuditService(awsSqsClient);
+
+            service.submitAuditEvent(auditEvent);
+
+            verify(awsSqsClient).send(expectedJson);
+        }
+
+        @Test
+        void shouldLogEventNameWhenSubmittingAuditEvent() {
+            TestAuditEvent auditEvent =
+                    new TestAuditEvent(
+                            "TEST_EVENT",
+                            1234567890L,
+                            1234567890000L,
+                            CommonTestVariables.CLIENT_ID,
+                            ComponentId.AUTH.getValue(),
+                            new TestAuditEvent.TestUser(
+                                    "user-123",
+                                    CommonTestVariables.EMAIL,
+                                    CommonTestVariables.IP_ADDRESS,
+                                    CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                    CommonTestVariables.CLIENT_SESSION_ID));
+
+            StructuredAuditService service = new StructuredAuditService(awsSqsClient);
+
+            service.submitAuditEvent(auditEvent);
+
+            assertEquals(1, logging.events().size());
+            assertTrue(
+                    logging.events()
+                            .get(0)
+                            .getMessage()
+                            .getFormattedMessage()
+                            .contains("Sending audit event to SQS: TEST_EVENT"));
+        }
+    }
+
+    @Nested
+    class Constants {
+
+        @Test
+        void shouldHaveUnknownConstant() {
+            assertEquals("", StructuredAuditService.UNKNOWN);
+        }
+    }
+
+    @Nested
+    class Construction {
+
+        @Test
+        void shouldCreateServiceWithConfigurationService() {
+            StructuredAuditService service = new StructuredAuditService(configurationService);
+
+            assertNotNull(service);
+        }
+
+        @Test
+        void shouldCreateServiceWithAwsSqsClient() {
+            StructuredAuditService service = new StructuredAuditService(awsSqsClient);
+
+            assertNotNull(service);
+        }
+    }
+
+    private record TestAuditEvent(
+            String eventName,
+            long timestamp,
+            long eventTimestampMs,
+            String clientId,
+            String componentId,
+            TestUser user)
+            implements StructuredAuditEvent {
+
+        private record TestUser(
+                String userId,
+                String email,
+                String ipAddress,
+                String persistentSessionId,
+                String govukSigninJourneyId) {}
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: di-authentication-local
 
 # Services for running an authentication stack locally

--- a/docs/adr/0003-structured-audit-service.md
+++ b/docs/adr/0003-structured-audit-service.md
@@ -1,0 +1,85 @@
+# StructuredAuditService for typed audit events
+
+## Decision
+
+We will implement a `StructuredAuditService` that provides type-safe audit event submission using strongly-typed event classes that implement a `StructuredAuditEvent` interface. This service will serialize events to JSON using snake_case field naming and submit them to the TxMA audit queue via SQS.
+
+## Context
+
+The authentication service needs to emit audit events for security monitoring and compliance purposes. Previously, audit events were created using unstructured approaches that could lead to inconsistencies in event format and missing required fields.
+
+We identified the need for a more robust audit system that:
+
+- Ensures consistent event structure across all audit events
+- Provides compile-time safety for event creation
+- Standardizes field naming conventions
+- Maintains compatibility with existing TxMA infrastructure
+- Reduces the likelihood of malformed audit events
+
+## Detail
+
+This approach introduces:
+
+**StructuredAuditEvent Interface**: A common interface that all audit events must implement, defining required fields:
+
+- `eventName()`: The name of the audit event
+- `timestamp()`: Unix timestamp in seconds
+- `eventTimestampMs()`: Unix timestamp in milliseconds
+- `clientId()`: The client identifier (nullable)
+- `componentId()`: The component generating the event
+
+**Concrete Event Classes**: Strongly-typed record classes for each audit event type (e.g., `AuthEmailFraudCheckBypassed`) that:
+
+- Implement the `StructuredAuditEvent` interface
+- Use Java records for immutability and reduced boilerplate
+- Include nested record classes for complex data structures (User, Extensions)
+- Provide static factory methods for easy creation
+- Enforce non-null constraints on required fields
+
+**StructuredAuditService**: A service class that:
+
+- Accepts any `StructuredAuditEvent` implementation
+- Serializes events to JSON
+- Submits serialized events to the TxMA audit queue
+
+**Integration Pattern**: Services inject `StructuredAuditService` and create specific event instances:
+
+```java
+var auditEvent = AuthEmailFraudCheckBypassed.create(
+    clientId,
+    new AuthEmailFraudCheckBypassed.User(userId, email, ipAddress, sessionId, journeyId),
+    new AuthEmailFraudCheckBypassed.Extensions(journeyType, timestamp)
+);
+auditService.submitAuditEvent(auditEvent);
+```
+
+## Consequences
+
+### Positive
+
+- **Type Safety**: Compile-time verification of event structure prevents runtime errors from malformed events
+- **Consistency**: All audit events follow the same interface contract, ensuring consistent field presence
+- **Maintainability**: Adding new audit events requires implementing the interface, making the contract explicit
+- **Documentation**: Event structure is self-documenting through the type system
+- **Testability**: Strongly-typed events are easier to test and mock
+- **Field Naming**: Automatic snake_case conversion ensures consistent naming convention for downstream systems, which can be overridden on a case-by-case basis
+- **Immutability**: Using records ensures audit events cannot be modified after creation
+
+### Negative
+
+- **Code Volume**: Each audit event type requires a dedicated class, increasing the codebase size
+- **Migration Effort**: Existing unstructured audit events need to be migrated to the new system
+- **Dependency**: Services now depend on specific audit event classes in addition to the service
+
+### Neutral
+
+- **Performance**: Minimal impact as JSON serialization overhead is similar to previous approaches
+- **Compatibility**: Events are still submitted to the same TxMA infrastructure via SQS
+- **Configuration**: Service configuration remains the same (queue URL, region, etc.)
+
+## Implementation Notes
+
+- The `StructuredAuditService.UNKNOWN` constant provides a standard placeholder for unavailable field values
+- Event timestamps are automatically generated using `Instant.now()` in factory methods
+- The service supports both direct `AwsSqsClient` injection for testing and `ConfigurationService`-based initialization
+- Component IDs are standardized using a `ComponentId` enum (e.g., `ComponentId.AUTH.getValue()`)

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     implementation project(path: ':shared')
     implementation project(':user-permissions')
+    implementation project(':audit-events')
 
     compileOnly configurations.lambda,
             configurations.sqs,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -29,6 +29,9 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ISS;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
@@ -134,10 +137,12 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_EMAIL_FRAUD_CHECK_BYPASSED,
                 auditContext,
-                AuditService.MetadataPair.pair("journey_type", JourneyType.REGISTRATION.getValue()),
                 AuditService.MetadataPair.pair(
-                        "assessment_checked_at_timestamp",
+                        AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.REGISTRATION.getValue()),
+                AuditService.MetadataPair.pair(
+                        AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP,
                         NowHelper.toUnixTimestamp(NowHelper.now())),
-                AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
+                AuditService.MetadataPair.pair(
+                        AUDIT_EVENT_EXTENSIONS_ISS, AuditService.COMPONENT_ID));
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.audit.AuditContext;
-import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.auditevents.entity.AuthEmailFraudCheckBypassed;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
@@ -15,10 +15,8 @@ import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -26,20 +24,13 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.ArrayList;
-import java.util.Optional;
-
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ISS;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailFraudBlockRequest> {
 
     private static final Logger LOG = LogManager.getLogger(CheckEmailFraudBlockHandler.class);
 
-    private final AuditService auditService;
+    private final StructuredAuditService auditService;
     private final DynamoEmailCheckResultService dynamoEmailCheckResultService;
 
     protected CheckEmailFraudBlockHandler(
@@ -47,7 +38,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
             ClientService clientService,
             AuthenticationService authenticationService,
             DynamoEmailCheckResultService dynamoEmailCheckResultService,
-            AuditService auditService,
+            StructuredAuditService auditService,
             AuthSessionService authSessionService) {
         super(
                 CheckEmailFraudBlockRequest.class,
@@ -63,7 +54,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
         super(CheckEmailFraudBlockRequest.class, configurationService);
         this.dynamoEmailCheckResultService =
                 new DynamoEmailCheckResultService(configurationService);
-        this.auditService = new AuditService(configurationService);
+        this.auditService = new StructuredAuditService(configurationService);
     }
 
     public CheckEmailFraudBlockHandler() {
@@ -116,33 +107,21 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
             APIGatewayProxyRequestEvent input,
             UserContext userContext,
             CheckEmailFraudBlockRequest request) {
-
-        var sessionId =
-                RequestHeaderHelper.getHeaderValueOrElse(
-                        input.getHeaders(), SESSION_ID_HEADER, AuditService.UNKNOWN);
-
-        var auditContext =
-                new AuditContext(
+        var newAuditEvent =
+                AuthEmailFraudCheckBypassed.create(
                         userContext.getAuthSession().getClientId(),
-                        ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                        sessionId,
-                        AuditService.UNKNOWN,
-                        request.getEmail(),
-                        IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()),
-                        new ArrayList<>());
+                        new AuthEmailFraudCheckBypassed.User(
+                                StructuredAuditService.UNKNOWN,
+                                request.getEmail(),
+                                IpAddressHelper.extractIpAddress(input),
+                                PersistentIdHelper.extractPersistentIdFromHeaders(
+                                        input.getHeaders()),
+                                ClientSessionIdHelper.extractSessionIdFromHeaders(
+                                        input.getHeaders())),
+                        new AuthEmailFraudCheckBypassed.Extensions(
+                                JourneyType.REGISTRATION.getValue(),
+                                NowHelper.toUnixTimestamp(NowHelper.now())));
 
-        auditService.submitAuditEvent(
-                FrontendAuditableEvent.AUTH_EMAIL_FRAUD_CHECK_BYPASSED,
-                auditContext,
-                AuditService.MetadataPair.pair(
-                        AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.REGISTRATION.getValue()),
-                AuditService.MetadataPair.pair(
-                        AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP,
-                        NowHelper.toUnixTimestamp(NowHelper.now())),
-                AuditService.MetadataPair.pair(
-                        AUDIT_EVENT_EXTENSIONS_ISS, AuditService.COMPONENT_ID));
+        auditService.submitAuditEvent(newAuditEvent);
     }
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(":orchestration-shared"), noXray
     implementation project(":shared-test"), noXray
     implementation project(":orchestration-shared-test"), noXray
+    implementation project(":audit-events"), noXray
     implementation project(":oidc-api"), noXray
     implementation project(":frontend-api"), noXray
     implementation project(":auth-external-api"), noXray

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -2,35 +2,46 @@ package uk.gov.di.authentication.api;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_EMAIL_FRAUD_CHECK_BYPASSED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ISS;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
-    public static final String CLIENT_SESSION_ID = "some-client-session-id";
-    private static final String INTERNAl_SECTOR_URI = "https://test.account.gov.uk";
-    private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
     private static final Subject SUBJECT = new Subject();
+
+    private static final String EXTENSIONS_JOURNEY_TYPE =
+            "extensions." + AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+    private static final String EXTENSIONS_ISS = "extensions." + AUDIT_EVENT_EXTENSIONS_ISS;
 
     DynamoEmailCheckResultService dynamoEmailCheckResultService =
             new DynamoEmailCheckResultService(TEST_CONFIGURATION_SERVICE);
@@ -44,30 +55,138 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
 
     @BeforeEach
     void setup() {
-        handler = new CheckEmailFraudBlockHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        handler =
+                new CheckEmailFraudBlockHandler(EMAIL_CHECK_AND_TXMA_ENABLED_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 
-    @Test
-    void shouldReturnCorrectStatusBasedOnDbResult() {
-        userStore.signUp(EMAIL, "password-1", SUBJECT);
-        var sessionId = IdGenerator.generate();
-        authSessionExtension.addSession(sessionId);
-        dynamoEmailCheckResultService.saveEmailCheckResult(
-                EMAIL, EmailCheckResultStatus.ALLOW, unixTimePlusNDays(), "test-reference");
-        Map<String, String> headers = new HashMap<>();
+    @Nested
+    class UserSubmitsEmailForFraudCheck {
+
+        @Test
+        void whenNoFraudCheckResultExists() {
+            userStore.signUp(CommonTestVariables.EMAIL, "password-1", SUBJECT);
+            var sessionId = IdGenerator.generate();
+            authSessionExtension.addSession(sessionId);
+
+            Map<String, String> headers = createHeaders(sessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(format("{ \"email\": \"%s\"}", CommonTestVariables.EMAIL)),
+                            headers,
+                            Map.of());
+
+            assertThat(response, hasStatus(200));
+            assertThat(
+                    response,
+                    hasJsonBody(
+                            new CheckEmailFraudBlockResponse(
+                                    CommonTestVariables.EMAIL,
+                                    EmailCheckResultStatus.PENDING.getValue())));
+
+            List<AuditableEvent> expectedEvents = List.of(AUTH_EMAIL_FRAUD_CHECK_BYPASSED);
+            Map<String, Map<String, String>> eventExpectations = new HashMap<>();
+
+            Map<String, String> fraudCheckBypassedAttributes = new HashMap<>();
+            fraudCheckBypassedAttributes.put(
+                    EXTENSIONS_JOURNEY_TYPE, JourneyType.REGISTRATION.getValue());
+            fraudCheckBypassedAttributes.put(EXTENSIONS_ISS, "AUTH");
+            eventExpectations.put(
+                    AUTH_EMAIL_FRAUD_CHECK_BYPASSED.name(), fraudCheckBypassedAttributes);
+
+            verifyAuditEvents(expectedEvents, eventExpectations);
+        }
+
+        @Test
+        void whenEmailIsAllowed() {
+            userStore.signUp(CommonTestVariables.EMAIL, "password-1", SUBJECT);
+            var sessionId = IdGenerator.generate();
+            authSessionExtension.addSession(sessionId);
+
+            dynamoEmailCheckResultService.saveEmailCheckResult(
+                    CommonTestVariables.EMAIL,
+                    EmailCheckResultStatus.ALLOW,
+                    unixTimePlusNDays(),
+                    "test-reference");
+
+            Map<String, String> headers = createHeaders(sessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(format("{ \"email\": \"%s\"}", CommonTestVariables.EMAIL)),
+                            headers,
+                            Map.of());
+
+            assertThat(response, hasStatus(200));
+            assertThat(
+                    response,
+                    hasJsonBody(
+                            new CheckEmailFraudBlockResponse(
+                                    CommonTestVariables.EMAIL,
+                                    EmailCheckResultStatus.ALLOW.getValue())));
+
+            assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        }
+
+        @Test
+        void whenEmailIsDenied() {
+            userStore.signUp(CommonTestVariables.EMAIL, "password-1", SUBJECT);
+            var sessionId = IdGenerator.generate();
+            authSessionExtension.addSession(sessionId);
+
+            dynamoEmailCheckResultService.saveEmailCheckResult(
+                    CommonTestVariables.EMAIL,
+                    EmailCheckResultStatus.DENY,
+                    unixTimePlusNDays(),
+                    "test-reference");
+
+            Map<String, String> headers = createHeaders(sessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(format("{ \"email\": \"%s\"}", CommonTestVariables.EMAIL)),
+                            headers,
+                            Map.of());
+
+            assertThat(response, hasStatus(200));
+            assertThat(
+                    response,
+                    hasJsonBody(
+                            new CheckEmailFraudBlockResponse(
+                                    CommonTestVariables.EMAIL,
+                                    EmailCheckResultStatus.DENY.getValue())));
+
+            assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        }
+    }
+
+    private Map<String, String> createHeaders(String sessionId) {
+        Map<String, String> headers = new HashMap<>(CommonTestVariables.VALID_HEADERS);
         headers.put("Session-Id", sessionId);
         headers.put("X-API-Key", FRONTEND_API_KEY);
-        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
-        var response =
-                makeRequest(Optional.of(format("{ \"email\": \"%s\"}", EMAIL)), headers, Map.of());
+        headers.put("Client-Session-Id", CommonTestVariables.CLIENT_SESSION_ID);
+        return headers;
+    }
 
-        assertThat(response, hasStatus(200));
-        assertThat(
-                response,
-                hasJsonBody(
-                        new CheckEmailFraudBlockResponse(
-                                EMAIL, EmailCheckResultStatus.ALLOW.getValue())));
+    private void verifyAuditEvents(
+            List<AuditableEvent> expectedEvents,
+            Map<String, Map<String, String>> eventExpectations) {
+        List<String> receivedEvents = assertTxmaAuditEventsReceived(txmaAuditQueue, expectedEvents);
+
+        for (Map.Entry<String, Map<String, String>> eventEntry : eventExpectations.entrySet()) {
+            String eventName = eventEntry.getKey();
+            Map<String, String> attributes = eventEntry.getValue();
+
+            AuditEventExpectation expectation = new AuditEventExpectation(eventName);
+
+            for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
+                expectation.withAttribute(attributeEntry.getKey(), attributeEntry.getValue());
+            }
+
+            expectation.verify(receivedEvents);
+            assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        }
     }
 
     private long unixTimePlusNDays() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/StructuredAuditServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/StructuredAuditServiceIntegrationTest.java
@@ -1,0 +1,174 @@
+package uk.gov.di.authentication.services;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
+
+import java.util.List;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StructuredAuditServiceIntegrationTest {
+
+    @RegisterExtension
+    protected static final SqsQueueExtension sqsQueue = new SqsQueueExtension("local-audit-queue");
+
+    private StructuredAuditService structuredAuditService;
+
+    @BeforeEach
+    void setUp() {
+        ConfigurationService configurationService = new TestConfigurationService();
+        structuredAuditService = new StructuredAuditService(configurationService);
+    }
+
+    @Test
+    void shouldSuccessfullySubmitStructuredAuditEventToQueue() {
+        TestAuditEvent auditEvent =
+                new TestAuditEvent(
+                        "TEST_EVENT",
+                        System.currentTimeMillis() / 1000,
+                        System.currentTimeMillis(),
+                        CommonTestVariables.CLIENT_ID,
+                        ComponentId.AUTH.getValue(),
+                        new TestAuditEvent.TestUser(
+                                "test-user-id",
+                                CommonTestVariables.EMAIL,
+                                CommonTestVariables.IP_ADDRESS,
+                                CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                CommonTestVariables.CLIENT_SESSION_ID),
+                        new TestAuditEvent.TestExtensions("REGISTRATION", "testValue"));
+
+        assertDoesNotThrow(() -> structuredAuditService.submitAuditEvent(auditEvent));
+
+        await().untilAsserted(
+                        () -> {
+                            List<String> messages = sqsQueue.getRawMessages();
+                            assertEquals(1, messages.size());
+
+                            String message = messages.get(0);
+                            assertTrue(message.contains("TEST_EVENT"));
+                            assertTrue(message.contains(CommonTestVariables.EMAIL));
+                            assertTrue(message.contains(CommonTestVariables.CLIENT_ID));
+                            assertTrue(message.contains("REGISTRATION"));
+                        });
+    }
+
+    @Test
+    void shouldSerializeEventWithCorrectSnakeCaseProperties() {
+        TestAuditEvent auditEvent =
+                new TestAuditEvent(
+                        "TEST_EVENT",
+                        System.currentTimeMillis() / 1000,
+                        System.currentTimeMillis(),
+                        CommonTestVariables.CLIENT_ID,
+                        ComponentId.AUTH.getValue(),
+                        new TestAuditEvent.TestUser(
+                                "test-user-id",
+                                CommonTestVariables.EMAIL,
+                                CommonTestVariables.IP_ADDRESS,
+                                CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                CommonTestVariables.CLIENT_SESSION_ID),
+                        new TestAuditEvent.TestExtensions("REGISTRATION", "testValue"));
+
+        assertDoesNotThrow(() -> structuredAuditService.submitAuditEvent(auditEvent));
+
+        await().untilAsserted(
+                        () -> {
+                            List<String> messages = sqsQueue.getRawMessages();
+                            assertEquals(1, messages.size());
+
+                            String message = messages.get(0);
+
+                            assertTrue(message.contains("\"event_name\":"));
+                            assertTrue(message.contains("\"event_timestamp_ms\":"));
+                            assertTrue(message.contains("\"client_id\":"));
+                            assertTrue(message.contains("\"component_id\":"));
+                            assertTrue(message.contains("\"user_id\":"));
+                            assertTrue(message.contains("\"ip_address\":"));
+                            assertTrue(message.contains("\"persistent_session_id\":"));
+                            assertTrue(message.contains("\"govuk_signin_journey_id\":"));
+                            assertTrue(message.contains("\"journey_type\":"));
+
+                            assertTrue(message.contains("\"exampleCamelCaseName\":"));
+                        });
+    }
+
+    @Test
+    void shouldHandleMultipleAuditEvents() {
+        String[] journeyTypes = {"REGISTRATION", "SIGN_IN", "ACCOUNT_RECOVERY"};
+
+        for (String journeyType : journeyTypes) {
+            TestAuditEvent auditEvent =
+                    new TestAuditEvent(
+                            "TEST_EVENT",
+                            System.currentTimeMillis() / 1000,
+                            System.currentTimeMillis(),
+                            CommonTestVariables.CLIENT_ID,
+                            ComponentId.AUTH.getValue(),
+                            new TestAuditEvent.TestUser(
+                                    "test-user-id",
+                                    CommonTestVariables.EMAIL,
+                                    CommonTestVariables.IP_ADDRESS,
+                                    CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                                    CommonTestVariables.CLIENT_SESSION_ID),
+                            new TestAuditEvent.TestExtensions(journeyType, "testValue"));
+
+            assertDoesNotThrow(() -> structuredAuditService.submitAuditEvent(auditEvent));
+        }
+
+        await().untilAsserted(
+                        () -> {
+                            List<String> messages = sqsQueue.getRawMessages();
+                            assertEquals(3, messages.size());
+
+                            assertTrue(messages.stream().anyMatch(m -> m.contains("REGISTRATION")));
+                            assertTrue(messages.stream().anyMatch(m -> m.contains("SIGN_IN")));
+                            assertTrue(
+                                    messages.stream()
+                                            .anyMatch(m -> m.contains("ACCOUNT_RECOVERY")));
+                        });
+    }
+
+    private record TestAuditEvent(
+            String eventName,
+            long timestamp,
+            long eventTimestampMs,
+            String clientId,
+            String componentId,
+            TestUser user,
+            TestExtensions extensions)
+            implements uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent {
+
+        private record TestUser(
+                String userId,
+                String email,
+                String ipAddress,
+                String persistentSessionId,
+                String govukSigninJourneyId) {}
+
+        private record TestExtensions(
+                String journeyType,
+                @SerializedName("exampleCamelCaseName") String exampleCamelCaseName) {}
+    }
+
+    private static class TestConfigurationService extends ConfigurationService {
+        @Override
+        public String getAwsRegion() {
+            return "eu-west-2";
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return sqsQueue.getQueueUrl();
+        }
+    }
+}

--- a/local-running/Dockerfile
+++ b/local-running/Dockerfile
@@ -16,6 +16,7 @@ COPY shared ./shared
 COPY user-permissions ./user-permissions
 COPY auth-external-api ./auth-external-api
 COPY frontend-api ./frontend-api
+COPY audit-events ./audit-events
 
 RUN --mount=type=cache,target=/root/.gradle ./gradlew :local-running:build --no-daemon
 RUN mkdir untarred && tar -xvf local-running/build/distributions/local-running.tar -C ./untarred

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ include 'ticf-cri-stub'
 include 'user-permissions'
 include 'deprecation-checker'
 include 'local-running'
+include 'audit-events'
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -184,6 +184,24 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         }
                     };
 
+    protected static final ConfigurationService EMAIL_CHECK_AND_TXMA_ENABLED_CONFIGURATION_SERVICE =
+            new IntegrationTestConfigurationService(
+                    notificationsQueue,
+                    tokenSigner,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters) {
+
+                @Override
+                public String getTxmaAuditQueueUrl() {
+                    return txmaAuditQueue.getQueueUrl();
+                }
+
+                @Override
+                public boolean isEmailCheckEnabled() {
+                    return true;
+                }
+            };
+
     protected static final ConfigurationService
             ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -82,6 +82,13 @@ public class AuditAssertionsHelper {
 
     public static List<String> assertTxmaAuditEventsReceived(
             SqsQueueExtension queue, Collection<AuditableEvent> events) {
+        return assertTxmaAuditEventsReceived(queue, events, true);
+    }
+
+    public static List<String> assertTxmaAuditEventsReceived(
+            SqsQueueExtension queue,
+            Collection<AuditableEvent> events,
+            boolean validateDeviceInformation) {
 
         var expectedTxmaEvents = events.stream().map(Objects::toString).toList();
 
@@ -132,11 +139,13 @@ public class AuditAssertionsHelper {
                         unexpectedEvents, expectedTxmaEvents, namesOfSentEvents));
 
         // Check all sent events applied business rules, i.e. include a device_information section.
-        sentEvents.forEach(
-                sentEvent -> {
-                    var event = asJson(sentEvent);
-                    assertValidAuditEventsHaveDeviceInformationInRestrictedSection(event);
-                });
+        if (validateDeviceInformation) {
+            sentEvents.forEach(
+                    sentEvent -> {
+                        var event = asJson(sentEvent);
+                        assertValidAuditEventsHaveDeviceInformationInRestrictedSection(event);
+                    });
+        }
 
         return sentEvents;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -11,9 +11,6 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT = "attemptNoFailedAt";
     String AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE = "notification-type";
     String AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED = "MFACodeEntered";
-    String AUDIT_EVENT_EXTENSIONS_ISS = "iss";
-    String AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP =
-            "assessment_checked_at_timestamp";
 
     AuditableEvent parseFromName(String name);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -11,6 +11,9 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT = "attemptNoFailedAt";
     String AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE = "notification-type";
     String AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED = "MFACodeEntered";
+    String AUDIT_EVENT_EXTENSIONS_ISS = "iss";
+    String AUDIT_EVENT_EXTENSIONS_ASSESSMENT_CHECKED_AT_TIMESTAMP =
+            "assessment_checked_at_timestamp";
 
     AuditableEvent parseFromName(String name);
 }


### PR DESCRIPTION
## What

This PR introduces a new `StructuredAuditService` that provides audit event submission using strongly-typed event classes, replacing the previous unstructured approach for audit events.

An ADR is drafted for this approach and an initial implementation in `CheckEmailFraudBlockHandler` is done. This brings `AUTH_EMAIL_FRAUD_CHECK_BYPASSED` to spec based on the event catalogue.

## How to review

1. Code Review
1. Deploy and see the `AUTH_EMAIL_FRAUD_CHECK_BYPASSED` audit event is raised as expected in the audit queue after entering email OTP during account creation.

## Checklist

- [X] Deployment of this PR will not break active user journeys
- [X] Impact on orch and auth mutual dependencies has been checked.
- [X] No changes required or changes have been made to stub-orchestration.