### PR TITLE
Revert "ATO-1946: Add clientName to token metric"

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -62,7 +62,6 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_GRANT_CODE;
 import static java.lang.String.format;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT;
-import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetrics.SUCCESSFUL_TOKEN_ISSUED;
 import static uk.gov.di.orchestration.shared.domain.TokenGeneratedAuditableEvent.OIDC_TOKEN_GENERATED;
@@ -284,8 +283,7 @@ public class TokenHandler
                 new HashMap<>(
                         Map.of(
                                 ENVIRONMENT.getValue(), configurationService.getEnvironment(),
-                                CLIENT.getValue(), clientRegistry.getClientID(),
-                                CLIENT_NAME.getValue(), clientRegistry.getClientName()));
+                                CLIENT.getValue(), clientRegistry.getClientID()));
         cloudwatchMetricsService.incrementCounter(SUCCESSFUL_TOKEN_ISSUED.getValue(), dimensions);
 
         LOG.info("Successfully generated tokens");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
-import uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
@@ -258,9 +257,7 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                CLIENT_ID,
-                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                CLIENT_NAME));
+                                CLIENT_ID));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -393,9 +390,7 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                CLIENT_ID,
-                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                CLIENT_NAME));
+                                CLIENT_ID));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -801,9 +796,7 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID,
-                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                    CLIENT_NAME));
+                                    CLIENT_ID));
             verify(auditService)
                     .submitAuditEvent(
                             OIDC_TOKEN_GENERATED,
@@ -850,9 +843,7 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID,
-                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                    CLIENT_NAME));
+                                    CLIENT_ID));
             verify(auditService, never())
                     .submitAuditEvent(eq(OIDC_TOKEN_GENERATED), anyString(), any());
 
@@ -1122,9 +1113,7 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID,
-                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                    CLIENT_NAME));
+                                    CLIENT_ID));
             verify(auditService)
                     .submitAuditEvent(
                             OIDC_TOKEN_GENERATED,
@@ -1264,9 +1253,7 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                DOC_APP_CLIENT_ID.getValue(),
-                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
-                                CLIENT_NAME));
+                                DOC_APP_CLIENT_ID.getValue()));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -1542,7 +1529,7 @@ public class TokenHandlerTest {
     private ClientRegistry generateClientRegistry(KeyPair keyPair, String clientID) {
         return new ClientRegistry()
                 .withClientID(clientID)
-                .withClientName(CLIENT_NAME)
+                .withClientName("test-client")
                 .withRedirectUrls(singletonList(REDIRECT_URI))
                 .withScopes(SCOPES.toStringList())
                 .withContacts(singletonList(TEST_EMAIL))


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#7091

Adding the clientName dimension to the successfulTokenIssued metric broke some RP Dashboards.
After reverting this change, if necessary we'll add a new metric.