### PR TITLE
AuUT-4633 Add daily sms limit reached alarms

### DIFF
--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -68,6 +68,46 @@ resource "aws_cloudwatch_metric_alarm" "spot_request_sqs_cloudwatch_p1_alarm" {
   alarm_actions     = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "domestic_sms_limit_exceeded_alarm" {
+  alarm_name          = "${var.environment}-${var.environment == "production" ? "P1-" : ""}domestic-sms-limit-exceeded-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "SmsLimitExceeded"
+  namespace           = "Authentication"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "2"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    Environment        = var.environment
+    SmsDestinationType = "DOMESTIC"
+  }
+
+  alarm_description = "${var.environment == "production" ? "CRITICAL: " : ""}Domestic SMS daily limit exceeded (${var.environment}). 2+ 429 responses from Notify. ACCOUNT: ${local.aws_account_alias}"
+  alarm_actions     = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "international_sms_limit_exceeded_alarm" {
+  alarm_name          = "${var.environment}-${var.environment == "production" ? "P1-" : ""}international-sms-limit-exceeded-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "SmsLimitExceeded"
+  namespace           = "Authentication"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "2"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    Environment        = var.environment
+    SmsDestinationType = "INTERNATIONAL"
+  }
+
+  alarm_description = "${var.environment == "production" ? "CRITICAL: " : ""}International SMS daily limit exceeded (${var.environment}). 2+ 429 responses from Notify. ACCOUNT: ${local.aws_account_alias}"
+  alarm_actions     = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
+}
+
 
 # Turning WAF blocked alerts off until we figure out how best to utilise them
 #resource "aws_cloudwatch_metric_alarm" "waf_oidc_blocked_request_cloudwatch_alarm" {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -17,7 +17,8 @@ public enum CloudwatchMetricDimensions {
     APPLICATION("Application"),
     NOTIFICATION_TYPE("NotificationType"),
     COUNTRY("Country"),
-    NOTIFICATION_HTTP_ERROR("NotificationHttpError");
+    NOTIFICATION_HTTP_ERROR("NotificationHttpError"),
+    SMS_DESTINATION_TYPE("SmsDestinationType");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -25,7 +25,8 @@ public enum CloudwatchMetrics {
     SMS_NOTIFICATION_SENT("SmsNotificationSent"),
     EMAIL_NOTIFICATION_SENT("EmailNotificationSent"),
     SMS_NOTIFICATION_ERROR("SmsNotificationError"),
-    EMAIL_NOTIFICATION_ERROR("EmailNotificationError");
+    EMAIL_NOTIFICATION_ERROR("EmailNotificationError"),
+    SMS_LIMIT_EXCEEDED("SmsLimitExceeded");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -32,6 +32,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NOTIFICATION_HTTP_ERROR;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.REQUESTED_LEVEL_OF_CONFIDENCE;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.SMS_DESTINATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
@@ -41,6 +42,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_NOT
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_AUTHORISATION_ERROR;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_HANDOFF;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_IPV_RESPONSE;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SMS_LIMIT_EXCEEDED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SMS_NOTIFICATION_ERROR;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SMS_NOTIFICATION_SENT;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -295,6 +297,19 @@ public class CloudwatchMetricsService {
             metricName = EMAIL_NOTIFICATION_SENT.getValue();
         }
         incrementCounter(metricName, dimensions);
+    }
+
+    public void emitSmsLimitExceededMetric(
+            NotifiableType notificationType,
+            Boolean isTestDestination,
+            Application application,
+            String destinationType) {
+        var dimensions =
+                getNotificationBaseMetricDimensions(
+                        notificationType, isTestDestination, application);
+        dimensions.put(SMS_DESTINATION_TYPE.getValue(), destinationType);
+
+        incrementCounter(SMS_LIMIT_EXCEEDED.getValue(), dimensions);
     }
 
     private HashMap<String, String> getNotificationBaseMetricDimensions(


### PR DESCRIPTION
## What

When the international SMS quota is exceeded we start to get 429 responses from Notify.

<!-- Describe what you have changed and why -->

This change adds two alarms for exceeding the international quota and the domestic quota.  In production the alarms with trigger PagerDuty.

This is part one of two changes.  The next change will be an early warning alarm when the number of messages being sent looks like the daily quota will be exceeded.


## How to review

1. Deploy to a dev environment.
2. Check the metrics and alarms are created.
3. Use the aws cli to emit updates to the metric and check the alarm is activated.
4. Optionally create a subscription on the SNS topic to confirm the alarm is emitting a notification.

I have already tested this in authdev1 and confirmed the alarms are activated and received notifications from SNS.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
6. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
