### PR TITLE
ATO-1746:remove policy usage on auth doc app table

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -16,7 +16,6 @@ module "oidc_authorize_role" {
     aws_iam_policy.orch_to_auth_kms_policy.arn,
     aws_iam_policy.auth_public_encryption_key_parameter_policy.arn,
     local.client_registry_encryption_policy_arn,
-    local.doc_app_credential_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.oidc_token_kms_signing_policy.arn
   ]

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -9,11 +9,8 @@ module "doc_app_callback_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
-    aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
-    aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
     aws_iam_policy.doc_app_rp_client_id_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.doc_app_credential_encryption_policy_arn
+    module.oidc_txma_audit.access_policy_arn
   ]
   extra_tags = {
     Service = "doc-app-callback"

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -6,8 +6,7 @@ module "oidc_jwks_role" {
 
   policies_to_attach = [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
-    aws_iam_policy.doc_app_auth_kms_policy.arn,
-    local.doc_app_credential_encryption_policy_arn
+    aws_iam_policy.doc_app_auth_kms_policy.arn
   ]
   extra_tags = {
     Service = "jwks.json"

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -57,7 +57,6 @@ locals {
   account_modifiers_encryption_policy_arn     = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
   common_passwords_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
-  doc_app_credential_encryption_policy_arn    = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_policy_arn
   doc_app_credential_encryption_key_arn       = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_key_arn
   user_credentials_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn
   user_profile_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -13,7 +13,6 @@ module "oidc_userinfo_role_2" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.doc_app_credential_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
   extra_tags = {


### PR DESCRIPTION
### Wider context of change

Migrate Doc App table to Orch

### What’s changed

Remove Auth Doc App table policy usages

### Manual testing

Deploy to sandpit and run through doc app journey
