### PR TITLE
ATO-1941: Send slack alerts to orch prod alerts channel

### DIFF
--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -49,7 +49,7 @@ const buildMessageRequest = async function (
     process.env.DEPLOY_ENVIRONMENT,
   );
   const isEnabledForProd =
-    process.env.PROD_ALERTS_ENABLED === "true" &&
+    process.env.ORCH_PROD_ALERTS_ENABLED === "true" &&
     process.env.DEPLOY_ENVIRONMENT === "production";
   if (isEnabledForNonProd || isEnabledForProd) {
     body.channel =

--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -2,88 +2,99 @@ const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
 const ssmClient = new SSMClient();
 
 const getParameter = async (parameterName) => {
-    const getParameterCommand = new GetParameterCommand({
-        Name: parameterName
-    });
-    return (await ssmClient.send(getParameterCommand)).Parameter.Value
-}
-
-const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
-    var description = snsMessage.AlarmDescription.split("ACCOUNT:");
-    var account = snsMessage.AWSAccountId;
-    if (description.length > 1) {
-        account = description[1];
-    }
-    return {
-        attachments: [
-            {
-                fallback: description[0],
-                color: colorCode,
-                title: snsMessage.AlarmName,
-                text: description[0],
-                fields: [
-                    {
-                        title: "Status",
-                        value: snsMessage.NewStateValue,
-                        short: false,
-                    },
-                    {
-                        title: "Account",
-                        value: account,
-                        short: false,
-                    },
-                ],
-                footer: snsMessageFooter,
-            },
-        ],
-    };
+  const getParameterCommand = new GetParameterCommand({
+    Name: parameterName,
+  });
+  return (await ssmClient.send(getParameterCommand)).Parameter.Value;
 };
 
