### PR TITLE
AUT-4197: Set email check retry policy

### DIFF
--- a/ci/terraform/shared/sqs-policy.tf
+++ b/ci/terraform/shared/sqs-policy.tf
@@ -40,3 +40,28 @@ resource "aws_sqs_queue_policy" "pending_email_check_queue_subscription" {
 
   policy = data.aws_iam_policy_document.pending_email_check_queue_subscription_policy_document.json
 }
+
+data "aws_iam_policy_document" "pending_email_check_dlq_policy_document" {
+  statement {
+    effect = "Allow"
+    sid    = "AllowCrossAccountSendMessageToDLQ"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.auth_check_account_id}:root"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.pending_email_check_dead_letter_queue.arn
+    ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "pending_email_check_dlq_policy" {
+  queue_url = aws_sqs_queue.pending_email_check_dead_letter_queue.id
+  policy    = data.aws_iam_policy_document.pending_email_check_dlq_policy_document.json
+}

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -4,7 +4,7 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
   max_message_size           = 2048
   message_retention_seconds  = 1209600
   receive_wait_time_seconds  = 10
-  visibility_timeout_seconds = 46
+  visibility_timeout_seconds = 270
 
   kms_master_key_id                 = aws_kms_key.pending_email_check_queue_encryption_key.arn
   kms_data_key_reuse_period_seconds = 300

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -11,7 +11,7 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.pending_email_check_dead_letter_queue.arn
-    maxReceiveCount     = 1
+    maxReceiveCount     = 3
   })
 }
 


### PR DESCRIPTION
## What

- Sets the retry policy to what is outlined in AUT-4197
- Sets permissions to allow the email check account to send SQS messages to the pending email check DLQ. These permissions are the allowance of ingress of SQS messages from the email check account to the pending email check DLQ, and the allowance of the email check account to use the pending_email_check_queue_encryption_key to encrypt those messages.

## How to review

1. Code Review
2. Deploy to dev with the associated PR. Send a message to the lambda in the AWS test area with the email 'stubemailassessmentfailure@example.com'. See that this SQS message appears in the pending email check DLQ.

## Related PRs

https://github.com/govuk-one-login/authentication-check-experian/pull/514
