### PR TITLE
BAU: Result type for Orchestration

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/matchers/ResultMatcher.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/matchers/ResultMatcher.java
@@ -1,0 +1,54 @@
+package uk.gov.di.orchestration.sharedtest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.opentest4j.AssertionFailedError;
+import uk.gov.di.orchestration.result.Err;
+import uk.gov.di.orchestration.result.Ok;
+import uk.gov.di.orchestration.result.Result;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class ResultMatcher<T, U> extends TypeSafeMatcher<Result<T, U>> {
+
+    private final Predicate<T> okPredicate;
+    private final Predicate<U> errPredicate;
+
+    private ResultMatcher(Predicate<T> okPredicate, Predicate<U> errPredicate) {
+        this.okPredicate = okPredicate;
+        this.errPredicate = errPredicate;
+    }
+
+    @Override
+    protected boolean matchesSafely(Result<T, U> item) {
+        if (item instanceof Ok<T, U> ok) {
+            return okPredicate.test(ok.value());
+        }
+
+        if (item instanceof Err<T, U> err) {
+            return errPredicate.test(err.value());
+        }
+
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {}
+
+    public static <T, U> ResultMatcher<T, U> okWithValue(T value) {
+        return new ResultMatcher<>(
+                (actual) -> Objects.equals(value, actual), failWithMessage("Expected Ok, was Err"));
+    }
+
+    public static <T, U> ResultMatcher<T, U> errWithValue(T value) {
+        return new ResultMatcher<>(
+                failWithMessage("Expected Err, was Ok"), (actual) -> Objects.equals(value, actual));
+    }
+
+    private static <T> Predicate<T> failWithMessage(String message) {
+        return (input) -> {
+            throw new AssertionFailedError(message);
+        };
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Err.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Err.java
@@ -1,0 +1,15 @@
+package uk.gov.di.orchestration.result;
+
+import java.util.function.Function;
+
+public record Err<T, E>(E value) implements Result<T, E> {
+    @Override
+    public <U> Result<U, E> map(Function<T, U> mapper) {
+        return new Err<>(value);
+    }
+
+    @Override
+    public <U> U resolve(Function<T, U> okMap, Function<E, U> errMap) {
+        return errMap.apply(value);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Ok.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Ok.java
@@ -1,0 +1,15 @@
+package uk.gov.di.orchestration.result;
+
+import java.util.function.Function;
+
+public record Ok<T, E>(T value) implements Result<T, E> {
+    @Override
+    public <U> Result<U, E> map(Function<T, U> mapper) {
+        return new Ok<>(mapper.apply(value));
+    }
+
+    @Override
+    public <U> U resolve(Function<T, U> okMap, Function<E, U> errMap) {
+        return okMap.apply(value);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Result.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/result/Result.java
@@ -1,0 +1,18 @@
+package uk.gov.di.orchestration.result;
+
+import java.util.function.Function;
+
+public sealed interface Result<T, E> permits Ok, Err {
+
+    static <T, E> Result<T, E> ok(T value) {
+        return new Ok<>(value);
+    }
+
+    static <T, E> Result<T, E> err(E value) {
+        return new Err<>(value);
+    }
+
+    <U> Result<U, E> map(Function<T, U> mapper);
+
+    <U> U resolve(Function<T, U> okMap, Function<E, U> errMap);
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
@@ -1,0 +1,30 @@
+package uk.gov.di.orchestration.result;
+
+import org.junit.jupiter.api.Test;
+
+import static java.util.function.Function.identity;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ResultTest {
+
+    @Test
+    void okayResolvesValue() {
+        var ok =
+                Result.<String, String>ok("hello")
+                        .map(String::toUpperCase)
+                        .resolve(identity(), (x) -> "");
+
+        assertThat(ok, is("HELLO"));
+    }
+
+    @Test
+    void errResolvesValueWithoutApplyingMap() {
+        var ok =
+                Result.<String, String>err("goodbye")
+                        .map(String::toUpperCase)
+                        .resolve((x) -> "", identity());
+
+        assertThat(ok, is("goodbye"));
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
@@ -2,29 +2,24 @@ package uk.gov.di.orchestration.result;
 
 import org.junit.jupiter.api.Test;
 
-import static java.util.function.Function.identity;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.orchestration.sharedtest.matchers.ResultMatcher.errWithValue;
+import static uk.gov.di.orchestration.sharedtest.matchers.ResultMatcher.okWithValue;
 
 class ResultTest {
 
     @Test
     void okayResolvesValue() {
-        var ok =
-                Result.<String, String>ok("hello")
-                        .map(String::toUpperCase)
-                        .resolve(identity(), (x) -> "");
+        var ok = Result.<String, String>ok("hello").map(String::toUpperCase);
 
-        assertThat(ok, is("HELLO"));
+        assertThat(ok, is(okWithValue("HELLO")));
     }
 
     @Test
     void errResolvesValueWithoutApplyingMap() {
-        var ok =
-                Result.<String, String>err("goodbye")
-                        .map(String::toUpperCase)
-                        .resolve((x) -> "", identity());
+        var err = Result.<String, String>err("hello").map(String::toUpperCase);
 
-        assertThat(ok, is("goodbye"));
+        assertThat(err, is(errWithValue("hello")));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/result/ResultTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.result;
 
 import org.junit.jupiter.api.Test;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.orchestration.sharedtest.matchers.ResultMatcher.errWithValue;
@@ -10,16 +11,36 @@ import static uk.gov.di.orchestration.sharedtest.matchers.ResultMatcher.okWithVa
 class ResultTest {
 
     @Test
-    void okayResolvesValue() {
+    void mapAppliesToOkValue() {
         var ok = Result.<String, String>ok("hello").map(String::toUpperCase);
 
         assertThat(ok, is(okWithValue("HELLO")));
     }
 
     @Test
-    void errResolvesValueWithoutApplyingMap() {
+    void mapDoesNotApplyToErrValue() {
         var err = Result.<String, String>err("hello").map(String::toUpperCase);
 
         assertThat(err, is(errWithValue("hello")));
+    }
+
+    @Test
+    void resolveAppliesToOkValue() {
+        var ok =
+                Result.<String, String>ok("hello")
+                        .map(String::toUpperCase)
+                        .resolve(identity(), identity());
+
+        assertThat(ok, is("HELLO"));
+    }
+
+    @Test
+    void resolveAppliesToErrValue() {
+        var err =
+                Result.<String, String>err("hello")
+                        .map(String::toUpperCase)
+                        .resolve(identity(), identity());
+
+        assertThat(err, is("hello"));
     }
 }


### PR DESCRIPTION
This introduces a `Result<T,U>` type with accompanying test and matcher. We will expand on this in the future as we wire it into our handlers.

