### PR TITLE
AUT-4543: Use internal common subject in reauth audit events

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -120,7 +120,7 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                 var auditContext =
                         AuditContext.auditContextFromUserContext(
                                 userContext,
-                                userProfile.get().getSubjectID(),
+                                userContext.getAuthSession().getInternalCommonSubjectId(),
                                 userProfile.get().getEmail(),
                                 IpAddressHelper.extractIpAddress(input),
                                 userProfile.get().getPhoneNumber(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -213,7 +213,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         getReauthFailureReasonFromCountTypes(exceedingCounts);
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                        auditContext,
+                        auditContext.withSubjectId(authSession.getInternalCommonSubjectId()),
                         ReauthMetadataBuilder.builder(calculatedPairwiseId)
                                 .withAllIncorrectAttemptCounts(reauthCounts)
                                 .withFailureReason(failureReason)
@@ -266,7 +266,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     auditContext,
                     userProfile,
                     isReauthJourney,
-                    calculatedPairwiseId);
+                    calculatedPairwiseId,
+                    authSession);
         }
 
         return handleValidCredentials(
@@ -454,7 +455,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             AuditContext auditContext,
             UserProfile userProfile,
             boolean isReauthJourney,
-            String calculatedPairwiseId) {
+            String calculatedPairwiseId,
+            AuthSessionItem authSession) {
         var updatedIncorrectPasswordCount = incorrectPasswordCount + 1;
 
         incrementCountOfFailedAttemptsToProvidePassword(userProfile, isReauthJourney);
@@ -472,7 +474,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             if (isReauthJourneyWithFlagsEnabled(isReauthJourney)) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                        auditContext,
+                        auditContext.withSubjectId(authSession.getInternalCommonSubjectId()),
                         ReauthMetadataBuilder.builder(calculatedPairwiseId)
                                 .withAllIncorrectAttemptCounts(
                                         authenticationAttemptsService

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -73,6 +74,10 @@ class AuthenticationAuthCodeHandlerTest {
     private static final String LOCATION = "location";
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
+    private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
+    private static final String TEST_INTERNAL_COMMON_SUBJECT =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    TEST_SUBJECT_ID, TEST_SECTOR_IDENTIFIER, TEST_SALT);
     private static final String CALCULATED_PAIRWISE_ID = "some-rp-pairwise-id";
     private static final Long PASSWORD_RESET_TIME = 1696869005821L;
 
@@ -94,7 +99,7 @@ class AuthenticationAuthCodeHandlerTest {
                     CLIENT_ID,
                     CLIENT_SESSION_ID,
                     SESSION_ID,
-                    TEST_SUBJECT_ID,
+                    TEST_INTERNAL_COMMON_SUBJECT,
                     EMAIL,
                     IP_ADDRESS,
                     UK_MOBILE_NUMBER,
@@ -108,7 +113,8 @@ class AuthenticationAuthCodeHandlerTest {
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)
                         .withEmailAddress(CommonTestVariables.EMAIL)
-                        .withClientId(CLIENT_ID);
+                        .withClientId(CLIENT_ID)
+                        .withInternalCommonSubjectId(TEST_INTERNAL_COMMON_SUBJECT);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(clientService.getClient(CLIENT_ID))
                 .thenReturn(Optional.of(new ClientRegistry().withClientID(CLIENT_ID)));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -91,7 +91,8 @@ class CheckReAuthUserHandlerTest {
                     .withSessionId(SESSION_ID)
                     .withEmailAddress(EMAIL_USED_TO_SIGN_IN)
                     .withClientId(CLIENT_ID)
-                    .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST);
+                    .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)
+                    .withInternalCommonSubjectId(TEST_SUBJECT_ID);
 
     private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(
@@ -204,7 +205,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_INCORRECT_EMAIL_ENTERED,
-                        testAuditContextWithAuditEncoded.withUserId(AuditService.UNKNOWN),
+                        testAuditContextWithAuditEncoded,
                         pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                         pair("incorrect_email_attempt_count", 1),
                         pair("user_supplied_email", EMAIL_USED_TO_SIGN_IN, true));
@@ -340,7 +341,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_INCORRECT_EMAIL_ENTERED,
-                        testAuditContextWithAuditEncoded.withUserId(AuditService.UNKNOWN),
+                        testAuditContextWithAuditEncoded,
                         pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                         pair("incorrect_email_attempt_count", 3),
                         pair("user_supplied_email", DIFFERENT_EMAIL_USED_TO_REAUTHENTICATE, true));
@@ -368,7 +369,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_INCORRECT_EMAIL_ENTERED,
-                        testAuditContextWithAuditEncoded.withUserId(AuditService.UNKNOWN),
+                        testAuditContextWithAuditEncoded,
                         pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                         pair("incorrect_email_attempt_count", 3),
                         pair("user_supplied_email", DIFFERENT_EMAIL_USED_TO_REAUTHENTICATE, true),
@@ -398,7 +399,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_INCORRECT_EMAIL_ENTERED,
-                        testAuditContextWithAuditEncoded.withUserId(AuditService.UNKNOWN),
+                        testAuditContextWithAuditEncoded,
                         pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                         pair("incorrect_email_attempt_count", 1),
                         pair("user_supplied_email", EMAIL_USED_TO_SIGN_IN, true));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -535,7 +535,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                         .withClientId(CLIENT_ID.getValue())
                                         .withClientName(CLIENT_NAME)
                                         .withIsSmokeTest(false)
-                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)));
+                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)
+                                        .withInternalCommonSubjectId(expectedCommonSubject)));
     }
 
     private UserCredentials usingApplicableUserCredentials(MFAMethodType mfaMethodType) {


### PR DESCRIPTION
## What

A user being able to reauthenticate is predicated on the principle that we know their internal common subject (ICS) ID. To verify that a user is who they say they are we compare the user credentials associated with an ICS derived from the user context against the user credentials of the email entered during reauth. As such, we should emit the ICS as the user_id for all reauth audit events.

The ICS is not to be confused with the subject ID on the user profile. The subject ID on the user profile is a raw UUID subject. The ICS, however, takes this value with a salt and the internal sector URI and hashes the concatenation of these values.

## How to review

1. Code Review
