### PR TITLE
BAU: update delete policies important resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -430,6 +430,8 @@ Resources:
 
   OrchSessionTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Orch-Session
       AttributeDefinitions:
@@ -574,6 +576,8 @@ Resources:
 
   AuthUserInfoTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Auth-User-Info
       AttributeDefinitions:
@@ -659,6 +663,8 @@ Resources:
 
   ClientSessionTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Client-Session
       AttributeDefinitions:
@@ -791,6 +797,8 @@ Resources:
 
   ClientRegistryTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-client-registry
       AttributeDefinitions:
@@ -906,6 +914,8 @@ Resources:
 
   OrchIdentityCredentialsTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Orch-Identity-Credentials
       AttributeDefinitions:
@@ -993,6 +1003,8 @@ Resources:
 
   RpPublicKeyCacheTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     # checkov:skip=CKV_AWS_28: It would be harmful to restore old keys from a backup of this data, and keys will be fetched if not present anyway.
     Properties:
       TableName: !Sub ${Environment}-RpPublicKeyCache
@@ -1056,6 +1068,8 @@ Resources:
 
   StateStorageTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-State-Storage
       AttributeDefinitions:
@@ -1116,6 +1130,8 @@ Resources:
 
   DocAppCredentialTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Orch-Doc-App-Credential
       AttributeDefinitions:
@@ -1176,6 +1192,8 @@ Resources:
 
   JwksCacheTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub ${Environment}-Jwks-Cache
       AttributeDefinitions:
@@ -4943,6 +4961,8 @@ Resources:
 
   BackChannelLogoutQueueEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for back channel logout queue and dlq
       PendingWindowInDays: 30

--- a/template.yaml
+++ b/template.yaml
@@ -344,6 +344,8 @@ Resources:
       TargetKeyId: !Ref MainKmsKey
   MainKmsKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: Key used to encrypt Orchestration
       EnableKeyRotation: true
@@ -373,6 +375,8 @@ Resources:
 
   OrchSessionTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Orch session DynamoDB table
       EnableKeyRotation: true
@@ -539,6 +543,8 @@ Resources:
 
   AuthUserInfoTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for AuthUserInfo DynamoDB table
       EnableKeyRotation: true
@@ -599,6 +605,8 @@ Resources:
   #region ClientSession DynamoDB Table
   ClientSessionTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for ClientSession DynamoDB table
       EnableKeyRotation: true
@@ -729,6 +737,8 @@ Resources:
   #region ClientRegistry DynamoDB Table
   ClientRegistryTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Orchestration Client Registry DynamoDB table
       EnableKeyRotation: true
@@ -842,6 +852,8 @@ Resources:
   #region OrchIdentityCredentials DynamoDB Table
   OrchIdentityCredentialsTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for OrchIdentityCredentials DynamoDB table
       EnableKeyRotation: true
@@ -950,6 +962,8 @@ Resources:
 
   RpPublicKeyTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for RP public key DynamoDB table
       EnableKeyRotation: true
@@ -1011,6 +1025,8 @@ Resources:
 
   StateStorageTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Orchestration State storage DynamoDB table
       EnableKeyRotation: true
@@ -1069,6 +1085,8 @@ Resources:
 
   DocAppCredentialTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Doc App Credential DynamoDB table
       EnableKeyRotation: true
@@ -1127,6 +1145,8 @@ Resources:
 
   JwksCacheTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Jwks Cache DynamoDB table
       EnableKeyRotation: true
@@ -2617,6 +2637,8 @@ Resources:
   GlobalLogoutTestQueueEncryptionKey:
     Condition: IsDevOrBuild
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for global logout test queue and dlq
       PendingWindowInDays: 30
@@ -6176,6 +6198,8 @@ Resources:
 
   SlackEventsKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: Key used to encrypt Slack events topic
       EnableKeyRotation: true
@@ -6284,6 +6308,8 @@ Resources:
 
   OrchAuthCodeTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for OrchAuthCode DynamoDB table
       EnableKeyRotation: true
@@ -6379,6 +6405,8 @@ Resources:
 
   ClientRateLimitTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for Client Rate Limit DynamoDB table
       EnableKeyRotation: true
@@ -6564,6 +6592,8 @@ Resources:
 
   OrchIPVTokenSigningKmsKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS signing key for authentication to the IPV token endpoint
       PendingWindowInDays: 30

