### PR TITLE
ATO-1892: add rate limit alarm

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6213,7 +6213,7 @@ Resources:
 
   #endregion
 
-  #region Client Rate Limit DynamoDB Table
+  #region Client Rate Limit
 
   ClientRateLimitTableEncryptionKey:
     Type: AWS::KMS::Key
@@ -6272,7 +6272,35 @@ Resources:
       Tags:
         - Key: Name
           Value: ClientRateLimitTable
+
+  ClientRateLimitMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub ${Environment}-client-rate-limit-filter
+      FilterPattern: '{($.message = "Client with ID * has exceeded rate limit. Current count: *. Limit *")}'
+      LogGroupName: !Ref AuthorisationFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub ${Environment}-client-rate-limit-count
+          MetricNamespace: ClientRateLimitCount
+          MetricValue: 1
+
+  ClientRateLimitAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${Environment}-client-rate-limit-alarm
+      AlarmDescription: !Sub "1 or more clients have hit their rate limit for ${Environment}.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/h4DKTQE"
+      Namespace: ClientRateLimitCount
+      MetricName: !Sub ${Environment}-client-rate-limit-count
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref SlackEvents
   #endregion
+
   #region ClientRateLimitTable policies
   ClientRateLimitTableReadWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -6299,6 +6327,7 @@ Resources:
               - kms:Encrypt
             Resource: !GetAtt ClientRateLimitTableEncryptionKey.Arn
   #endregion
+
   #region StateStorage policies
   StateStorageTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -6362,6 +6391,7 @@ Resources:
               - kms:Encrypt
             Resource: !GetAtt StateStorageTableEncryptionKey.Arn
   #endregion
+
   #region IPV token signing key pair
 
   OrchIPVTokenSigningKmsKeyAlias:


### PR DESCRIPTION
### Wider context of change

We want to add an alarm to know when a rate limit has been hit for a client.

### What’s changed

A new cloudwatch alarm triggered on the `RpRateLimitExceeded` metric

### Manual testing

Tested in dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
