### PR TITLE
ATO-1963 Access token dynamo classes

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchAccessTokenServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchAccessTokenServiceIntegrationTest.java
@@ -1,0 +1,112 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.shared.exceptions.OrchAccessTokenException;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchAccessTokenExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrchAccessTokenServiceIntegrationTest {
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String RP_PAIRWISE_ID = "test-rp-pairwise-id";
+    private static final String TOKEN = "test-token";
+    private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "test-internal-pairwise-subject-id";
+    private static final String CLIENT_SESSION_ID = "test-client-session-id";
+    private static final String AUTH_CODE = "test-auth-code";
+
+    @RegisterExtension
+    protected static final OrchAccessTokenExtension orchAccessTokenExtension =
+            new OrchAccessTokenExtension();
+
+    @Test
+    void shouldStoreOrchAccessTokenWithAllFieldsSet() {
+        orchAccessTokenExtension.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+        var accessToken = orchAccessTokenExtension.getAccessToken(CLIENT_ID, RP_PAIRWISE_ID);
+
+        assertTrue(accessToken.isPresent());
+        assertEquals(CLIENT_ID, accessToken.get().getClientId());
+        assertEquals(RP_PAIRWISE_ID, accessToken.get().getRpPairwiseId());
+        assertEquals(CLIENT_SESSION_ID, accessToken.get().getClientSessionId());
+        assertEquals(TOKEN, accessToken.get().getToken());
+        assertEquals(
+                INTERNAL_PAIRWISE_SUBJECT_ID, accessToken.get().getInternalPairwiseSubjectId());
+        assertEquals(AUTH_CODE, accessToken.get().getAuthCode());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNoAccessTokenExistsForClientId() {
+        orchAccessTokenExtension.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+        var accessToken =
+                orchAccessTokenExtension.getAccessToken("unknown client id", RP_PAIRWISE_ID);
+        assertTrue(accessToken.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNoAccessTokenExistsForRpPairwiseId() {
+        orchAccessTokenExtension.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+        var accessToken =
+                orchAccessTokenExtension.getAccessToken(CLIENT_ID, "unknown rp pairwise id");
+        assertTrue(accessToken.isEmpty());
+    }
+
+    @Test
+    void shouldReturnAccessTokenForAuthCode() {
+        orchAccessTokenExtension.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+        var accessToken = orchAccessTokenExtension.getAccessTokenForAuthCode(AUTH_CODE);
+        assertTrue(accessToken.isPresent());
+        assertEquals(CLIENT_ID, accessToken.get().getClientId());
+        assertEquals(RP_PAIRWISE_ID, accessToken.get().getRpPairwiseId());
+        assertEquals(CLIENT_SESSION_ID, accessToken.get().getClientSessionId());
+        assertEquals(TOKEN, accessToken.get().getToken());
+        assertEquals(
+                INTERNAL_PAIRWISE_SUBJECT_ID, accessToken.get().getInternalPairwiseSubjectId());
+        assertEquals(AUTH_CODE, accessToken.get().getAuthCode());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNoAccessTokenExistsForAuthCode() {
+        orchAccessTokenExtension.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+        var accessToken = orchAccessTokenExtension.getAccessTokenForAuthCode("unknown auth code");
+        assertTrue(accessToken.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenFailingToSaveAccessToken() {
+        assertThrows(
+                OrchAccessTokenException.class,
+                () -> orchAccessTokenExtension.saveAccessToken(null, null, null, null, null, null));
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchAccessTokenService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
 
@@ -95,7 +96,8 @@ public class UserInfoHandler
                                 new JwksService(
                                         configurationService,
                                         new KmsConnectionService(configurationService)),
-                                configurationService));
+                                configurationService),
+                        new OrchAccessTokenService(configurationService));
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
     }
@@ -119,7 +121,8 @@ public class UserInfoHandler
                                 new JwksService(
                                         configurationService,
                                         new KmsConnectionService(configurationService)),
-                                configurationService));
+                                configurationService),
+                        new OrchAccessTokenService(configurationService));
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.OrchAccessTokenService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
@@ -54,6 +55,8 @@ class AccessTokenServiceTest {
             mock(RedisConnectionService.class);
     private final TokenValidationService tokenValidationService =
             mock(TokenValidationService.class);
+    private final OrchAccessTokenService orchAccessTokenService =
+            mock(OrchAccessTokenService.class);
     private final DynamoClientService clientService = mock(DynamoClientService.class);
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Subject SUBJECT = new Subject("some-subject");
@@ -87,7 +90,10 @@ class AccessTokenServiceTest {
     void setUp() {
         validationService =
                 new AccessTokenService(
-                        redisConnectionService, clientService, tokenValidationService);
+                        redisConnectionService,
+                        clientService,
+                        tokenValidationService,
+                        orchAccessTokenService);
     }
 
     @AfterEach

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAccessTokenExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAccessTokenExtension.java
@@ -1,0 +1,121 @@
+package uk.gov.di.orchestration.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.entity.OrchAccessTokenItem;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.OrchAccessTokenService;
+import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class OrchAccessTokenExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String TABLE_NAME = "local-Access-Token";
+    private static final String CLIENT_ID_FIELD = "ClientId";
+    private static final String RP_PAIRWISE_ID_FIELD = "RpPairwiseId";
+    private static final String AUTH_CODE_FIELD = "AuthCode";
+    private static final String AUTH_CODE_INDEX = "AuthCodeIndex";
+    private OrchAccessTokenService orchAccessTokenService;
+    private final ConfigurationService configurationService;
+
+    public OrchAccessTokenExtension() {
+        this.configurationService =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        orchAccessTokenService = new OrchAccessTokenService(configurationService);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, TABLE_NAME, CLIENT_ID_FIELD, Optional.of(RP_PAIRWISE_ID_FIELD));
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(TABLE_NAME)) {
+            createOrchAccessTokenTable();
+        }
+    }
+
+    private void createOrchAccessTokenTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(TABLE_NAME)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(CLIENT_ID_FIELD)
+                                        .build(),
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.RANGE)
+                                        .attributeName(RP_PAIRWISE_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(CLIENT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(RP_PAIRWISE_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(AUTH_CODE_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .globalSecondaryIndexes(
+                                GlobalSecondaryIndex.builder()
+                                        .indexName(AUTH_CODE_INDEX)
+                                        .keySchema(
+                                                KeySchemaElement.builder()
+                                                        .keyType(KeyType.HASH)
+                                                        .attributeName(AUTH_CODE_FIELD)
+                                                        .build())
+                                        .projection(
+                                                Projection.builder()
+                                                        .projectionType(ProjectionType.ALL)
+                                                        .build())
+                                        .build())
+                        .build();
+        dynamoDB.createTable(request);
+    }
+
+    public void saveAccessToken(
+            String clientId,
+            String rpPairwiseId,
+            String token,
+            String internalPairwiseSubjectId,
+            String clientSessionId,
+            String authCode) {
+        orchAccessTokenService.saveAccessToken(
+                clientId,
+                rpPairwiseId,
+                token,
+                internalPairwiseSubjectId,
+                clientSessionId,
+                authCode);
+    }
+
+    public Optional<OrchAccessTokenItem> getAccessToken(String clientId, String rpPairwiseId) {
+        return orchAccessTokenService.getAccessToken(clientId, rpPairwiseId);
+    }
+
+    public Optional<OrchAccessTokenItem> getAccessTokenForAuthCode(String authCode) {
+        return orchAccessTokenService.getAccessTokenForAuthCode(authCode);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchAccessTokenItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchAccessTokenItem.java
@@ -1,0 +1,113 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class OrchAccessTokenItem {
+
+    private static final String ATTRIBUTE_CLIENT_ID = "ClientId";
+    private static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
+    private static final String ATTRIBUTE_TOKEN = "Token";
+    private static final String ATTRIBUTE_INTERNAL_PAIRWISE_SUBJECT_ID =
+            "InternalPairwiseSubjectId";
+    private static final String ATTRIBUTE_CLIENT_SESSION_ID = "ClientSessionId";
+    private static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
+
+    private String clientId;
+    private String rpPairwiseId;
+    private String token;
+    private String internalPairwiseSubjectId;
+    private String clientSessionId;
+    private String authCode;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_ID)
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public OrchAccessTokenItem withClientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
+    public String getRpPairwiseId() {
+        return rpPairwiseId;
+    }
+
+    public void setRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+    }
+
+    public OrchAccessTokenItem withRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_INTERNAL_PAIRWISE_SUBJECT_ID)
+    public String getInternalPairwiseSubjectId() {
+        return internalPairwiseSubjectId;
+    }
+
+    public void setInternalPairwiseSubjectId(String internalPairwiseSubjectId) {
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+    }
+
+    public OrchAccessTokenItem withInternalPairwiseSubjectId(String internalPairwiseSubjectId) {
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TOKEN)
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public OrchAccessTokenItem withToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_SESSION_ID)
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public OrchAccessTokenItem withClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+        return this;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "AuthCodeIndex")
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_CODE)
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public OrchAccessTokenItem withAuthCode(String authCode) {
+        this.authCode = authCode;
+        return this;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchAccessTokenException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchAccessTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class OrchAccessTokenException extends RuntimeException {
+
+    public OrchAccessTokenException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenService.java
@@ -18,10 +18,8 @@ public class OrchAccessTokenService extends BaseDynamoService<OrchAccessTokenIte
     }
 
     public OrchAccessTokenService(
-            DynamoDbClient dynamoDbClient,
-            DynamoDbTable<OrchAccessTokenItem> dynamoDbTable,
-            ConfigurationService configurationService) {
-        super(dynamoDbTable, dynamoDbClient, configurationService);
+            DynamoDbClient dynamoDbClient, DynamoDbTable<OrchAccessTokenItem> dynamoDbTable) {
+        super(dynamoDbTable, dynamoDbClient);
     }
 
     public Optional<OrchAccessTokenItem> getAccessToken(String clientId, String rpPairwiseId) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenService.java
@@ -1,0 +1,86 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.orchestration.shared.entity.OrchAccessTokenItem;
+import uk.gov.di.orchestration.shared.exceptions.OrchAccessTokenException;
+
+import java.util.Optional;
+
+public class OrchAccessTokenService extends BaseDynamoService<OrchAccessTokenItem> {
+    private static final Logger LOG = LogManager.getLogger(OrchAuthCodeService.class);
+    private static final String AUTH_CODE_INDEX = "AuthCodeIndex";
+
+    public OrchAccessTokenService(ConfigurationService configurationService) {
+        super(OrchAccessTokenItem.class, "Access-Token", configurationService, true);
+    }
+
+    public OrchAccessTokenService(
+            DynamoDbClient dynamoDbClient,
+            DynamoDbTable<OrchAccessTokenItem> dynamoDbTable,
+            ConfigurationService configurationService) {
+        super(dynamoDbTable, dynamoDbClient, configurationService);
+    }
+
+    public Optional<OrchAccessTokenItem> getAccessToken(String clientId, String rpPairwiseId) {
+        Optional<OrchAccessTokenItem> orchAccessToken = Optional.empty();
+        try {
+            orchAccessToken = get(clientId, rpPairwiseId);
+        } catch (Exception e) {
+            logAndThrowOrchAccessTokenException("Failed to get Orch access token from Dynamo", e);
+        }
+
+        if (orchAccessToken.isEmpty()) {
+            LOG.info(
+                    "No Orch access token found with clientId {} and rpPairwiseId {}",
+                    clientId,
+                    rpPairwiseId);
+        }
+        return orchAccessToken;
+    }
+
+    public Optional<OrchAccessTokenItem> getAccessTokenForAuthCode(String authCode) {
+        try {
+            var items = queryIndex(AUTH_CODE_INDEX, authCode);
+            if (items.isEmpty()) {
+                LOG.info("No Orch access token found with authCode {}", authCode);
+                return Optional.empty();
+            }
+            return Optional.of(items.get(0));
+        } catch (Exception e) {
+            logAndThrowOrchAccessTokenException(
+                    "Failed to get Orch access token from Dynamo for auth code", e);
+            return Optional.empty();
+        }
+    }
+
+    public void saveAccessToken(
+            String clientId,
+            String rpPairwiseId,
+            String token,
+            String internalPairwiseSubjectId,
+            String clientSessionId,
+            String authCode) {
+
+        try {
+            put(
+                    new OrchAccessTokenItem()
+                            .withClientId(clientId)
+                            .withRpPairwiseId(rpPairwiseId)
+                            .withToken(token)
+                            .withInternalPairwiseSubjectId(internalPairwiseSubjectId)
+                            .withClientSessionId(clientSessionId)
+                            .withAuthCode(authCode));
+        } catch (Exception e) {
+            logAndThrowOrchAccessTokenException(
+                    "Failed to save Orch access token item to Dynamo", e);
+        }
+    }
+
+    private void logAndThrowOrchAccessTokenException(String message, Exception e) {
+        LOG.error("{}. Error message: {}", message, e.getMessage());
+        throw new OrchAccessTokenException(message);
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenServiceTest.java
@@ -34,13 +34,11 @@ class OrchAccessTokenServiceTest {
 
     private final DynamoDbTable<OrchAccessTokenItem> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private OrchAccessTokenService orchAccessTokenService;
 
     @BeforeEach
     void setup() {
-        orchAccessTokenService =
-                new OrchAccessTokenService(dynamoDbClient, table, configurationService);
+        orchAccessTokenService = new OrchAccessTokenService(dynamoDbClient, table);
     }
 
     @Test
@@ -98,8 +96,9 @@ class OrchAccessTokenServiceTest {
                                         .partitionValue(CLIENT_ID)
                                         .sortValue(RP_PAIRWISE_ID)
                                         .build())
-                        .consistentRead(false)
+                        .consistentRead(true)
                         .build();
+
         when(table.getItem(orchAccessTokenGetRequest)).thenReturn(orchAccessTokenItem);
 
         var actualOrchAccessToken =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAccessTokenServiceTest.java
@@ -1,0 +1,190 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.orchestration.shared.entity.OrchAccessTokenItem;
+import uk.gov.di.orchestration.shared.exceptions.OrchAccessTokenException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OrchAccessTokenServiceTest {
+
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String RP_PAIRWISE_ID = "test-rp-pairwise-id";
+    private static final String TOKEN = "test-token";
+    private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "test-internal-pairwise-subject-id";
+    private static final String CLIENT_SESSION_ID = "test-client-session-id";
+    private static final String AUTH_CODE = "test-auth-code";
+    private static final String AUTH_CODE_INDEX = "AuthCodeIndex";
+
+    private final DynamoDbTable<OrchAccessTokenItem> table = mock(DynamoDbTable.class);
+    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private OrchAccessTokenService orchAccessTokenService;
+
+    @BeforeEach
+    void setup() {
+        orchAccessTokenService =
+                new OrchAccessTokenService(dynamoDbClient, table, configurationService);
+    }
+
+    @Test
+    void shouldStoreOrchAccessTokenItem() {
+        orchAccessTokenService.saveAccessToken(
+                CLIENT_ID,
+                RP_PAIRWISE_ID,
+                TOKEN,
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                CLIENT_SESSION_ID,
+                AUTH_CODE);
+
+        var orchAccessTokenItemCaptor = ArgumentCaptor.forClass(OrchAccessTokenItem.class);
+        verify(table).putItem(orchAccessTokenItemCaptor.capture());
+        var capturedRequest = orchAccessTokenItemCaptor.getValue();
+
+        assertOrchAccessTokenItemMatchesExpected(capturedRequest);
+    }
+
+    @Test
+    void shouldThrowWhenFailsToStoreOrchAccessToken() {
+        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
+                .when(table)
+                .putItem(any(OrchAccessTokenItem.class));
+
+        var exception =
+                assertThrows(
+                        OrchAccessTokenException.class,
+                        () ->
+                                orchAccessTokenService.saveAccessToken(
+                                        CLIENT_ID,
+                                        RP_PAIRWISE_ID,
+                                        TOKEN,
+                                        INTERNAL_PAIRWISE_SUBJECT_ID,
+                                        CLIENT_SESSION_ID,
+                                        AUTH_CODE));
+        assertEquals("Failed to save Orch access token item to Dynamo", exception.getMessage());
+    }
+
+    @Test
+    void shouldGetOrchAccessTokenForClientIdAndRpPairwiseId() {
+        var orchAccessTokenItem =
+                new OrchAccessTokenItem()
+                        .withClientId(CLIENT_ID)
+                        .withRpPairwiseId(RP_PAIRWISE_ID)
+                        .withToken(TOKEN)
+                        .withInternalPairwiseSubjectId(INTERNAL_PAIRWISE_SUBJECT_ID)
+                        .withClientSessionId(CLIENT_SESSION_ID)
+                        .withAuthCode(AUTH_CODE);
+
+        GetItemEnhancedRequest orchAccessTokenGetRequest =
+                GetItemEnhancedRequest.builder()
+                        .key(
+                                Key.builder()
+                                        .partitionValue(CLIENT_ID)
+                                        .sortValue(RP_PAIRWISE_ID)
+                                        .build())
+                        .consistentRead(false)
+                        .build();
+        when(table.getItem(orchAccessTokenGetRequest)).thenReturn(orchAccessTokenItem);
+
+        var actualOrchAccessToken =
+                orchAccessTokenService.getAccessToken(CLIENT_ID, RP_PAIRWISE_ID);
+
+        assertTrue(actualOrchAccessToken.isPresent());
+        assertOrchAccessTokenItemMatchesExpected(actualOrchAccessToken.get());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoAccessTokenForClientIdAndRpPairwiseId() {
+        when(table.getItem(any(GetItemEnhancedRequest.class))).thenReturn(null);
+
+        var actualOrchAccessToken =
+                orchAccessTokenService.getAccessToken(CLIENT_ID, RP_PAIRWISE_ID);
+
+        assertTrue(actualOrchAccessToken.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenFailsToGetOrchAccessToken() {
+        doThrow(DynamoDbException.builder().message("Failed to get item from table").build())
+                .when(table)
+                .getItem(any(GetItemEnhancedRequest.class));
+
+        var exception =
+                assertThrows(
+                        OrchAccessTokenException.class,
+                        () -> orchAccessTokenService.getAccessToken(CLIENT_ID, RP_PAIRWISE_ID));
+        assertEquals("Failed to get Orch access token from Dynamo", exception.getMessage());
+    }
+
+    @Test
+    void shouldGetOrchAccessTokenForAuthCode() {
+        var orchAccessTokenItem =
+                new OrchAccessTokenItem()
+                        .withClientId(CLIENT_ID)
+                        .withRpPairwiseId(RP_PAIRWISE_ID)
+                        .withToken(TOKEN)
+                        .withInternalPairwiseSubjectId(INTERNAL_PAIRWISE_SUBJECT_ID)
+                        .withClientSessionId(CLIENT_SESSION_ID)
+                        .withAuthCode(AUTH_CODE);
+
+        var spyService = spy(orchAccessTokenService);
+        doReturn(List.of(orchAccessTokenItem))
+                .when(spyService)
+                .queryIndex(AUTH_CODE_INDEX, AUTH_CODE);
+
+        var actualOrchAccessToken = spyService.getAccessTokenForAuthCode(AUTH_CODE);
+
+        assertTrue(actualOrchAccessToken.isPresent());
+        assertOrchAccessTokenItemMatchesExpected(actualOrchAccessToken.get());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoAccessTokenForAuthCode() {
+        var spyService = spy(orchAccessTokenService);
+        doReturn(List.of()).when(spyService).queryIndex(AUTH_CODE_INDEX, AUTH_CODE);
+
+        var actualOrchAccessToken = spyService.getAccessTokenForAuthCode(AUTH_CODE);
+
+        assertTrue(actualOrchAccessToken.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenFailsToGetOrchAccessTokenForAuthCode() {
+        var spyService = spy(orchAccessTokenService);
+        doThrow(RuntimeException.class).when(spyService).queryIndex("authCode-index", AUTH_CODE);
+
+        var exception =
+                assertThrows(
+                        OrchAccessTokenException.class,
+                        () -> orchAccessTokenService.getAccessTokenForAuthCode(AUTH_CODE));
+        assertEquals(
+                "Failed to get Orch access token from Dynamo for auth code",
+                exception.getMessage());
+    }
+
+    private void assertOrchAccessTokenItemMatchesExpected(OrchAccessTokenItem orchAccessTokenItem) {
+        assertEquals(CLIENT_ID, orchAccessTokenItem.getClientId());
+        assertEquals(RP_PAIRWISE_ID, orchAccessTokenItem.getRpPairwiseId());
+        assertEquals(TOKEN, orchAccessTokenItem.getToken());
+        assertEquals(
+                INTERNAL_PAIRWISE_SUBJECT_ID, orchAccessTokenItem.getInternalPairwiseSubjectId());
+        assertEquals(CLIENT_SESSION_ID, orchAccessTokenItem.getClientSessionId());
+        assertEquals(AUTH_CODE, orchAccessTokenItem.getAuthCode());
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1115,9 +1115,9 @@ Resources:
         - Key: Name
           Value: DocAppCredentialTable
 
-    #endregion
+  #endregion
 
-    #region Jwks Cache DynamoDB Table
+  #region Jwks Cache DynamoDB Table
 
   JwksCacheTableEncryptionKey:
     Type: AWS::KMS::Key
@@ -1177,7 +1177,78 @@ Resources:
         - Key: Name
           Value: JwksCacheTable
 
-    #endregion
+  #endregion
+
+  #region Access Token DynamoDB Table
+
+  AccessTokenTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for Access Token DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  AccessTokenTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-Access-Token
+      AttributeDefinitions:
+        - AttributeName: ClientId
+          AttributeType: S
+        - AttributeName: RpPairwiseId
+          AttributeType: S
+        - AttributeName: AuthCode
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        - IndexName: AuthCodeIndex
+          KeySchema:
+            - AttributeName: AuthCode
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      KeySchema:
+        - AttributeName: ClientId
+          KeyType: HASH
+        - AttributeName: RpPairwiseId
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt AccessTokenTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: AccessTokenTable
+
+  #endregion
 
   #region Fetch JWKS Lambda
 

--- a/template.yaml
+++ b/template.yaml
@@ -1183,6 +1183,8 @@ Resources:
 
   AccessTokenTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Access Token DynamoDB table
       EnableKeyRotation: true
@@ -1212,6 +1214,8 @@ Resources:
 
   AccessTokenTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Access-Token
       AttributeDefinitions:

--- a/template.yaml
+++ b/template.yaml
@@ -5781,6 +5781,58 @@ Resources:
               - kms:DescribeKey
             Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
 
+  AccessTokenTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAccessTokenTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:DescribeStream
+              - dynamodb:Get*
+              - dynamodb:Query
+              - dynamodb:Scan
+            Resource:
+              - !Sub ${AccessTokenTable.Arn}/index/*
+              - !GetAtt AccessTokenTable.Arn
+          - Sid: AllowAccessTokenTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt AccessTokenTableEncryptionKey.Arn
+
+  AccessTokenTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAccessTokenTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:UpdateItem
+              - dynamodb:PutItem
+            Resource: !GetAtt AccessTokenTable.Arn
+          - Sid: AllowAccessTokenTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt AccessTokenTableEncryptionKey.Arn
+
   TxmaQueueSendPermissionPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
### Wider context of change

Moving access token store from Redis to Dynamo

### What’s changed

- add new OrchAccessTokenItem to represent the data in the new Access Token table in dynamo
- add new OrchAccessTokenService to read from and write to that table.

### Manual testing

- tested in dev using hardcoded values to check that the service reads successfully from the table.

### Related PRs

Creation of access token table (rebased from this branch) https://github.com/govuk-one-login/authentication-api/pull/7153
