### PR TITLE
ATO-1928: Remove user profile table permissions for TokenHandler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1836,8 +1836,6 @@ Resources:
             - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
-        - !Ref UserProfileTableReadAccessPolicy
-        - !Ref UserProfileTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref IdTokenKmsAccessPolicy


### PR DESCRIPTION
### Wider context of change

We are no longer using the user profile table in TokenHandler, this means we can safely remove the cross account permissions for the table in TokenHandler.

### What’s changed

This PR removes the cross-account permissions for the user profile table in TokenHandler

### Manual testing

Tested in dev by performing:
- an auth journey
- an identity journey
- a docapp journey

All 3 journeys completed successfully.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

Stacked on https://github.com/govuk-one-login/authentication-api/pull/6997
