### PR TITLE
AUT-4714: Increase memory for the manually-delete-account lambda

### DIFF
--- a/ci/terraform/account-management/manually-delete-account.tf
+++ b/ci/terraform/account-management/manually-delete-account.tf
@@ -21,12 +21,13 @@ module "account_management_manually_delete_account_role" {
 }
 
 resource "aws_lambda_function" "manually_delete_account_lambda" {
-  function_name = replace("${var.environment}-manually-delete-account-lambda", ".", "")
-  role          = module.account_management_manually_delete_account_role.arn
-  handler       = "uk.gov.di.accountmanagement.lambda.ManuallyDeleteAccountHandler::handleRequest"
-  timeout       = 30
-  publish       = true
-
+  function_name                  = replace("${var.environment}-manually-delete-account-lambda", ".", "")
+  role                           = module.account_management_manually_delete_account_role.arn
+  handler                        = "uk.gov.di.accountmanagement.lambda.ManuallyDeleteAccountHandler::handleRequest"
+  timeout                        = 30
+  publish                        = true
+  memory_size                    = 1536
+  reserved_concurrent_executions = 1
 
   s3_bucket               = aws_s3_bucket.source_bucket.bucket
   s3_key                  = aws_s3_object.account_management_api_release_zip.key


### PR DESCRIPTION
## What

Increase memory for the manually-delete-account lambda

Some deletions failed due to out of memory errors

## How to review

1. Code Review
1. Deploy to a test environment with `./deploy-authdevs.sh -b -a`
1. Go into the lambda console and find the lambda so it can be tested
1. Follow the [instructions](https://govukverify.atlassian.net/wiki/spaces/OPS/pages/5032673281/TSD+Account+Deletion+Process#Part-Three---TSD-Engineer-processing-account-deletions) to test deleting an account 

Tested in authdev1

