### PR TITLE
AUT-4557: Support enhanced email check audit data

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler;
 import uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -82,7 +83,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         TEST_NEW_EMAIL,
                         EmailCheckResultStatus.ALLOW,
                         unixTimePlusNDays(),
-                        "test-reference");
+                        "test-reference",
+                        CommonTestVariables.JOURNEY_ID,
+                        CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA);
 
                 Map<String, String> headers = new HashMap<>();
                 headers.put(TXMA_AUDIT_ENCODED_HEADER, "ENCODED_DEVICE_DETAILS");

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -286,7 +287,9 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 NEW_EMAIL_ADDRESS,
                 EmailCheckResultStatus.DENY,
                 unixTimePlusNDays(1),
-                "test-reference");
+                "test-reference",
+                CommonTestVariables.JOURNEY_ID,
+                CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA);
         var internalCommonSubId = setupUserAndRetrieveInternalCommonSubId();
         var otp = redis.generateAndSaveEmailCode(NEW_EMAIL_ADDRESS, 300);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -105,7 +105,9 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
                     CommonTestVariables.EMAIL,
                     EmailCheckResultStatus.ALLOW,
                     unixTimePlusNDays(1),
-                    "test-reference");
+                    "test-reference",
+                    CommonTestVariables.JOURNEY_ID,
+                    CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA);
 
             Map<String, String> headers =
                     constructFrontendHeaders(sessionId, CommonTestVariables.CLIENT_SESSION_ID);
@@ -137,7 +139,9 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
                     CommonTestVariables.EMAIL,
                     EmailCheckResultStatus.DENY,
                     unixTimePlusNDays(1),
-                    "test-reference");
+                    "test-reference",
+                    CommonTestVariables.JOURNEY_ID,
+                    CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA);
 
             Map<String, String> headers =
                     constructFrontendHeaders(sessionId, CommonTestVariables.CLIENT_SESSION_ID);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 import uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler;
@@ -16,10 +18,10 @@ import uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 class EmailCheckResultWriterIntegrationTest extends HandlerIntegrationTest<SQSEvent, Void> {
-    private static final String TEST_MSG_EMAIL = "test@test.com";
     private static final long TEST_MSG_TIME_TO_EXIST = 4073717403L;
     private static final String TEST_MSG_REF_NUMBER = "123456-abc1234def5678";
     DynamoEmailCheckResultService dynamoEmailCheckResultService =
@@ -42,11 +44,13 @@ class EmailCheckResultWriterIntegrationTest extends HandlerIntegrationTest<SQSEv
         handler.handleRequest(event, mock(Context.class));
 
         EmailCheckResultStore dbEntry =
-                dynamoEmailCheckResultService.getEmailCheckStore(TEST_MSG_EMAIL).get();
-        assertEquals(TEST_MSG_EMAIL, dbEntry.getEmail());
+                dynamoEmailCheckResultService.getEmailCheckStore(CommonTestVariables.EMAIL).get();
+        assertEquals(CommonTestVariables.EMAIL, dbEntry.getEmail());
         assertEquals(emailCheckResultStatus, dbEntry.getStatus());
         assertEquals(TEST_MSG_REF_NUMBER, dbEntry.getReferenceNumber());
         assertEquals(TEST_MSG_TIME_TO_EXIST, dbEntry.getTimeToExist());
+        assertEquals(CommonTestVariables.JOURNEY_ID, dbEntry.getGovukSigninJourneyId());
+        assertNotNull(dbEntry.getEmailCheckResponse());
     }
 
     @NotNull
