### PR TITLE
BAU: add open_telemetry dependency to utils

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -17,6 +17,7 @@ dependencies {
             configurations.govuk_notify,
             configurations.nimbus,
             configurations.xray,
+            configurations.open_telemetry,
             "software.amazon.awssdk:cloudwatch:${rootProject.ext.dependencyVersions.aws_sdk_v2_version}"
 
     runtimeOnly configurations.logging_runtime


### PR DESCRIPTION
## What

- This is so that the email check results writer can autoconfigure, allowing shared trace context to link up spans from the results writer to traces from calling services

## How to review


1. Code Review
