### PR TITLE
ATO-1878: remove old roles

### DIFF
--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -1,4 +1,3 @@
-# ATO-1878: Duplicate role so we can combine policies
 module "frontend_api_verify_code_role_with_combined_auth_attempts_policy" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -27,35 +26,6 @@ module "frontend_api_verify_code_role_with_combined_auth_attempts_policy" {
   }
 }
 
-module "frontend_api_verify_code_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "frontend-api-verify-code-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_write_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
-    aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
-    aws_iam_policy.dynamo_auth_session_read_policy.arn,
-    aws_iam_policy.dynamo_auth_session_write_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
-  ]
-  extra_tags = {
-    Service = "verify-code"
-  }
-}
 
 module "verify_code" {
   source = "../modules/endpoint-module-v2"

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -1,4 +1,3 @@
-# ATO-1878: Duplicate role so we can combine policies
 module "frontend_api_verify_mfa_code_role_with_combined_auth_attempts_policy" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -13,36 +12,6 @@ module "frontend_api_verify_mfa_code_role_with_combined_auth_attempts_policy" {
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_read_write_delete_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.dynamo_auth_session_read_write_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn,
-    local.experian_phone_check_sqs_queue_policy_arn
-  ]
-  extra_tags = {
-    Service = "verify-mfa-code"
-  }
-}
-
-module "frontend_api_verify_mfa_code_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "frontend-api-verify-mfa-code-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_write_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
-    aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_write_policy.arn,


### PR DESCRIPTION
### Wider context of change: 

AWS IAM has a hard limit of [20 policies per role](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#:~:text=Managed%20policies%20per%20role). The verify code and verifyMfaCode handlers are at this limit, and we need to free up some slots for future work. To achieve this we can combine the `authentication_attempts-*` policies into one policy. This role starts that by duplicating the original role and then combining these policies into one. This is the first part of a series of changes - done in this order to ensure no re-ordering of policies in an existing role and that this change is ZDD compatible .

### What’s changed:
- Removes unused role

### Manual testing:
- Deploy to sandpit:
- Saw old role removed

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