--- a/template.yaml
+++ b/template.yaml
@@ -344,8 +344,8 @@ Resources:
       TargetKeyId: !Ref MainKmsKey
   MainKmsKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: Key used to encrypt Orchestration
       EnableKeyRotation: true
@@ -375,8 +375,8 @@ Resources:
 
   OrchSessionTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Orch session DynamoDB table
       EnableKeyRotation: true
@@ -430,8 +430,8 @@ Resources:
 
   OrchSessionTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Orch-Session
       AttributeDefinitions:
@@ -545,8 +545,8 @@ Resources:
 
   AuthUserInfoTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for AuthUserInfo DynamoDB table
       EnableKeyRotation: true
@@ -576,8 +576,8 @@ Resources:
 
   AuthUserInfoTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Auth-User-Info
       AttributeDefinitions:
@@ -609,8 +609,8 @@ Resources:
   #region ClientSession DynamoDB Table
   ClientSessionTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for ClientSession DynamoDB table
       EnableKeyRotation: true
@@ -663,8 +663,8 @@ Resources:
 
   ClientSessionTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Client-Session
       AttributeDefinitions:
@@ -743,8 +743,8 @@ Resources:
   #region ClientRegistry DynamoDB Table
   ClientRegistryTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Orchestration Client Registry DynamoDB table
       EnableKeyRotation: true
@@ -797,8 +797,8 @@ Resources:
 
   ClientRegistryTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-client-registry
       AttributeDefinitions:
@@ -860,8 +860,8 @@ Resources:
   #region OrchIdentityCredentials DynamoDB Table
   OrchIdentityCredentialsTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for OrchIdentityCredentials DynamoDB table
       EnableKeyRotation: true
@@ -914,8 +914,8 @@ Resources:
 
   OrchIdentityCredentialsTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Orch-Identity-Credentials
       AttributeDefinitions:
@@ -972,8 +972,8 @@ Resources:
 
   RpPublicKeyTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for RP public key DynamoDB table
       EnableKeyRotation: true
@@ -1003,8 +1003,8 @@ Resources:
 
   RpPublicKeyCacheTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     # checkov:skip=CKV_AWS_28: It would be harmful to restore old keys from a backup of this data, and keys will be fetched if not present anyway.
     Properties:
       TableName: !Sub ${Environment}-RpPublicKeyCache
@@ -1037,8 +1037,8 @@ Resources:
 
   StateStorageTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Orchestration State storage DynamoDB table
       EnableKeyRotation: true
@@ -1068,8 +1068,8 @@ Resources:
 
   StateStorageTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-State-Storage
       AttributeDefinitions:
@@ -1099,8 +1099,8 @@ Resources:
 
   DocAppCredentialTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Doc App Credential DynamoDB table
       EnableKeyRotation: true
@@ -1130,8 +1130,8 @@ Resources:
 
   DocAppCredentialTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Orch-Doc-App-Credential
       AttributeDefinitions:
@@ -1161,8 +1161,8 @@ Resources:
 
   JwksCacheTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Jwks Cache DynamoDB table
       EnableKeyRotation: true
@@ -1192,8 +1192,8 @@ Resources:
 
   JwksCacheTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Jwks-Cache
       AttributeDefinitions:
@@ -2655,8 +2655,8 @@ Resources:
   GlobalLogoutTestQueueEncryptionKey:
     Condition: IsDevOrBuild
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for global logout test queue and dlq
       PendingWindowInDays: 30
@@ -4961,8 +4961,8 @@ Resources:
 
   BackChannelLogoutQueueEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for back channel logout queue and dlq
       PendingWindowInDays: 30
@@ -6218,8 +6218,8 @@ Resources:
 
   SlackEventsKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: Key used to encrypt Slack events topic
       EnableKeyRotation: true
@@ -6328,8 +6328,8 @@ Resources:
 
   OrchAuthCodeTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for OrchAuthCode DynamoDB table
       EnableKeyRotation: true
@@ -6425,8 +6425,8 @@ Resources:
 
   ClientRateLimitTableEncryptionKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Client Rate Limit DynamoDB table
       EnableKeyRotation: true
@@ -6612,8 +6612,8 @@ Resources:
 
   OrchIPVTokenSigningKmsKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS signing key for authentication to the IPV token endpoint
       PendingWindowInDays: 30


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
