### PR TITLE
AUT-4210: UpdateEmailHandler should reject block email addresses

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -12,14 +12,12 @@ import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +26,7 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_EMAIL_FRAUD_CHECK_BYPASSED;
+import static uk.gov.di.authentication.shared.helpers.NowHelper.unixTimePlusNDays;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
@@ -105,7 +104,7 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
             dynamoEmailCheckResultService.saveEmailCheckResult(
                     CommonTestVariables.EMAIL,
                     EmailCheckResultStatus.ALLOW,
-                    unixTimePlusNDays(),
+                    unixTimePlusNDays(1),
                     "test-reference");
 
             Map<String, String> headers =
@@ -137,7 +136,7 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
             dynamoEmailCheckResultService.saveEmailCheckResult(
                     CommonTestVariables.EMAIL,
                     EmailCheckResultStatus.DENY,
-                    unixTimePlusNDays(),
+                    unixTimePlusNDays(1),
                     "test-reference");
 
             Map<String, String> headers =
@@ -180,9 +179,5 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
             expectation.verify(receivedEvents);
             assertNoTxmaAuditEventsReceived(txmaAuditQueue);
         }
-    }
-
-    private long unixTimePlusNDays() {
-        return NowHelper.nowPlus(1, ChronoUnit.DAYS).toInstant().getEpochSecond();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.NowHelper.unixTimePlusNDays;
 
 class DynamoEmailCheckResultServiceIntegrationTest {
 
@@ -51,9 +52,5 @@ class DynamoEmailCheckResultServiceIntegrationTest {
         var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
 
         assertFalse(result.isPresent());
-    }
-
-    private long unixTimePlusNDays(Integer numberOfDays) {
-        return NowHelper.nowPlus(numberOfDays, ChronoUnit.DAYS).toInstant().getEpochSecond();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -29,6 +29,10 @@ public class NowHelper {
         return date.toInstant().getEpochSecond();
     }
 
+    public static long unixTimePlusNDays(int days) {
+        return nowPlus(days, ChronoUnit.DAYS).toInstant().getEpochSecond();
+    }
+
     public static class NowClock {
         private final Clock clock;
 


### PR DESCRIPTION
## What

Move the `unixTimePlusNDays` into the shared `NowHelper`
Return a 403 in the `UpdateEmailHandler` if the `PendingEmailCheckResultStatus` is `DENY`

## How to review

1. Code Review
2. Tested by @alhcomer and I and it passed
