### PR TITLE
ATO-1975: Enable strongly consistent reads in all orch environments

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataService.java
@@ -32,18 +32,15 @@ public class ClientRateLimitDataService extends BaseDynamoService<SlidingWindowD
     }
 
     public ClientRateLimitDataService(
-            DynamoDbClient dynamoDbClient,
-            DynamoDbTable<SlidingWindowData> dynamoDbTable,
-            ConfigurationService configurationService) {
-        this(dynamoDbClient, dynamoDbTable, configurationService, Clock.systemUTC());
+            DynamoDbClient dynamoDbClient, DynamoDbTable<SlidingWindowData> dynamoDbTable) {
+        this(dynamoDbClient, dynamoDbTable, Clock.systemUTC());
     }
 
     public ClientRateLimitDataService(
             DynamoDbClient dynamoDbClient,
             DynamoDbTable<SlidingWindowData> dynamoDbTable,
-            ConfigurationService configurationService,
             Clock clock) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.nowClock = new NowHelper.NowClock(clock);
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.oidc.entity.SlidingWindowData;
 import uk.gov.di.authentication.oidc.exceptions.ClientRateLimitDataException;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -39,13 +38,11 @@ class ClientRateLimitDataServiceTest {
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private final DynamoDbTable<SlidingWindowData> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private ClientRateLimitDataService clientRateLimitDataService;
 
     @BeforeEach
     void setup() {
-        clientRateLimitDataService =
-                new ClientRateLimitDataService(dynamoDbClient, table, configurationService);
+        clientRateLimitDataService = new ClientRateLimitDataService(dynamoDbClient, table);
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -100,11 +100,7 @@ public class BaseDynamoService<T> {
                 QueryConditional.keyEqualTo(Key.builder().partitionValue(partition).build());
         return dynamoTable
                 .index(indexName)
-                .query(
-                        QueryEnhancedRequest.builder()
-                                .consistentRead(true)
-                                .queryConditional(queryConditional)
-                                .build())
+                .query(QueryEnhancedRequest.builder().queryConditional(queryConditional).build())
                 .stream()
                 .flatMap(page -> page.items().stream())
                 .toList();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -1,7 +1,5 @@
 package uk.gov.di.orchestration.shared.services;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -23,10 +21,8 @@ import java.util.stream.Stream;
 import static uk.gov.di.orchestration.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
 public class BaseDynamoService<T> {
-    private static final Logger LOG = LogManager.getLogger(BaseDynamoService.class);
     private final DynamoDbTable<T> dynamoTable;
     private final DynamoDbClient client;
-    private final boolean useConsistentReads;
 
     public BaseDynamoService(
             Class<T> objectClass, String table, ConfigurationService configurationService) {
@@ -45,23 +41,14 @@ public class BaseDynamoService<T> {
         client = createDynamoClient(configurationService);
         var enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
         dynamoTable = enhancedClient.table(tableName, TableSchema.fromBean(objectClass));
-        useConsistentReads = configurationService.isUseStronglyConsistentReads();
-        LOG.info(
-                "Is using strongly consistent reads for table \"{}\": {}",
-                table,
-                useConsistentReads);
         if (!isTableInOrchAccount) {
             warmUp();
         }
     }
 
-    public BaseDynamoService(
-            DynamoDbTable<T> dynamoTable,
-            DynamoDbClient client,
-            ConfigurationService configurationService) {
+    public BaseDynamoService(DynamoDbTable<T> dynamoTable, DynamoDbClient client) {
         this.dynamoTable = dynamoTable;
         this.client = client;
-        this.useConsistentReads = configurationService.isUseStronglyConsistentReads();
     }
 
     public void update(T item) {
@@ -83,10 +70,7 @@ public class BaseDynamoService<T> {
     private Optional<T> get(Key key) {
         return Optional.ofNullable(
                 dynamoTable.getItem(
-                        GetItemEnhancedRequest.builder()
-                                .consistentRead(useConsistentReads)
-                                .key(key)
-                                .build()));
+                        GetItemEnhancedRequest.builder().consistentRead(true).key(key).build()));
     }
 
     public Optional<T> getWithConsistentRead(String partition) {
@@ -118,7 +102,7 @@ public class BaseDynamoService<T> {
                 .index(indexName)
                 .query(
                         QueryEnhancedRequest.builder()
-                                .consistentRead(useConsistentReads)
+                                .consistentRead(true)
                                 .queryConditional(queryConditional)
                                 .build())
                 .stream()
@@ -140,7 +124,7 @@ public class BaseDynamoService<T> {
         return dynamoTable
                 .query(
                         QueryEnhancedRequest.builder()
-                                .consistentRead(useConsistentReads)
+                                .consistentRead(true)
                                 .queryConditional(queryConditional)
                                 .build())
                 .stream()

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -414,10 +414,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
-    public boolean isUseStronglyConsistentReads() {
-        return getFlagOrFalse("USE_STRONGLY_CONSISTENT_READS");
-    }
-
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksCacheService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksCacheService.java
@@ -39,7 +39,7 @@ public class JwksCacheService extends BaseDynamoService<JwksCacheItem> {
             DynamoDbTable<JwksCacheItem> dynamoDbTable,
             ConfigurationService configurationService,
             Clock clock) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getJwkCacheExpirationInSeconds();
         this.configurationService = configurationService;
         this.nowClock = new NowHelper.NowClock(clock);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -106,28 +106,10 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
 
         if (authCodeItem.isEmpty()) {
             LOG.info(
-                    "No orch auth code item found. Retrying with strongly consistent reads. Code: {}",
+                    "No orch auth code item found with strongly consistent reads enabled. Code: {}",
                     code);
 
-            try {
-                authCodeItem = getWithConsistentRead(code);
-            } catch (Exception e) {
-                logAndThrowOrchAuthCodeException(
-                        String.format(
-                                "Failed to get orch auth code item with strongly consistent reads. Code: %s",
-                                code),
-                        e);
-            }
-
-            if (authCodeItem.isEmpty()) {
-                LOG.info(
-                        "No orch auth code item found on retry with strongly consistent reads enabled. No further retries, returning. Code: {}",
-                        code);
-
-                return Optional.empty();
-            }
-
-            LOG.info("Orch auth code item found on retry with strongly consistent reads enabled.");
+            return Optional.empty();
         }
 
         Optional<OrchAuthCodeItem> unusedAuthCodeItem = authCodeItem.filter(c -> !c.getIsUsed());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -40,7 +40,7 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
             DynamoDbTable<OrchAuthCodeItem> dynamoDbTable,
             ConfigurationService configurationService,
             Clock clock) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getAuthCodeExpiry();
         this.nowClock = new NowHelper.NowClock(clock);
         this.objectMapper = SerializationService.getInstance();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
@@ -42,7 +42,7 @@ public class OrchClientSessionService extends BaseDynamoService<OrchClientSessio
             DynamoDbClient dynamoDbClient,
             DynamoDbTable<OrchClientSessionItem> dynamoDbTable,
             ConfigurationService configurationService) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.configurationService = configurationService;
         this.timeToLive = configurationService.getSessionExpiry();
         this.nowClock = new NowClock(Clock.systemUTC());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -37,7 +37,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
             DynamoDbClient dynamoDbClient,
             DynamoDbTable<OrchSessionItem> dynamoDbTable,
             ConfigurationService configurationService) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getSessionExpiry();
         this.configurationService = configurationService;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/StateStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/StateStorageService.java
@@ -40,7 +40,7 @@ public class StateStorageService extends BaseDynamoService<StateItem> {
             DynamoDbTable<StateItem> dynamoDbTable,
             ConfigurationService configurationService,
             Clock clock) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+        super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getSessionExpiry();
         this.nowClock = new NowHelper.NowClock(clock);
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -31,7 +31,7 @@ class OrchClientSessionServiceTest {
     private static final GetItemEnhancedRequest CLIENT_SESSION_GET_REQUEST =
             GetItemEnhancedRequest.builder()
                     .key(CLIENT_SESSION_ID_PARTITION_KEY)
-                    .consistentRead(false)
+                    .consistentRead(true)
                     .build();
     private final DynamoDbTable<OrchClientSessionItem> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -38,7 +38,7 @@ class OrchSessionServiceTest {
     private static final GetItemEnhancedRequest SESSION_GET_REQUEST =
             GetItemEnhancedRequest.builder()
                     .key(SESSION_ID_PARTITION_KEY)
-                    .consistentRead(false)
+                    .consistentRead(true)
                     .build();
     private final DynamoDbTable<OrchSessionItem> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
@@ -31,7 +31,7 @@ class StateStorageServiceTest {
     private static final Key STATE_PARTITION_KEY =
             Key.builder().partitionValue(PREFIXED_SESSION_ID).build();
     private static final GetItemEnhancedRequest STATE_GET_REQUEST =
-            GetItemEnhancedRequest.builder().key(STATE_PARTITION_KEY).consistentRead(false).build();
+            GetItemEnhancedRequest.builder().key(STATE_PARTITION_KEY).consistentRead(true).build();
     private final DynamoDbTable<StateItem> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);

--- a/template.yaml
+++ b/template.yaml
@@ -83,12 +83,6 @@ Conditions:
       !Equals [!Ref Environment, production],
     ]
   IsProduction: !Equals [!Ref Environment, production]
-  UseStronglyConsistentReads:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-    ]
   UseGlobalLogoutTxmaQueue: !Equals [staging, !Ref Environment]
 
 Mappings:
@@ -1879,10 +1873,6 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref OrchDocAppCredentialTableReadAccessPolicy
         - !Ref OrchDocAppCredentialTableWriteAccessPolicy
@@ -2083,10 +2073,6 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -2299,10 +2285,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -2472,10 +2454,6 @@ Resources:
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref OrchSessionTableReadAndDeleteAccessPolicy
         - !Ref ClientSessionTableReadAndDeleteAccessPolicy
@@ -2859,10 +2837,6 @@ Resources:
           SEND_STORAGE_TOKEN_TO_IPV_ENABLED: true
           IPV_JWK_CACHE_EXPIRATION_IN_SECONDS: 300
           JWK_CACHE_EXPIRATION_IN_SECONDS: 300
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref AuthUserInfoTableReadWriteAccessPolicy
@@ -3494,10 +3468,6 @@ Resources:
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
           DOC_APP_JWK_CACHE_EXPIRATION_IN_SECONDS: 300
           JWK_CACHE_EXPIRATION_IN_SECONDS: 300
 
@@ -3708,10 +3678,6 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -3899,10 +3865,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -4076,10 +4038,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref ClientRegistryTableWriteAccessPolicy
@@ -4251,10 +4209,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref ClientRegistryTableWriteAccessPolicy
@@ -4576,10 +4530,6 @@ Resources:
             - !GetAtt StubSpotRequestQueue.QueueUrl
           IPV_JWK_CACHE_EXPIRATION_IN_SECONDS: 300
           JWK_CACHE_EXPIRATION_IN_SECONDS: 300
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAndWriteAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -4787,10 +4737,6 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
-          USE_STRONGLY_CONSISTENT_READS: !If
-            - UseStronglyConsistentReads
-            - true
-            - false
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref OrchIdentityCredentialsTableWriteAccessPolicy


### PR DESCRIPTION
### Wider context of change

We have recently started seeing issues possibly related to not using strongly consistent reads in production. We currently have a feature flag that enables strongly consistent reads up to staging

### What’s changed

This PR removes the feature flag for enabling strongly consistent reads, and instead always enables strongly consistent reads in all environments.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