-const buildMessageRequest = async function (snsMessage, colorCode, snsMessageFooter) {
-    const body = formatMessage(snsMessage, colorCode, snsMessageFooter);
-    const isEnabledForNonProd = ["dev", "staging", "integration"].includes(process.env.DEPLOY_ENVIRONMENT);
-    const isEnabledForProd = process.env.PROD_ALERTS_ENABLED === "true" && process.env.DEPLOY_ENVIRONMENT === "production";
-    if (isEnabledForNonProd || isEnabledForProd) {
-        body.channel = process.env.SLACK_CHANNEL_ID ||
-            (await getParameter(process.env.DEPLOY_ENVIRONMENT + "-slack-channel-id"));
-    }
-    return {
-        method: "post",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-    };
+const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
+  var description = snsMessage.AlarmDescription.split("ACCOUNT:");
+  var account = snsMessage.AWSAccountId;
+  if (description.length > 1) {
+    account = description[1];
+  }
+  return {
+    attachments: [
+      {
+        fallback: description[0],
+        color: colorCode,
+        title: snsMessage.AlarmName,
+        text: description[0],
+        fields: [
+          {
+            title: "Status",
+            value: snsMessage.NewStateValue,
+            short: false,
+          },
+          {
+            title: "Account",
+            value: account,
+            short: false,
+          },
+        ],
+        footer: snsMessageFooter,
+      },
+    ],
+  };
+};
+
+const buildMessageRequest = async function (
+  snsMessage,
+  colorCode,
+  snsMessageFooter,
+) {
+  const body = formatMessage(snsMessage, colorCode, snsMessageFooter);
+  const isEnabledForNonProd = ["dev", "staging", "integration"].includes(
+    process.env.DEPLOY_ENVIRONMENT,
+  );
+  const isEnabledForProd =
+    process.env.PROD_ALERTS_ENABLED === "true" &&
+    process.env.DEPLOY_ENVIRONMENT === "production";
+  if (isEnabledForNonProd || isEnabledForProd) {
+    body.channel =
+      process.env.SLACK_CHANNEL_ID ||
+      (await getParameter(
+        process.env.DEPLOY_ENVIRONMENT + "-slack-channel-id",
+      ));
+  }
+  return {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  };
 };
 
 // eslint-disable-next-line no-unused-vars
 const handler = async function (event, context) {
-    console.log("Alert lambda triggered");
-    const slackHookUrl =
-        process.env.SLACK_WEBHOOK_URL ||
-        (await getParameter(process.env.DEPLOY_ENVIRONMENT + "-slack-hook-url"));
-    let colorCode = process.env.ERROR_COLOR || "#C70039";
-    let snsMessageFooter = process.env.MESSAGE_FOOTER || "GOV.UK Sign In alert";
+  console.log("Alert lambda triggered");
+  const slackHookUrl =
+    process.env.SLACK_WEBHOOK_URL ||
+    (await getParameter(process.env.DEPLOY_ENVIRONMENT + "-slack-hook-url"));
+  let colorCode = process.env.ERROR_COLOR || "#C70039";
+  let snsMessageFooter = process.env.MESSAGE_FOOTER || "GOV.UK Sign In alert";
 
-    let snsMessage = JSON.parse(event.Records[0].Sns.Message);
-    if (snsMessage.NewStateValue === "OK") {
-        colorCode = process.env.OK_COLOR || "#36a64f";
-    }
-    const messageRequest = await buildMessageRequest(
-        snsMessage,
-        colorCode,
-        snsMessageFooter
-    );
+  let snsMessage = JSON.parse(event.Records[0].Sns.Message);
+  if (snsMessage.NewStateValue === "OK") {
+    colorCode = process.env.OK_COLOR || "#36a64f";
+  }
+  const messageRequest = await buildMessageRequest(
+    snsMessage,
+    colorCode,
+    snsMessageFooter,
+  );
 
-    console.log("Sending alert to slack");
-    try {
-        // eslint-disable-next-line no-undef
-        const response = await fetch(slackHookUrl, messageRequest);
-        const message = await response.text();
-        console.log(message);
-    } catch (error) {
-        console.log(error);
-    }
+  console.log("Sending alert to slack");
+  try {
+    // eslint-disable-next-line no-undef
+    const response = await fetch(slackHookUrl, messageRequest);
+    const message = await response.text();
+    console.log(message);
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 module.exports = { handler };

--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -73,7 +73,9 @@ const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
 
 const buildMessageRequest = async function (snsMessage, colorCode, snsMessageFooter) {
     const body = formatMessage(snsMessage, colorCode, snsMessageFooter);
-    if (process.env.DEPLOY_ENVIRONMENT === "integration" || process.env.DEPLOY_ENVIRONMENT === "dev" || process.env.DEPLOY_ENVIRONMENT === "staging") {
+    const isEnabledForNonProd = ["dev", "staging", "integration"].includes(process.env.DEPLOY_ENVIRONMENT);
+    const isEnabledForProd = process.env.PROD_ALERTS_ENABLED === "true" && process.env.DEPLOY_ENVIRONMENT === "production";
+    if (isEnabledForNonProd || isEnabledForProd) {
         body.channel = process.env.SLACK_CHANNEL_ID ||
             (await getParameter(process.env.DEPLOY_ENVIRONMENT + "-slack-channel-id"));
     }

--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -14,61 +14,29 @@ const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
     if (description.length > 1) {
         account = description[1];
     }
-    if (JSON.stringify(snsMessage).includes("ElastiCache")) {
-        return {
-            attachments: [
-                {
-                    fallback:
-                        Object.keys(snsMessage)[0] +
-                        "for cluster: " +
-                        Object.values(snsMessage)[0],
-                    color: "#ff9966",
-                    title: Object.values(snsMessage)[0] + "-notification",
-                    text:
-                        Object.keys(snsMessage)[0] +
-                        " for cluster: " +
-                        Object.values(snsMessage)[0],
-                    fields: [
-                        {
-                            title: "Status",
-                            value: "INFO",
-                            short: false,
-                        },
-                        {
-                            title: "Account",
-                            value: account,
-                            short: false,
-                        },
-                    ],
-                    footer: snsMessageFooter,
-                },
-            ],
-        };
-    } else {
-        return {
-            attachments: [
-                {
-                    fallback: description[0],
-                    color: colorCode,
-                    title: snsMessage.AlarmName,
-                    text: description[0],
-                    fields: [
-                        {
-                            title: "Status",
-                            value: snsMessage.NewStateValue,
-                            short: false,
-                        },
-                        {
-                            title: "Account",
-                            value: account,
-                            short: false,
-                        },
-                    ],
-                    footer: snsMessageFooter,
-                },
-            ],
-        };
-    }
+    return {
+        attachments: [
+            {
+                fallback: description[0],
+                color: colorCode,
+                title: snsMessage.AlarmName,
+                text: description[0],
+                fields: [
+                    {
+                        title: "Status",
+                        value: snsMessage.NewStateValue,
+                        short: false,
+                    },
+                    {
+                        title: "Account",
+                        value: account,
+                        short: false,
+                    },
+                ],
+                footer: snsMessageFooter,
+            },
+        ],
+    };
 };
 
 const buildMessageRequest = async function (snsMessage, colorCode, snsMessageFooter) {

--- a/template.yaml
+++ b/template.yaml
@@ -4853,7 +4853,7 @@ Resources:
       AlarmActions:
         - !If
           - IsProduction
-          - !Ref ProdSlackEvents
+          - !Ref OrchProdSlackEvents
           - !Ref SlackEvents
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
@@ -6142,15 +6142,15 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
-  ProdSlackEvents:
+  OrchProdSlackEvents:
     Condition: IsProduction
     Type: AWS::SNS::Topic
     Properties:
       DisplayName: "Slack Alerts for production"
       TopicName: production-slack-events
-      KmsMasterKeyId: !GetAtt ProdSlackEventsKey.Arn
+      KmsMasterKeyId: !GetAtt OrchProdSlackEventsKey.Arn
 
-  ProdSlackEventsKey:
+  OrchProdSlackEventsKey:
     Condition: IsProduction
     Type: AWS::KMS::Key
     Properties:
@@ -6206,18 +6206,18 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
-  ProdSlackEventsPolicy:
+  OrchProdSlackEventsPolicy:
     Condition: IsProduction
     Type: AWS::SNS::TopicPolicy
     Properties:
       Topics:
-        - !Ref ProdSlackEvents
+        - !Ref OrchProdSlackEvents
       PolicyDocument:
         Version: 2012-10-17
         Statement:
           - Action: sns:Publish
             Effect: Allow
-            Resource: !Ref ProdSlackEvents
+            Resource: !Ref OrchProdSlackEvents
             Principal:
               Service:
                 - cloudwatch.amazonaws.com
@@ -6265,15 +6265,15 @@ Resources:
           Properties:
             Topic: !Ref SlackEvents
 
-  ProdSlackNotificationsFunction:
+  OrchProdSlackNotificationsFunction:
     Condition: IsProduction
     Type: AWS::Serverless::Function
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
-    # checkov:skip=CKV_AWS_117: ProdSlackNotificationsFunction doesn't need vpc configuration
+    # checkov:skip=CKV_AWS_117: OrchProdSlackNotificationsFunction doesn't need vpc configuration
     IgnoreGlobals: "*"
     Properties:
       AutoPublishAlias: latest
-      FunctionName: !Sub ${Environment}-ProdSlackNotificationsFunction
+      FunctionName: !Sub ${Environment}-OrchProdSlackNotificationsFunction
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -6305,7 +6305,7 @@ Resources:
         SNS:
           Type: SNS
           Properties:
-            Topic: !Ref ProdSlackEvents
+            Topic: !Ref OrchProdSlackEvents
 
   SlackNotificationsPermission:
     Type: AWS::Lambda::Permission
@@ -6316,15 +6316,15 @@ Resources:
       SourceAccount: !Ref AWS::AccountId
       SourceArn: !Ref SlackEvents
 
-  ProdSlackNotificationsPermission:
+  OrchProdSlackNotificationsPermission:
     Condition: IsProduction
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref ProdSlackNotificationsFunction
+      FunctionName: !Ref OrchProdSlackNotificationsFunction
       Action: lambda:InvokeFunction
       Principal: sns.amazonaws.com
       SourceAccount: !Ref AWS::AccountId
-      SourceArn: !Ref ProdSlackEvents
+      SourceArn: !Ref OrchProdSlackEvents
 
   #endregion
 

--- a/template.yaml
+++ b/template.yaml
@@ -4851,7 +4851,10 @@ Resources:
       AlarmDescription: !Sub "${Environment} backchannel logout DLQ has 5 or more messages.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/spaces/Orch/pages/5292228639/Runbook+Backchannel+Logout+DLQ+Alarm"
       ActionsEnabled: true
       AlarmActions:
-        - !Ref SlackEvents
+        - !If
+          - IsProduction
+          - !Ref ProdSlackEvents
+          - !Ref SlackEvents
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:

--- a/template.yaml
+++ b/template.yaml
@@ -6290,7 +6290,7 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           DEPLOY_ENVIRONMENT: production
-          PROD_ALERTS_ENABLED: true
+          ORCH_PROD_ALERTS_ENABLED: true
       Policies:
         - Statement:
             - Sid: AllowGetParameters

--- a/template.yaml
+++ b/template.yaml
@@ -6286,7 +6286,8 @@ Resources:
       Environment:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
-          DEPLOY_ENVIRONMENT: !Ref Environment
+          DEPLOY_ENVIRONMENT: production
+          PROD_ALERTS_ENABLED: true
       Policies:
         - Statement:
             - Sid: AllowGetParameters

--- a/template.yaml
+++ b/template.yaml
@@ -6139,6 +6139,52 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
+  ProdSlackEvents:
+    Condition: IsProduction
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: "Slack Alerts for production"
+      TopicName: production-slack-events
+      KmsMasterKeyId: !GetAtt ProdSlackEventsKey.Arn
+
+  ProdSlackEventsKey:
+    Condition: IsProduction
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Key used to encrypt prod Slack events topic
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: !Sub logs.${AWS::Region}.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+          - Effect: Allow
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: "*"
+            Condition:
+              StringEquals:
+                AWS:SourceAccount: !Ref AWS::AccountId
+
   SlackEventsPolicy:
     Type: AWS::SNS::TopicPolicy
     Properties:
@@ -6150,6 +6196,25 @@ Resources:
           - Action: sns:Publish
             Effect: Allow
             Resource: !Ref SlackEvents
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+            Condition:
+              StringEquals:
+                AWS:SourceAccount: !Ref AWS::AccountId
+
+  ProdSlackEventsPolicy:
+    Condition: IsProduction
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref ProdSlackEvents
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Resource: !Ref ProdSlackEvents
             Principal:
               Service:
                 - cloudwatch.amazonaws.com
@@ -6181,11 +6246,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           DEPLOY_ENVIRONMENT: !Ref Environment
-      Events:
-        SNS:
-          Type: SNS
-          Properties:
-            Topic: !Ref SlackEvents
       Policies:
         - Statement:
             - Sid: AllowGetParameters
@@ -6196,6 +6256,52 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-channel-id"
                 - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-hook-url"
+      Events:
+        SNS:
+          Type: SNS
+          Properties:
+            Topic: !Ref SlackEvents
+
+  ProdSlackNotificationsFunction:
+    Condition: IsProduction
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
+    # checkov:skip=CKV_AWS_117: ProdSlackNotificationsFunction doesn't need vpc configuration
+    IgnoreGlobals: "*"
+    Properties:
+      AutoPublishAlias: latest
+      FunctionName: !Sub ${Environment}-ProdSlackNotificationsFunction
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      CodeUri: ./orchestration-alerting
+      Handler: slackNotifications.handler
+      ReservedConcurrentExecutions: 1
+      Runtime: "nodejs20.x"
+      Environment:
+        Variables:
+          # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+          DEPLOY_ENVIRONMENT: !Ref Environment
+      Policies:
+        - Statement:
+            - Sid: AllowGetParameters
+              Effect: "Allow"
+              Action:
+                - "ssm:GetParameter"
+                - "ssm:GetParameters"
+              Resource:
+                - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-channel-id"
+                - !Sub "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-slack-hook-url"
+      Events:
+        SNS:
+          Type: SNS
+          Properties:
+            Topic: !Ref ProdSlackEvents
 
   SlackNotificationsPermission:
     Type: AWS::Lambda::Permission
@@ -6205,6 +6311,16 @@ Resources:
       Principal: sns.amazonaws.com
       SourceAccount: !Ref AWS::AccountId
       SourceArn: !Ref SlackEvents
+
+  ProdSlackNotificationsPermission:
+    Condition: IsProduction
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ProdSlackNotificationsFunction
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !Ref ProdSlackEvents
 
   #endregion
 


### PR DESCRIPTION
### Wider context of change

We would like to make the orch-nonprod-alerts slack channel less noisy. We already have a prod-alerts slack channel for build notifications. 

### What’s changed

This PR creates a new version of the `SlackNotificationsFunction` specifically for production alerts. This involves creating a new encrypted SNS topic. All the new Prod specific infrastructure is only deployed in the prod environment. This new version (ProdSlackNotificationsFunction) is only used in the back channel logout DLQ alarm at the moment.

It's best to review this commit-by-commit, as the penultimate commit applies our JS linting rules to the whole `slackNotifications.js` file and makes the diff look awful :smile:

I've also added the new SSM params needed for the prod alarms to work

### Manual testing

Tested in dev by temporarily adding the dev environment to the condition for the new infrastructure, and manually triggering the back channel logout DLQ alarm. The slack message got sent to the prod alerts channel as expected.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
