### PR TITLE
ATO-1851: set JWKSCache

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -34,6 +34,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
+import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
@@ -121,6 +122,7 @@ public class DocAppCallbackHandler
                         configurationService,
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService),
+                        new JwksCacheService(configurationService),
                         new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
@@ -145,6 +147,7 @@ public class DocAppCallbackHandler
                         configurationService,
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService),
+                        new JwksCacheService(configurationService),
                         new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -35,6 +35,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -75,7 +76,7 @@ class DocAppCriServiceTest {
     private DocAppCriService docAppCriService;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws MalformedURLException {
         docAppCriService = new DocAppCriService(configService, kmsService, docAppCriApi);
         when(docAppCriApi.tokenURI()).thenReturn(TOKEN_URI);
         when(configService.getDocAppAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
@@ -83,6 +84,7 @@ class DocAppCriServiceTest {
         when(configService.getDocAppAuthorisationCallbackURI()).thenReturn(REDIRECT_URI);
         when(configService.getEnvironment()).thenReturn("test");
         when(configService.getDocAppJwksURI()).thenReturn(DOC_APP_JWKS_URI);
+        when(configService.getDocAppJwksUrl()).thenReturn(DOC_APP_JWKS_URI.toURL());
     }
 
     @Nested

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -52,6 +52,7 @@ import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthExternalApiStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.JwksCacheExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.JwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
@@ -143,6 +144,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     @RegisterExtension public static final JwksExtension ipvJwksExtension = new JwksExtension();
+
+    @RegisterExtension
+    public static final JwksCacheExtension jwksCacheExtension = new JwksCacheExtension();
 
     protected static ConfigurationService configurationService;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -47,6 +47,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.sharedtest.extensions.JwksCacheExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.JwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
@@ -57,6 +58,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.KeyPair;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
@@ -124,6 +126,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @RegisterExtension public static final JwksExtension jwksExtension = new JwksExtension();
 
     @RegisterExtension
+    public static final JwksCacheExtension jwksCacheExtension = new JwksCacheExtension();
+
+    @RegisterExtension
     public static final KmsKeyExtension tokenSigningKey = new KmsKeyExtension("token-signing-key");
 
     @RegisterExtension
@@ -171,6 +176,21 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .setScheme("http")
                                 .build();
                     } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                public URL getDocAppJwksUrl() {
+                    try {
+                        return new URIBuilder()
+                                .setHost("localhost")
+                                .setPort(jwksExtension.getHttpPort())
+                                .setPath("/.well-known/jwks.json")
+                                .setScheme("http")
+                                .build()
+                                .toURL();
+                    } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
                 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -73,6 +73,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
@@ -183,6 +184,7 @@ public class AuthorisationHandler
         this.configurationService = configurationService;
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var jwksService = new JwksService(configurationService, kmsConnectionService);
+        var jwksCacheService = new JwksCacheService(configurationService);
         var stateStorageService = new StateStorageService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
         this.crossBrowserOrchestrationService =
@@ -205,6 +207,7 @@ public class AuthorisationHandler
                         configurationService,
                         kmsConnectionService,
                         jwksService,
+                        jwksCacheService,
                         stateStorageService);
         var cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
         this.cloudwatchMetricsService = cloudwatchMetricService;
@@ -232,12 +235,14 @@ public class AuthorisationHandler
         this.clientService = new DynamoClientService(configurationService);
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var jwksService = new JwksService(configurationService, kmsConnectionService);
+        var jwksCacheService = new JwksCacheService(configurationService);
         var stateStorageService = new StateStorageService(configurationService);
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
                         kmsConnectionService,
                         jwksService,
+                        jwksCacheService,
                         stateStorageService);
         var cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
         this.cloudwatchMetricsService = cloudwatchMetricService;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -49,6 +49,7 @@ public class DocAppAuthorisationService {
     private final ConfigurationService configurationService;
     private final KmsConnectionService kmsConnectionService;
     private final JwksService jwksService;
+    private final JwksCacheService jwksCacheService;
     private final StateStorageService stateStorageService;
     private final NowHelper.NowClock nowClock;
     public static final String STATE_STORAGE_PREFIX = "state:";
@@ -60,11 +61,13 @@ public class DocAppAuthorisationService {
             ConfigurationService configurationService,
             KmsConnectionService kmsConnectionService,
             JwksService jwksService,
+            JwksCacheService jwksCacheService,
             StateStorageService stateStorageService,
             Clock clock) {
         this.configurationService = configurationService;
         this.kmsConnectionService = kmsConnectionService;
         this.jwksService = jwksService;
+        this.jwksCacheService = jwksCacheService;
         this.stateStorageService = stateStorageService;
         this.nowClock = new NowHelper.NowClock(clock);
     }
@@ -73,10 +76,12 @@ public class DocAppAuthorisationService {
             ConfigurationService configurationService,
             KmsConnectionService kmsConnectionService,
             JwksService jwksService,
+            JwksCacheService jwksCacheService,
             StateStorageService stateStorageService) {
         this.configurationService = configurationService;
         this.kmsConnectionService = kmsConnectionService;
         this.jwksService = jwksService;
+        this.jwksCacheService = jwksCacheService;
         this.stateStorageService = stateStorageService;
         this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
     }
@@ -243,7 +248,9 @@ public class DocAppAuthorisationService {
     private JWK getPublicEncryptionKey() {
         try {
             LOG.info("Getting Doc App Auth Encryption Public Key via JWKS endpoint");
-            return jwksService.getDocAppJwk();
+            var cachedDocAppJwk = jwksService.getDocAppJwk();
+            jwksCacheService.getOrGenerateDocAppJwksCacheItem();
+            return cachedDocAppJwk;
         } catch (MalformedURLException e) {
             LOG.error("Invalid JWKs URL", e);
             throw new DocAppAuthorisationServiceException(e);

--- a/template.yaml
+++ b/template.yaml
@@ -2094,8 +2094,7 @@ Resources:
         - !Ref IdTokenKmsAccessPolicy
         - !Ref IdTokenKmsRsaAccessPolicy
         - !Ref InvokeFetchJwksHandlerPolicy
-        - !Ref RpPublicKeyCacheTableReadAccessPolicy
-        - !Ref RpPublicKeyCacheTableWriteAccessPolicy
+        - !Ref RpPublicKeyCacheTableReadWriteAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
         - !Ref OrchAuthCodeTableReadAccessPolicy
@@ -2876,6 +2875,7 @@ Resources:
         - !Ref ClientSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
         - !Ref StateStorageTableReadWriteAccessPolicy
+        - !Ref JwksCacheTableReadWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3511,12 +3511,12 @@ Resources:
         - !Ref AuthPublicEncryptionKeyAccessPolicy
         - !Ref IpvCapacityAccessPolicy
         - !Ref InvokeFetchJwksHandlerPolicy
-        - !Ref RpPublicKeyCacheTableWriteAccessPolicy
-        - !Ref RpPublicKeyCacheTableReadAccessPolicy
+        - !Ref RpPublicKeyCacheTableReadWriteAccessPolicy
         - !Ref OrchSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
         - !Ref StateStorageTableWriteAccessPolicy
         - !Ref ClientRateLimitTableReadWriteAccessPolicy
+        - !Ref JwksCacheTableReadWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -5736,7 +5736,7 @@ Resources:
               - kms:DescribeKey
             Resource: !GetAtt DocAppCredentialTableEncryptionKey.Arn
 
-  RpPublicKeyCacheTableReadAccessPolicy:
+  RpPublicKeyCacheTableReadWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
@@ -5748,23 +5748,6 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt RpPublicKeyCacheTable.Arn
-          - Sid: AllowRpPublicKeyCacheTableKeyAccess
-            Effect: Allow
-            Action:
-              - kms:Encrypt
-              - kms:Decrypt
-              - kms:ReEncrypt*
-              - kms:GenerateDataKey*
-              - kms:CreateGrant
-              - kms:DescribeKey
-            Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
-
-  RpPublicKeyCacheTableWriteAccessPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
           - Sid: AllowRpPublicKeyCacheTableWriteAccess
             Effect: Allow
             Action:
@@ -6162,7 +6145,11 @@ Resources:
             Effect: Allow
             Action:
               - dynamodb:PutItem
-              - dynamodb:UpdateItem
+            Resource: !GetAtt JwksCacheTable.Arn
+          - Sid: AllowJwksCacheTableIndexQueryAccess
+            Effect: Allow
+            Action:
+              - dynamodb:Query
             Resource: !GetAtt JwksCacheTable.Arn
           - Sid: AllowJwksCacheTableDecryptionAndEncryption
             Effect: Allow


### PR DESCRIPTION
### Wider context of change

We currently cache JWKS keys in memory, which works for when the lambda runs with provisioned concurrency at the moment. However, we would like to turn on SnapStart for lambdas to improve response time. The downside to this is that we wont be able to use an in-memory cache.

Instead of storing the cache in memory, we can use DynamoDB to store public keys we are caching. The logic for caching will remain mostly the same, and we can even delegate to DynamoDB to invalidate cache entries with a TTL (we are currently doing this manually).

### What’s changed

Setting the JWKSCacheItem and added logs to check.

### Manual testing

Tested DocApp journey in dev. TODO: test IPV journey in dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
