### PR TITLE
AUT-4207: Delete delay_seconds

### DIFF
--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -1,6 +1,5 @@
 resource "aws_sqs_queue" "pending_email_check_queue" {
   name                       = "${var.environment}-pending-email-check-queue"
-  delay_seconds              = 10
   max_message_size           = 2048
   message_retention_seconds  = 1209600
   receive_wait_time_seconds  = 10


### PR DESCRIPTION
## What

- The AWS default is 0 seconds
- The 10s delay was causing unnecessary latency

## How to review

1. Code Review