@@ -58,11 +62,24 @@ class EmailCheckResultWriterIntegrationTest extends HandlerIntegrationTest<SQSEv
         if (doesMessageContainRequiredFields) {
             sqsMessage.setBody(
                     String.format(
-                            "{ \"EmailAddress\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"RequestReference\": \"%s\", \"TimeOfInitialRequest\":1000 }",
-                            TEST_MSG_EMAIL,
+                            """
+                            {
+                              "EmailAddress": "%s",
+                              "Status": "%s",
+                              "TimeToExist": "%d",
+                              "RequestReference": "%s",
+                              "TimeOfInitialRequest": 1000,
+                              "GovukSigninJourneyId": "%s",
+                              "EmailCheckResponse": %s
+                            }""",
+                            CommonTestVariables.EMAIL,
                             status.toString(),
                             TEST_MSG_TIME_TO_EXIST,
-                            TEST_MSG_REF_NUMBER));
+                            TEST_MSG_REF_NUMBER,
+                            CommonTestVariables.JOURNEY_ID,
+                            SerializationService.getInstance()
+                                    .writeValueAsString(
+                                            CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA)));
         } else {
             sqsMessage.setBody(("{}"));
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -3,16 +3,20 @@ package uk.gov.di.authentication.services;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.helpers.NowHelper.unixTimePlusNDays;
 
@@ -31,8 +35,15 @@ class DynamoEmailCheckResultServiceIntegrationTest {
 
     @Test
     void shouldSaveAndReadAnEmailCheckResult() {
+        var testResponseData = CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA;
+
         dynamoEmailCheckResultService.saveEmailCheckResult(
-                email, status, unixTimePlusNDays(1), referenceNumber);
+                email,
+                status,
+                unixTimePlusNDays(1),
+                referenceNumber,
+                CommonTestVariables.JOURNEY_ID,
+                testResponseData);
 
         var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
 
@@ -40,6 +51,23 @@ class DynamoEmailCheckResultServiceIntegrationTest {
         assertThat(result.get().getEmail(), equalTo(email));
         assertThat(result.get().getStatus(), equalTo(status));
         assertThat(result.get().getReferenceNumber(), equalTo(referenceNumber));
+
+        var responseSection = result.get().getEmailCheckResponse();
+        assertNotNull(responseSection);
+
+        var responseMap = (Map<?, ?>) responseSection;
+        assertThat(responseMap.get("testString"), equalTo("testValue1"));
+        assertThat(((Number) responseMap.get("testNumber")).intValue(), equalTo(456));
+        assertThat(responseMap.get("testBoolean"), equalTo(true));
+
+        var testArray = (List<?>) responseMap.get("testArray");
+        assertThat(testArray.size(), equalTo(2));
+        assertThat(testArray.get(0), equalTo("testItem1"));
+        assertThat(testArray.get(1), equalTo("testItem2"));
+
+        var testObject = (Map<?, ?>) responseMap.get("testObject");
+        assertThat(testObject.get("testNestedString"), equalTo("testNestedValue"));
+        assertThat(((Number) testObject.get("testNestedNumber")).intValue(), equalTo(789));
     }
 
     @Test
@@ -47,7 +75,12 @@ class DynamoEmailCheckResultServiceIntegrationTest {
         long unixTimeInThePast =
                 NowHelper.nowPlus(-1, ChronoUnit.DAYS).toInstant().getEpochSecond();
         dynamoEmailCheckResultService.saveEmailCheckResult(
-                email, status, unixTimeInThePast, referenceNumber);
+                email,
+                status,
+                unixTimeInThePast,
+                referenceNumber,
+                CommonTestVariables.JOURNEY_ID,
+                CommonTestVariables.EMAIL_CHECK_RESPONSE_TEST_DATA);
 
         var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/converters/ObjectConverter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/converters/ObjectConverter.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.shared.converters;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+public class ObjectConverter implements AttributeConverter<Object> {
+
+    private static final SerializationService serializationService =
+            SerializationService.getInstance();
+
+    @Override
+    public AttributeValue transformFrom(Object input) {
+        if (input == null) {
+            return AttributeValue.builder().nul(true).build();
+        }
+        return AttributeValue.builder().s(serializationService.writeValueAsString(input)).build();
+    }
+
+    @Override
+    public Object transformTo(AttributeValue input) {
+        if (input.nul() != null && input.nul()) {
+            return null;
+        }
+        try {
+            return serializationService.readValue(input.s(), Object.class);
+        } catch (Json.JsonException e) {
+            throw new RuntimeException("Failed to deserialize Object", e);
+        }
+    }
+
+    @Override
+    public EnhancedType<Object> type() {
+        return EnhancedType.of(Object.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.S;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
@@ -9,4 +9,6 @@ public record EmailCheckResultSqsMessage(
         @Expose @SerializedName("Status") @Required EmailCheckResultStatus status,
         @Expose @SerializedName("TimeToExist") @Required long timeToExist,
         @Expose @SerializedName("RequestReference") @Required String requestReference,
-        @Expose @SerializedName("TimeOfInitialRequest") @Required long timeOfInitialRequest) {}
+        @Expose @SerializedName("TimeOfInitialRequest") @Required long timeOfInitialRequest,
+        @Expose @SerializedName("GovukSigninJourneyId") String govukSigninJourneyId,
+        @Expose @SerializedName("EmailCheckResponse") Object emailCheckResponse) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
@@ -2,7 +2,9 @@ package uk.gov.di.authentication.shared.entity;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.authentication.shared.converters.ObjectConverter;
 
 @DynamoDbBean
 public class EmailCheckResultStore {
@@ -11,11 +13,15 @@ public class EmailCheckResultStore {
     public static final String ATTRIBUTE_STATUS = "Status";
     public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
     public static final String ATTRIBUTE_REFERENCE_NUMBER = "ReferenceNumber";
+    public static final String ATTRIBUTE_GOVUK_SIGNIN_JOURNEY_ID = "GovukSigninJourneyId";
+    public static final String ATTRIBUTE_EMAIL_CHECK_RESPONSE = "EmailCheckResponse";
 
     private String email;
     private EmailCheckResultStatus status;
     private long timeToExist;
     private String referenceNumber;
+    private String govukSigninJourneyId;
+    private Object emailCheckResponse;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_EMAIL)
@@ -71,6 +77,35 @@ public class EmailCheckResultStore {
 
     public EmailCheckResultStore withReferenceNumber(String referenceNumber) {
         this.referenceNumber = referenceNumber;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_GOVUK_SIGNIN_JOURNEY_ID)
+    public String getGovukSigninJourneyId() {
+        return govukSigninJourneyId;
+    }
+
+    public void setGovukSigninJourneyId(String govukSigninJourneyId) {
+        this.govukSigninJourneyId = govukSigninJourneyId;
+    }
+
+    public EmailCheckResultStore withGovukSigninJourneyId(String govukSigninJourneyId) {
+        this.govukSigninJourneyId = govukSigninJourneyId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_EMAIL_CHECK_RESPONSE)
+    @DynamoDbConvertedBy(ObjectConverter.class)
+    public Object getEmailCheckResponse() {
+        return emailCheckResponse;
+    }
+
+    public void setEmailCheckResponse(Object emailCheckResponse) {
+        this.emailCheckResponse = emailCheckResponse;
+    }
+
+    public EmailCheckResultStore withEmailCheckResponse(Object emailCheckResponse) {
+        this.emailCheckResponse = emailCheckResponse;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CommonTestVariables.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CommonTestVariables.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.helpers;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
@@ -24,6 +25,7 @@ public class CommonTestVariables {
     public static final String CLIENT_NAME = "client-name";
     public static final String CLIENT_ID = "client-id";
     public static final String INTERNAL_COMMON_SUBJECT_ID = "urn:some:subject:identifier";
+    public static final String JOURNEY_ID = "journey-id";
     public static final Map<String, String> VALID_HEADERS =
             Map.ofEntries(
                     Map.entry(
@@ -67,4 +69,17 @@ public class CommonTestVariables {
                     UK_MOBILE_NUMBER,
                     PriorityIdentifier.BACKUP,
                     "backup-sms-identifier");
+
+    public static final Object EMAIL_CHECK_RESPONSE_TEST_DATA =
+            Map.of(
+                    "testString",
+                    "testValue1",
+                    "testNumber",
+                    456,
+                    "testBoolean",
+                    true,
+                    "testArray",
+                    List.of("testItem1", "testItem2"),
+                    "testObject",
+                    Map.of("testNestedString", "testNestedValue", "testNestedNumber", 789));
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
@@ -18,13 +18,27 @@ public class DynamoEmailCheckResultService extends BaseDynamoService<EmailCheckR
     }
 
     public void saveEmailCheckResult(
-            String email, EmailCheckResultStatus status, Long timeToExist, String referenceNumber) {
+            String email,
+            EmailCheckResultStatus status,
+            Long timeToExist,
+            String referenceNumber,
+            String govukSigninJourneyId,
+            Object emailCheckResponse) {
         var emailCheckResult =
                 new EmailCheckResultStore()
                         .withEmail(email)
                         .withStatus(status)
                         .withTimeToExist(timeToExist)
                         .withReferenceNumber(referenceNumber);
+
+        if (govukSigninJourneyId != null) {
+            emailCheckResult.withGovukSigninJourneyId(govukSigninJourneyId);
+        }
+
+        if (emailCheckResponse != null) {
+            emailCheckResult.withEmailCheckResponse(emailCheckResponse);
+        }
+
         put(emailCheckResult);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/converters/ObjectConverterTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/converters/ObjectConverterTest.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.shared.converters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectConverterTest {
+
+    private ObjectConverter objectConverter;
+
+    @BeforeEach
+    void setUp() {
+        objectConverter = new ObjectConverter();
+    }
+
+    @Test
+    void shouldTransformFromObjectToAttributeValue() {
+        Map<String, Object> testObject = Map.of("key", "value", "number", 123);
+
+        AttributeValue result = objectConverter.transformFrom(testObject);
+
+        String jsonString = result.s();
+        assertTrue(jsonString.contains("\"key\":\"value\""));
+        assertTrue(jsonString.contains("\"number\":123"));
+    }
+
+    @Test
+    void shouldTransformFromNullToNullAttributeValue() {
+        AttributeValue result = objectConverter.transformFrom(null);
+
+        assertTrue(result.nul());
+    }
+
+    @Test
+    void shouldTransformToObjectFromAttributeValue() {
+        AttributeValue attributeValue =
+                AttributeValue.builder().s("{\"key\":\"value\",\"number\":123}").build();
+
+        Object result = objectConverter.transformTo(attributeValue);
+
+        assertTrue(result instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals("value", resultMap.get("key"));
+        assertEquals(123.0, resultMap.get("number"));
+    }
+
+    @Test
+    void shouldTransformToNullFromNullAttributeValue() {
+        AttributeValue attributeValue = AttributeValue.builder().nul(true).build();
+
+        Object result = objectConverter.transformTo(attributeValue);
+
+        assertNull(result);
+    }
+
+    @Test
+    void shouldThrowRuntimeExceptionForInvalidJson() {
+        AttributeValue attributeValue = AttributeValue.builder().s("invalid json").build();
+
+        assertThrows(RuntimeException.class, () -> objectConverter.transformTo(attributeValue));
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -61,7 +61,9 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                         emailCheckResult.emailAddress(),
                         emailCheckResult.status(),
                         emailCheckResult.timeToExist(),
-                        emailCheckResult.requestReference());
+                        emailCheckResult.requestReference(),
+                        emailCheckResult.govukSigninJourneyId(),
+                        emailCheckResult.emailCheckResponse());
 
                 long currentTime = now().getTime();
                 long timeOfInitialRequest = emailCheckResult.timeOfInitialRequest();

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
@@ -17,8 +17,11 @@ import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -36,6 +39,8 @@ class EmailCheckResultWriterHandlerTest {
     private static ArgumentCaptor<EmailCheckResultStatus> statusCaptor;
     private static ArgumentCaptor<Long> timeToExistCaptor;
     private static ArgumentCaptor<String> referenceNumberCaptor;
+    private static ArgumentCaptor<String> govukSigninJourneyIdCaptor;
+    private static ArgumentCaptor<Object> emailCheckResponseCaptor;
     private EmailCheckResultWriterHandler handler;
 
     @BeforeAll
@@ -46,11 +51,14 @@ class EmailCheckResultWriterHandlerTest {
         statusCaptor = ArgumentCaptor.forClass(EmailCheckResultStatus.class);
         timeToExistCaptor = ArgumentCaptor.forClass(Long.class);
         referenceNumberCaptor = ArgumentCaptor.forClass(String.class);
+        govukSigninJourneyIdCaptor = ArgumentCaptor.forClass(String.class);
+        emailCheckResponseCaptor = ArgumentCaptor.forClass(Object.class);
     }
 
     @BeforeEach
     void setUp() {
         handler = new EmailCheckResultWriterHandler(dbMock, cloudWatchMock);
+        Mockito.reset(dbMock, cloudWatchMock);
     }
 
     @Test
@@ -66,12 +74,37 @@ class EmailCheckResultWriterHandlerTest {
             verify(dbMock)
                     .saveEmailCheckResult(
                             emailCaptor.capture(), statusCaptor.capture(),
-                            timeToExistCaptor.capture(), referenceNumberCaptor.capture());
+                            timeToExistCaptor.capture(), referenceNumberCaptor.capture(),
+                            govukSigninJourneyIdCaptor.capture(),
+                                    emailCheckResponseCaptor.capture());
 
             assertEquals(TEST_MSG_EMAIL, emailCaptor.getValue());
             assertEquals(emailCheckResultStatus, statusCaptor.getValue());
             assertEquals(TEST_MSG_TIME_TO_EXIST, timeToExistCaptor.getValue());
             assertEquals(TEST_MSG_REF_NUMBER, referenceNumberCaptor.getValue());
+            assertEquals("test-journey-id", govukSigninJourneyIdCaptor.getValue());
+
+            var capturedResponseSection = emailCheckResponseCaptor.getValue();
+            assertNotNull(capturedResponseSection);
+
+            var responseMap = (Map<?, ?>) capturedResponseSection;
+            assertEquals("testValue1", responseMap.get("testString"));
+            assertEquals(123, ((Number) responseMap.get("testNumber")).intValue());
+            assertEquals(true, responseMap.get("testBoolean"));
+
+            var testArray = (List<?>) responseMap.get("testArray");
+            assertEquals(2, testArray.size());
+            assertEquals("testItem1", testArray.get(0));
+            assertEquals("testItem2", testArray.get(1));
+
+            var testObject = (Map<?, ?>) responseMap.get("testObject");
+            assertEquals("testNestedValue", testObject.get("testNestedString"));
+            assertEquals(456, ((Number) testObject.get("testNestedNumber")).intValue());
+
+            var testChildObject = (Map<?, ?>) testObject.get("testChildObject");
+            assertEquals("testDeepValue", testChildObject.get("testDeepString"));
+            assertEquals(false, testChildObject.get("testDeepBoolean"));
+
             verify(cloudWatchMock).logEmailCheckDuration(REQUEST_DURATION);
         }
     }
@@ -89,6 +122,29 @@ class EmailCheckResultWriterHandlerTest {
                 thrown.getMessage());
     }
 
+    @Test
+    void shouldHandleV1Messages() {
+        SQSEvent event = getSqsEventWithV1Message();
+
+        handler.emailCheckResultWriterHandler(event);
+
+        verify(dbMock)
+                .saveEmailCheckResult(
+                        emailCaptor.capture(),
+                        statusCaptor.capture(),
+                        timeToExistCaptor.capture(),
+                        referenceNumberCaptor.capture(),
+                        govukSigninJourneyIdCaptor.capture(),
+                        emailCheckResponseCaptor.capture());
+
+        assertEquals(TEST_MSG_EMAIL, emailCaptor.getValue());
+        assertEquals(EmailCheckResultStatus.ALLOW, statusCaptor.getValue());
+        assertEquals(TEST_MSG_TIME_TO_EXIST, timeToExistCaptor.getValue());
+        assertEquals(TEST_MSG_REF_NUMBER, referenceNumberCaptor.getValue());
+        assertNull(govukSigninJourneyIdCaptor.getValue());
+        assertNull(emailCheckResponseCaptor.getValue());
+    }
+
     @NotNull
     private static SQSEvent getSqsEventWithSingleMessage(boolean doesMessageContainRequiredFields) {
         return getSqsEventWithSingleMessage(
@@ -104,7 +160,29 @@ class EmailCheckResultWriterHandlerTest {
         if (doesMessageContainRequiredFields) {
             sqsMessage.setBody(
                     String.format(
-                            "{ \"EmailAddress\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"RequestReference\": \"%s\", \"TimeOfInitialRequest\":%d }",
+                            """
+                            {
+                              "EmailAddress": "%s",
+                              "Status": "%s",
+                              "TimeToExist": "%d",
+                              "RequestReference": "%s",
+                              "TimeOfInitialRequest": %d,
+                              "GovukSigninJourneyId": "test-journey-id",
+                              "EmailCheckResponse": {
+                                "testString": "testValue1",
+                                "testNumber": 123,
+                                "testBoolean": true,
+                                "testArray": ["testItem1", "testItem2"],
+                                "testObject": {
+                                  "testNestedString": "testNestedValue",
+                                  "testNestedNumber": 456,
+                                  "testChildObject": {
+                                    "testDeepString": "testDeepValue",
+                                    "testDeepBoolean": false
+                                  }
+                                }
+                              }
+                            }""",
                             TEST_MSG_EMAIL,
                             status.toString(),
                             TEST_MSG_TIME_TO_EXIST,
@@ -113,6 +191,25 @@ class EmailCheckResultWriterHandlerTest {
         } else {
             sqsMessage.setBody(("{}"));
         }
+
+        List<SQSMessage> records = List.of(sqsMessage);
+        event.setRecords(records);
+        return event;
+    }
+
+    @NotNull
+    private static SQSEvent getSqsEventWithV1Message() {
+        SQSEvent event = new SQSEvent();
+        SQSMessage sqsMessage = new SQSMessage();
+
+        sqsMessage.setBody(
+                String.format(
+                        "{ \"EmailAddress\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"RequestReference\": \"%s\", \"TimeOfInitialRequest\":%d }",
+                        TEST_MSG_EMAIL,
+                        EmailCheckResultStatus.ALLOW.toString(),
+                        TEST_MSG_TIME_TO_EXIST,
+                        TEST_MSG_REF_NUMBER,
+                        REQUEST_DURATION));
 
         List<SQSMessage> records = List.of(sqsMessage);
         event.setRecords(records);


### PR DESCRIPTION
## What

Updates the email check result cache writing process to handle additional data sent by the service; journey IDs and structured response data required the later `_DECISION_USED` audit event.

## How to review

1. Code Review
1. Deploy along with matching PR from checking repo
1. Submit an email address though account creation
1. Wait and see in the cache DynamoDB table that a new record is added for the email with the expected properties and values

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.