### PR TITLE
ATO-1849: add JwksCache table and policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1031,7 +1031,69 @@ Resources:
         - Key: Name
           Value: DocAppCredentialTable
 
-  #endregion
+    #endregion
+
+    #region Jwks Cache DynamoDB Table
+
+  JwksCacheTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for Jwks Cache DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  JwksCacheTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-Jwks-Cache
+      AttributeDefinitions:
+        - AttributeName: JwksUrl
+          AttributeType: S
+        - AttributeName: KeyId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: JwksUrl
+          KeyType: HASH
+        - AttributeName: KeyId
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt JwksCacheTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: JwksCacheTable
+
+    #endregion
 
   #region Fetch JWKS Lambda
 
@@ -5999,6 +6061,30 @@ Resources:
             Action: lambda:InvokeFunction
             Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction:latest
 
+  JwksCacheTableReadWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowJwksCacheTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt JwksCacheTable.Arn
+          - Sid: AllowJwksCacheTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt JwksCacheTable.Arn
+          - Sid: AllowJwksCacheTableDecryptionAndEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+            Resource: !GetAtt JwksCacheTableEncryptionKey.Arn
   #endregion
 
   #region Slack notifications


### PR DESCRIPTION
### Wider context of change

We currently cache JWKS keys in memory, which works for when the lambda runs with provisioned concurrency at the moment. However, we would like to turn on SnapStart for lambdas to improve response time. The downside to this is that we wont be able to use an in-memory cache.

Instead of storing the cache in memory, we can use DynamoDB to store public keys we are caching. The logic for caching will remain mostly the same, and we can even delegate to DynamoDB to invalidate cache entries with a TTL (we are currently doing this manually).

### What’s changed

Created an empty dynamoDB table with JwksUrl partition key and KeyId as sort key. Also the read/write policy has been created.

### Manual testing

Ran on dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
