### PR TITLE
ATO-1979: Allow orch slack alerts to be send from build environment

### DIFF
--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -73,19 +73,14 @@ const buildMessageRequest = async function (
   snsMessageFooter,
 ) {
   const body = formatMessage(snsMessage, colorCode, snsMessageFooter);
-  const isNotBuildEnv = [
-    "dev",
-    "staging",
-    "integration",
-    "production",
-  ].includes(process.env.DEPLOY_ENVIRONMENT);
+
   const isEnabledForProd = process.env.DEPLOY_ENVIRONMENT === "production";
   const isPagerDutyAlarm = snsMessage.AlarmName.includes("pagerduty");
   if (isPagerDutyAlarm && isEnabledForProd) {
     body.channel =
       process.env.SLACK_CHANNEL_ID ||
       (await getParameter("pagerduty-slack-channel-id"));
-  } else if (isNotBuildEnv) {
+  } else {
     body.channel =
       process.env.SLACK_CHANNEL_ID ||
       (await getParameter(


### PR DESCRIPTION
### Wider context of change

For some reason we are filtering out the build env when sending slack alerts to our channels. We should allow for alerts to be sent from the build environment

### What’s changed

This PR sends slack notifications from all environments, instead of just dev, staging, integration and production

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
