### PR TITLE
ATO-1921: Update client registry policies to allow access to new table in orch

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -51,6 +51,7 @@ orch_environment                                   = "build"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:767397776536:key/7a1d86fe-1ca0-499c-95e9-ee8593a850f9"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/e284a04a-bac2-42b0-b723-ef0d32722ad5"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:767397776536:key/84243770-7ba6-42c6-a26c-28bc82e3efa2"
 
 orch_storage_token_jwk_enabled              = true
 orch_openid_configuration_enabled           = true

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -155,6 +155,7 @@ data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document"
     ]
     resources = [
       data.aws_dynamodb_table.client_registry_table.arn,
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-client-registry",
     ]
   }
 
@@ -169,7 +170,10 @@ data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document"
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.client_registry_encryption_key_arn]
+    resources = [
+      local.client_registry_encryption_key_arn,
+      var.orch_client_registry_table_encryption_key_arn
+    ]
   }
 }
 

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -45,6 +45,7 @@ orch_environment                                   = "integration"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:058264132019:key/fdf1686f-2d4d-4c7b-b3be-324b6ebba370"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/808a8c1e-82d8-487e-abb8-e13d6564b426"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:058264132019:key/11948d7f-8e88-41d3-afe5-5ec9f37f979d"
 
 orch_openid_configuration_enabled    = true
 orch_jwks_enabled                    = true

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -56,6 +56,7 @@ orch_environment                                   = "production"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:533266965190:key/9b57120e-3bcd-4fce-ada8-89ea9d1412d6"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/b2979629-c62f-458d-992b-ac4239c2cf81"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:533266965190:key/e9f1350d-75e2-4532-be84-8bec6de99755"
 
 orch_openid_configuration_enabled    = true
 orch_jwks_enabled                    = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -79,6 +79,7 @@ orch_environment                                   = "dev"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/590f841e-3eec-45f1-a9bc-4b32b2edece4"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:816047645251:key/97c19476-82ba-433f-8500-981857e7367e"
 
 cmk_for_back_channel_logout_enabled = true
 use_strongly_consistent_reads       = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -32,6 +32,7 @@ orch_environment                                   = "staging"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:590183975515:key/b94d81a1-a41f-4e61-859c-87dcacb32e51"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/d0bdb864-8478-4411-a44a-a4232fc97cf3"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:590183975515:key/4373aa74-95b2-454c-bd86-9716f105a1c4"
 cmk_for_back_channel_logout_enabled                = true
 
 contra_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -679,6 +679,10 @@ variable "orch_identity_credentials_table_encryption_key_arn" {
   type    = string
   default = ""
 }
+variable "orch_client_registry_table_encryption_key_arn" {
+  type    = string
+  default = ""
+}
 
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false

--- a/template.yaml
+++ b/template.yaml
@@ -5465,20 +5465,22 @@ Resources:
               - dynamodb:Get*
               - dynamodb:Query
               - dynamodb:Scan
-            Resource: !Sub
-              - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
-              - AccountId:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authAccountId,
-                  ]
-                AuthEnvironment:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authEnvironment,
-                  ]
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
+                - AccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authAccountId,
+                    ]
+                  AuthEnvironment:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authEnvironment,
+                    ]
+              - !GetAtt ClientRegistryTable.Arn
           - Sid: AllowClientRegistryTableKeyAccess
             Effect: Allow
             Action:
@@ -5489,11 +5491,12 @@ Resources:
               - kms:CreateGrant
               - kms:DescribeKey
             Resource:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                clientRegistryTableKeyArn,
-              ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  clientRegistryTableKeyArn,
+                ]
+              - !GetAtt ClientRegistryTableEncryptionKey.Arn
 
   ClientRegistryTableWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -5507,20 +5510,22 @@ Resources:
               - dynamodb:BatchWriteItem
               - dynamodb:UpdateItem
               - dynamodb:PutItem
-            Resource: !Sub
-              - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
-              - AccountId:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authAccountId,
-                  ]
-                AuthEnvironment:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authEnvironment,
-                  ]
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
+                - AccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authAccountId,
+                    ]
+                  AuthEnvironment:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authEnvironment,
+                    ]
+              - !GetAtt ClientRegistryTable.Arn
           - Sid: AllowClientRegistryTableKeyAccess
             Effect: Allow
             Action:
@@ -5531,11 +5536,12 @@ Resources:
               - kms:CreateGrant
               - kms:DescribeKey
             Resource:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                clientRegistryTableKeyArn,
-              ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  clientRegistryTableKeyArn,
+                ]
+              - !GetAtt ClientRegistryTableEncryptionKey.Arn
 
   OrchDocAppCredentialTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Wider context of change

We would like to move the client registry into the orch account. We created a dynamo table with an encryption key in a previous ticket. We would like to make sure all handlers that access the auth client registry can access the orch client registry.

### What’s changed

This PR adds the new client registry table to the existing client registry access policies. 

### Manual testing

Tested in sandpit by adding 2 new methods to the ClientService interface for testing reading and writing to the new orch client registry table, and implemented them by adding a new reference to the orch client registry table in DynamoClientService.

I then updated the implementation of ClientRegistrationHandler at the very start to check that calling write and read on the new table would not throw any access errors

I also updated the ProcessingIdentityHandler to do the same thing (this is testing the cross account access from auth)

For both lambdas, no errors were thrown, meaning the access policies were correct.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
