### PR TITLE
ATO-1746: disable table protection on doc app table so it can be deleted

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -247,7 +247,7 @@ resource "aws_dynamodb_table" "doc_app_credential_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
-  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+  deletion_protection_enabled = false
 
   attribute {
     name = "SubjectID"


### PR DESCRIPTION
### Wider context of change

Migrate doc app table to orch

### What’s changed

Turn table protection off on doc app table in auth so it can be deleted

### Manual testing

Deploy to sandpit
