### PR TITLE
BAU: Switch off Dynamo streaming on user-profile in prod environments

### DIFF
--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -20,6 +20,3 @@ orch_stub_deployed                   = false
 redis_node_size              = "cache.t2.small"
 provision_dynamo             = false
 provision_test_client_secret = false
-
-# Dynamo Configuration
-enable_user_profile_stream = true

--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -21,6 +21,3 @@ orch_stub_deployed                   = false
 redis_node_size              = "cache.m4.xlarge"
 provision_dynamo             = false
 provision_test_client_secret = false
-
-# Dynamo Configuration
-enable_user_profile_stream = true


### PR DESCRIPTION


## What

Switch off Dynamo streaming on user-profile in prod environments

Dynamo streaming was originally used to trigger an Experian phone check when a phone number was added to the database.  This is now deprecated and has been replaced by an SQS message instead, but streaming is still switched on.

Following the switch-off in test environments this change switches off in integration and production.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review

A previous PR tested this change in non-prod environments.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

## Related PRs

#7059 
