### PR TITLE
ATO-1945: Add isIdentityJourney dimension to existing metric

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -430,13 +430,20 @@ public class AuthorisationHandler
         var isDocAppJourney =
                 DocAppUserHelper.isDocCheckingAppUser(
                         authRequest.toParameters(), Optional.of(client));
+        var isIdentityJourney =
+                identityRequired(
+                        authRequest.toParameters(),
+                        client.isIdentityVerificationSupported(),
+                        configurationService.isIdentityEnabled());
         cloudwatchMetricsService.incrementCounter(
                 "orchAuthorizeRequestCount",
                 Map.of(
                         "clientName",
                         client.getClientName(),
                         "isDocAppJourney",
-                        Boolean.toString(isDocAppJourney)));
+                        Boolean.toString(isDocAppJourney),
+                        "isIdentityJourney",
+                        Boolean.toString(isIdentityJourney)));
 
         boolean reauthRequested =
                 getCustomParameterOpt(authRequest, "id_token_hint").isPresent()


### PR DESCRIPTION
### Wider context of change

We recently added a metric to measure when an RP makes a valid authorize request. The next 2 graphs we want to add is for number of successful auth and number of successful identity journeys. We have no way of distinguishing between a request for auth or a request for identity at the moment, so we need to add a new dimension to the metric we added in the previous PR. 

### What’s changed

This PR adds the `isIdentityJourney` dimension to the `orchAuthorizeRequestCount` metric.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

