### PR TITLE
BAU: Switch off Dynamo streaming on user-profile in non-prod environments

### DIFF
--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -20,3 +20,6 @@ orch_stub_deployed                   = false
 redis_node_size              = "cache.t2.small"
 provision_dynamo             = false
 provision_test_client_secret = false
+
+# Dynamo Configuration
+enable_user_profile_stream = true

--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -21,3 +21,6 @@ orch_stub_deployed                   = false
 redis_node_size              = "cache.m4.xlarge"
 provision_dynamo             = false
 provision_test_client_secret = false
+
+# Dynamo Configuration
+enable_user_profile_stream = true

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -113,7 +113,7 @@ variable "enforce_code_signing" {
 }
 
 variable "enable_user_profile_stream" {
-  default     = true
+  default     = false
   type        = bool
   description = "Whether the User Profile DynamoDB table should have streaming turned on (this is consumed by Experian Phone Check lambda in a separate repo)"
 }


### PR DESCRIPTION
## What

Switch off Dynamo streaming on user-profile in non-prod environments

Dynamo streaming was originally used to trigger an Experian phone check when a phone number was added to the database.  This is now deprecated and has been replaced by an SQS message instead, but streaming is still switched on.

Proves the switch off in all test environments.

## How to review

1. Code Review
1. Deploy to a test environment and run journeys to prove that the application is still working correctly.

Configuration equivalent to integration and production here has been tested in a test environment to prove that streaming will be maintained in those environments (for the moment)

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.



