### PR TITLE
ATO-1921: Fix auth deployment issues

### DIFF
--- a/ci/terraform/oidc/authdev3.tfvars
+++ b/ci/terraform/oidc/authdev3.tfvars
@@ -94,5 +94,6 @@ orch_environment                                   = "dev"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/590f841e-3eec-45f1-a9bc-4b32b2edece4"
+orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:816047645251:key/97c19476-82ba-433f-8500-981857e7367e"
 
 cmk_for_back_channel_logout_enabled = true


### PR DESCRIPTION
### Wider context of change

The auth dev environments are failing to deploy. This is because in the previous PR we added permissions to use the new orch client registry table to an existing policy - which is always deployed even if orch is stubbed.

We also missed adding the encryption key arn to the authdev3 tfvars file.

### What’s changed

This PR creates a new cross-account policy for accessing the orch client registry. This new policy is only created when orch is not stubbed. 

The orch dev client registry encryption key arn has also been added to the authdev3 tfvars file, as that environment is not stubbing orch.

### Manual testing

Deployed to authdev1 successfully.

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

