### PR TITLE
BAU: downgrade Jetty for local running

### DIFF
--- a/.github/workflows/dependency-review-on-pr.yml
+++ b/.github/workflows/dependency-review-on-pr.yml
@@ -21,3 +21,7 @@ jobs:
 
       - name: Perform dependency review
         uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
+        with:
+          # These exceptions should be rare and well justified
+          # - GHSA-qh8g-58pp-2wxh see https://github.com/govuk-one-login/authentication-api/pull/7105
+          allow-ghsas: GHSA-qh8g-58pp-2wxh

--- a/build.gradle
+++ b/build.gradle
@@ -168,12 +168,8 @@ subprojects {
                 }
 
                 // Jetty constraints
-                add(conf.name, 'org.eclipse.jetty.http2:jetty-http2-common:[12.0.17,12.1.0)') {
-                    because 'CVE-2025-1948 is fixed in org.eclipse.jetty.http2:jetty-http2-common:12.0.17 and higher'
-                }
-
-                add(conf.name, 'org.eclipse.jetty:jetty-http:[12.0.12,)') {
-                    because 'CVE-2024-6763 is fixed in org.eclipse.jetty:jetty-http:12.0.12 and higher'
+                add(conf.name, 'org.eclipse.jetty.http2:jetty-http2-common:[12.0.25,12.1.0)') {
+                    because 'CVE-2025-5115 is fixed in org.eclipse.jetty.http2:jetty-http2-common:12.0.25 and higher'
                 }
 
                 // Jackson constraints


### PR DESCRIPTION
## What

Jetty is only used by local running, but must be pinned to v11 because Javalin does not yet have support for v12. See https://github.com/javalin/javalin/issues/2067 - it is planned for Javalin 7, but there is no clear release date.

It is not used in any deployed services and does not expose us to risk when used locally, so the CVE can be safely dismissed:
- CVE-2024-6763 could cause misinterpretation of maliciously crafted URLs

If additional/higher severity CVEs appear, we may need to consider migrating to a different framework.