### PR TITLE
ATO-1944: Emit new metric for valid /authorize request

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -427,6 +427,9 @@ public class AuthorisationHandler
             LOG.warn("Error recording state length, continuing: ", e);
         }
 
+        cloudwatchMetricsService.incrementCounter(
+                "orchAuthorizeRequestCount", Map.of("clientName", client.getClientName()));
+
         boolean reauthRequested =
                 getCustomParameterOpt(authRequest, "id_token_hint").isPresent()
                         && authRequest.getPrompt() != null

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -422,7 +422,7 @@ public class AuthorisationHandler
             cloudwatchMetricsService.putEmbeddedValue(
                     "rpStateLength",
                     authRequest.getState().getValue().length(),
-                    Map.of("clientId", authRequest.getClientID().getValue()));
+                    Map.of("clientId", clientId, "clientName", client.getClientName()));
         } catch (Exception e) {
             LOG.warn("Error recording state length, continuing: ", e);
         }


### PR DESCRIPTION
### Wider context of change

We would like to add a new dashboard to measure the requests to orch's /authorize endpoint by client name. 

### What’s changed

This PR emits a new cloudwatch metric `orchAuthorizeRequestCount`, every time a client makes a valid /authorize request. 

This PR also adds the `clientName` to the `rpStateLength` metric, as there was only the `clientId` on it before, which made it harder to identify which client was nearing the state length limit at a glance.

### Manual testing

Deployed to dev, saw the new metrics appear in cloudwatch

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
