### PR TITLE
AUT-4572: Pull lockout business logic out of LoginHandler

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.AssertionFailedError;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.mfa.response.ResponseAuthAppMfaDetail;
 import uk.gov.di.accountmanagement.entity.mfa.response.ResponseSmsMfaDetail;
@@ -835,7 +836,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             Map<String, String> attributes = eventEntry.getValue();
 
             // Create the expectation for this event
-            AuditEventExpectation expectation = new AuditEventExpectation(eventName);
+            AuditEventExpectation expectation =
+                    new AuditEventExpectation(AccountManagementAuditableEvent.valueOf(eventName));
 
             // Add all expected attributes
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -845,7 +845,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             }
 
             // Verify the expectation against the received events
-            expectation.verify(receivedEvents);
+            expectation.assertPublished(receivedEvents);
         }
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
@@ -142,15 +142,15 @@ class MFAMethodsDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             var sentEvents = assertTxmaAuditEventsReceived(txmaAuditQueue, expectedEvents);
 
             AuditEventExpectation expectation =
-                    new AuditEventExpectation(AUTH_MFA_METHOD_DELETE_COMPLETED.name());
+                    new AuditEventExpectation(AUTH_MFA_METHOD_DELETE_COMPLETED);
             expectation.withAttribute(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
 
             // Only add phone number country code for SMS methods
             if (backupMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())) {
-                expectation.withAttribute(EXTENSIONS_MFA_TYPE, SMS);
+                expectation.withAttribute(EXTENSIONS_MFA_TYPE, SMS.getValue());
                 expectation.withAttribute(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
             } else if (backupMethod.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue())) {
-                expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP);
+                expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP.getValue());
             }
 
             expectation.verify(sentEvents);
@@ -181,9 +181,9 @@ class MFAMethodsDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             var sentEvents = assertTxmaAuditEventsReceived(txmaAuditQueue, expectedEvents);
 
             AuditEventExpectation expectation =
-                    new AuditEventExpectation(AUTH_MFA_METHOD_DELETE_COMPLETED.name());
+                    new AuditEventExpectation(AUTH_MFA_METHOD_DELETE_COMPLETED);
             expectation.withAttribute(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP);
+            expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP.getValue());
 
             expectation.verify(sentEvents);
         }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
@@ -153,7 +153,7 @@ class MFAMethodsDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP.getValue());
             }
 
-            expectation.verify(sentEvents);
+            expectation.assertPublished(sentEvents);
         }
 
         @Test
@@ -185,7 +185,7 @@ class MFAMethodsDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             expectation.withAttribute(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             expectation.withAttribute(EXTENSIONS_MFA_TYPE, AUTH_APP.getValue());
 
-            expectation.verify(sentEvents);
+            expectation.assertPublished(sentEvents);
         }
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -4,6 +4,7 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.lambda.MFAMethodsPutHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -1107,7 +1108,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             Map<String, String> attributes = eventEntry.getValue();
 
             // Create the expectation for this event
-            AuditEventExpectation expectation = new AuditEventExpectation(eventName);
+            AuditEventExpectation expectation =
+                    new AuditEventExpectation(AccountManagementAuditableEvent.valueOf(eventName));
 
             // Add all expected attributes
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -1117,7 +1117,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             }
 
             // Verify the expectation against the received events
-            expectation.verify(receivedEvents);
+            expectation.assertPublished(receivedEvents);
             assertNoTxmaAuditEventsReceived(txmaAuditQueue);
         }
     }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -113,7 +113,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 AuditEventExpectation expectation = new AuditEventExpectation(AUTH_SEND_OTP);
                 expectation.withAttribute(EXTENSIONS_NOTIFICATION_TYPE, VERIFY_EMAIL.name());
                 expectation.withAttribute(EXTENSIONS_TEST_USER, false);
-                expectation.verify(receivedEvents);
+                expectation.assertPublished(receivedEvents);
             }
         }
 
@@ -192,7 +192,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 sendOtpExpectation.withAttribute(
                         EXTENSIONS_NOTIFICATION_TYPE, VERIFY_PHONE_NUMBER.name());
                 sendOtpExpectation.withAttribute(EXTENSIONS_TEST_USER, false);
-                sendOtpExpectation.verify(receivedEvents);
+                sendOtpExpectation.assertPublished(receivedEvents);
 
                 AuditEventExpectation phoneCodeSentExpectation =
                         new AuditEventExpectation(AUTH_PHONE_CODE_SENT);
@@ -200,7 +200,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
                 phoneCodeSentExpectation.withAttribute(
                         EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-                phoneCodeSentExpectation.verify(receivedEvents);
+                phoneCodeSentExpectation.assertPublished(receivedEvents);
             }
         }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -110,7 +110,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
                 List<String> receivedEvents =
                         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_SEND_OTP));
-                AuditEventExpectation expectation = new AuditEventExpectation(AUTH_SEND_OTP.name());
+                AuditEventExpectation expectation = new AuditEventExpectation(AUTH_SEND_OTP);
                 expectation.withAttribute(EXTENSIONS_NOTIFICATION_TYPE, VERIFY_EMAIL.name());
                 expectation.withAttribute(EXTENSIONS_TEST_USER, false);
                 expectation.verify(receivedEvents);
@@ -188,15 +188,14 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 List<String> receivedEvents =
                         assertTxmaAuditEventsReceived(
                                 txmaAuditQueue, List.of(AUTH_SEND_OTP, AUTH_PHONE_CODE_SENT));
-                AuditEventExpectation sendOtpExpectation =
-                        new AuditEventExpectation(AUTH_SEND_OTP.name());
+                AuditEventExpectation sendOtpExpectation = new AuditEventExpectation(AUTH_SEND_OTP);
                 sendOtpExpectation.withAttribute(
                         EXTENSIONS_NOTIFICATION_TYPE, VERIFY_PHONE_NUMBER.name());
                 sendOtpExpectation.withAttribute(EXTENSIONS_TEST_USER, false);
                 sendOtpExpectation.verify(receivedEvents);
 
                 AuditEventExpectation phoneCodeSentExpectation =
-                        new AuditEventExpectation(AUTH_PHONE_CODE_SENT.name());
+                        new AuditEventExpectation(AUTH_PHONE_CODE_SENT);
                 phoneCodeSentExpectation.withAttribute(
                         EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
                 phoneCodeSentExpectation.withAttribute(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/anticorruptionlayer/ForbiddenReasonAntiCorruption.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/anticorruptionlayer/ForbiddenReasonAntiCorruption.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.frontendapi.anticorruptionlayer;
+
+import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
+import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+
+public class ForbiddenReasonAntiCorruption {
+
+    private ForbiddenReasonAntiCorruption() {}
+
+    public static ReauthFailureReasons toReauthFailureReason(ForbiddenReason decisionError) {
+        return switch (decisionError) {
+            case EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT -> ReauthFailureReasons
+                    .INCORRECT_EMAIL;
+            case EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT -> ReauthFailureReasons
+                    .INCORRECT_PASSWORD;
+            case EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT -> ReauthFailureReasons.INCORRECT_OTP;
+            default -> null;
+        };
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/anticorruptionlayer/ForbiddenReasonAntiCorruption.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/anticorruptionlayer/ForbiddenReasonAntiCorruption.java
@@ -14,7 +14,10 @@ public class ForbiddenReasonAntiCorruption {
             case EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT -> ReauthFailureReasons
                     .INCORRECT_PASSWORD;
             case EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT -> ReauthFailureReasons.INCORRECT_OTP;
-            default -> null;
+            case EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT,
+                    BLOCKED_FOR_PW_RESET_REQUEST,
+                    EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                    EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT -> ReauthFailureReasons.UNKNOWN;
         };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ReauthFailureReasons.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ReauthFailureReasons.java
@@ -3,7 +3,8 @@ package uk.gov.di.authentication.frontendapi.entity;
 public enum ReauthFailureReasons {
     INCORRECT_EMAIL("incorrect_email"),
     INCORRECT_PASSWORD("incorrect_password"),
-    INCORRECT_OTP("incorrect_otp");
+    INCORRECT_OTP("incorrect_otp"),
+    UNKNOWN("unknown");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -233,7 +233,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         var lockoutInformation = new ArrayList<LockoutInformation>();
 
         var signInResult =
-                permissionDecisionManager.canVerifyOtp(JourneyType.SIGN_IN, userPermissionContext);
+                permissionDecisionManager.canVerifyMfaOtp(
+                        JourneyType.SIGN_IN, userPermissionContext);
         if (signInResult.isFailure()) {
             return Result.failure(signInResult.getFailure());
         }
@@ -245,7 +246,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         }
 
         var passwordResetResult =
-                permissionDecisionManager.canVerifyOtp(
+                permissionDecisionManager.canVerifyMfaOtp(
                         JourneyType.PASSWORD_RESET_MFA, userPermissionContext);
         if (passwordResetResult.isFailure()) {
             return Result.failure(passwordResetResult.getFailure());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -78,7 +78,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     public CheckUserExistsHandler(ConfigurationService configurationService) {
         super(CheckUserExistsRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
-        this.permissionDecisionManager = new PermissionDecisionManager();
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -261,9 +261,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 FAILURE_REASON.getValue(),
-                                reauthFailureReason == null
-                                        ? "unknown"
-                                        : reauthFailureReason.getValue()));
+                                reauthFailureReason.getValue()));
 
                 return generateApiGatewayProxyErrorResponse(
                         400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -46,6 +46,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -90,6 +91,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     private final CommonPasswordsService commonPasswordsService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
+    private final PermissionDecisionManager permissionDecisionManager;
 
     public LoginHandler(
             ConfigurationService configurationService,
@@ -102,7 +104,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             CommonPasswordsService commonPasswordsService,
             AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
-            MFAMethodsService mfaMethodsService) {
+            MFAMethodsService mfaMethodsService,
+            PermissionDecisionManager permissionDecisionManager) {
         super(
                 LoginRequest.class,
                 configurationService,
@@ -117,6 +120,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.commonPasswordsService = commonPasswordsService;
         this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
+        this.permissionDecisionManager = permissionDecisionManager;
     }
 
     public LoginHandler(ConfigurationService configurationService) {
@@ -131,6 +135,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
+        this.permissionDecisionManager =
+                new PermissionDecisionManager(codeStorageService, configurationService);
     }
 
     public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -145,6 +151,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
+        this.permissionDecisionManager =
+                new PermissionDecisionManager(codeStorageService, configurationService);
     }
 
     public LoginHandler() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -81,7 +81,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     public static final String INTERNAL_SUBJECT_ID = "internalSubjectId";
     public static final String INCORRECT_PASSWORD_COUNT = "incorrectPasswordCount";
     public static final String PASSWORD_RESET_TYPE = "passwordResetType";
-    private final CodeStorageService codeStorageService;
     private final UserMigrationService userMigrationService;
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
@@ -95,7 +94,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
             ClientService clientService,
-            CodeStorageService codeStorageService,
             UserMigrationService userMigrationService,
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
@@ -112,7 +110,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 authenticationService,
                 true,
                 authSessionService);
-        this.codeStorageService = codeStorageService;
         this.userMigrationService = userMigrationService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
@@ -125,7 +122,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
     public LoginHandler(ConfigurationService configurationService) {
         super(LoginRequest.class, configurationService, true);
-        this.codeStorageService = new CodeStorageService(configurationService);
+        var codeStorageService = new CodeStorageService(configurationService);
         this.userMigrationService =
                 new UserMigrationService(
                         new DynamoService(configurationService), configurationService);
@@ -141,14 +138,14 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.userActionsManager =
                 new UserActionsManager(
                         configurationService,
-                        this.codeStorageService,
+                        codeStorageService,
                         this.authSessionService,
                         this.authenticationAttemptsService);
     }
 
     public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
         super(LoginRequest.class, configurationService, true);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
+        var codeStorageService = new CodeStorageService(configurationService, redis);
         this.userMigrationService =
                 new UserMigrationService(
                         new DynamoService(configurationService), configurationService);
@@ -164,7 +161,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.userActionsManager =
                 new UserActionsManager(
                         configurationService,
-                        this.codeStorageService,
+                        codeStorageService,
                         this.authSessionService,
                         this.authenticationAttemptsService);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -196,12 +196,11 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         JourneyType journeyType =
                 request.getJourneyType() != null ? request.getJourneyType() : JourneyType.SIGN_IN;
-        var journeyTypeValue = journeyType != null ? journeyType.getValue() : "missing";
-        var isReauthJourney =
-                journeyTypeValue.equalsIgnoreCase(JourneyType.REAUTHENTICATION.getValue());
+        var isReauthJourney = journeyType == JourneyType.REAUTHENTICATION;
 
         attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
-        attachLogFieldToLogs(JOURNEY_TYPE, journeyTypeValue);
+        attachLogFieldToLogs(
+                JOURNEY_TYPE, journeyType != null ? journeyType.getValue() : "missing");
 
         Optional<UserProfile> userProfileMaybe =
                 authenticationService.getUserProfileByEmailMaybe(request.getEmail());
@@ -228,7 +227,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         var decisionResult =
                 permissionDecisionManager.canReceivePassword(journeyType, userPermissionContext);
-        if (!decisionResult.isSuccess()) {
+        if (decisionResult.isFailure()) {
             DecisionError failure = decisionResult.getFailure();
             LOG.error("Failure to get canReceivePassword decision due to {}", failure);
             var httpResponse = DecisionErrorHttpMapper.toHttpResponse(failure);
@@ -476,7 +475,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         var decisionResult =
                 permissionDecisionManager.canReceivePassword(journeyType, userPermissionContext);
-        if (!decisionResult.isSuccess()) {
+        if (decisionResult.isFailure()) {
             DecisionError failure = decisionResult.getFailure();
             LOG.error("Failure to get canReceivePassword decision due to {}", failure);
             var httpResponse = DecisionErrorHttpMapper.toHttpResponse(failure);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -48,6 +48,7 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
@@ -95,6 +96,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final PermissionDecisionManager permissionDecisionManager;
+    private final UserActionsManager userActionsManager;
 
     public LoginHandler(
             ConfigurationService configurationService,
@@ -108,7 +110,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
-            PermissionDecisionManager permissionDecisionManager) {
+            PermissionDecisionManager permissionDecisionManager,
+            UserActionsManager userActionsManager) {
         super(
                 LoginRequest.class,
                 configurationService,
@@ -124,6 +127,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.permissionDecisionManager = permissionDecisionManager;
+        this.userActionsManager = userActionsManager;
     }
 
     public LoginHandler(ConfigurationService configurationService) {
@@ -141,6 +145,12 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.permissionDecisionManager =
                 new PermissionDecisionManager(
                         configurationService, codeStorageService, authenticationAttemptsService);
+        this.userActionsManager =
+                new UserActionsManager(
+                        configurationService,
+                        this.codeStorageService,
+                        this.authSessionService,
+                        this.authenticationAttemptsService);
     }
 
     public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -158,6 +168,12 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.permissionDecisionManager =
                 new PermissionDecisionManager(
                         configurationService, codeStorageService, authenticationAttemptsService);
+        this.userActionsManager =
+                new UserActionsManager(
+                        configurationService,
+                        this.codeStorageService,
+                        this.authSessionService,
+                        this.authenticationAttemptsService);
     }
 
     public LoginHandler() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -117,7 +117,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         this.passwordValidator = new PasswordValidator(commonPasswordsService);
         this.dynamoAccountModifiersService =
                 new DynamoAccountModifiersService(configurationService);
-        this.permissionDecisionManager = new PermissionDecisionManager();
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.userActionsManager = new UserActionsManager();
     }
 
@@ -136,7 +136,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         this.passwordValidator = new PasswordValidator(commonPasswordsService);
         this.dynamoAccountModifiersService =
                 new DynamoAccountModifiersService(configurationService);
-        this.permissionDecisionManager = new PermissionDecisionManager();
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.userActionsManager = new UserActionsManager();
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -118,7 +118,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         this.dynamoAccountModifiersService =
                 new DynamoAccountModifiersService(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
-        this.userActionsManager = new UserActionsManager();
+        this.userActionsManager = new UserActionsManager(configurationService);
     }
 
     public ResetPasswordHandler(
@@ -137,7 +137,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         this.dynamoAccountModifiersService =
                 new DynamoAccountModifiersService(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
-        this.userActionsManager = new UserActionsManager();
+        this.userActionsManager = new UserActionsManager(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -117,7 +117,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.auditService = auditService;
         this.mfaMethodsService = mfaMethodsService;
         this.permissionDecisionManager =
-                new PermissionDecisionManager(codeStorageService, configurationService);
+                new PermissionDecisionManager(configurationService, codeStorageService);
         this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
     }
 
@@ -137,7 +137,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.auditService = new AuditService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.permissionDecisionManager =
-                new PermissionDecisionManager(codeStorageService, configurationService);
+                new PermissionDecisionManager(configurationService, codeStorageService);
         this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
     }
 
@@ -154,7 +154,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.auditService = new AuditService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.permissionDecisionManager =
-                new PermissionDecisionManager(codeStorageService, configurationService);
+                new PermissionDecisionManager(configurationService, codeStorageService);
         this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -118,7 +118,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.mfaMethodsService = mfaMethodsService;
         this.permissionDecisionManager =
                 new PermissionDecisionManager(configurationService, codeStorageService);
-        this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
+        this.userActionsManager =
+                new UserActionsManager(
+                        configurationService, codeStorageService, authSessionService);
     }
 
     public ResetPasswordRequestHandler() {
@@ -138,7 +140,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.permissionDecisionManager =
                 new PermissionDecisionManager(configurationService, codeStorageService);
-        this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
+        this.userActionsManager =
+                new UserActionsManager(
+                        configurationService, codeStorageService, authSessionService);
     }
 
     public ResetPasswordRequestHandler(
@@ -155,7 +159,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.permissionDecisionManager =
                 new PermissionDecisionManager(configurationService, codeStorageService);
-        this.userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
+        this.userActionsManager =
+                new UserActionsManager(
+                        configurationService, codeStorageService, authSessionService);
     }
 
     @Override

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -153,7 +153,7 @@ class CheckUserExistsHandlerTest {
         // Setup default PermissionDecisionManager behavior after reset
         when(permissionDecisionManager.canReceivePassword(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyOtp(any(), any()))
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
     }
 
@@ -306,9 +306,10 @@ class CheckUserExistsHandlerTest {
                             lockoutExpiry,
                             false);
 
-            when(permissionDecisionManager.canVerifyOtp(eq(JourneyType.SIGN_IN), any()))
+            when(permissionDecisionManager.canVerifyMfaOtp(eq(JourneyType.SIGN_IN), any()))
                     .thenReturn(Result.success(signInLockout));
-            when(permissionDecisionManager.canVerifyOtp(eq(JourneyType.PASSWORD_RESET_MFA), any()))
+            when(permissionDecisionManager.canVerifyMfaOtp(
+                            eq(JourneyType.PASSWORD_RESET_MFA), any()))
                     .thenReturn(Result.success(passwordResetLockout));
 
             MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
@@ -569,12 +570,12 @@ class CheckUserExistsHandlerTest {
 
         @ParameterizedTest
         @MethodSource("decisionErrorToExpectedErrorResponse")
-        void shouldReturnCorrectErrorResponseForCanVerifyOtpFailure(
+        void shouldReturnCorrectErrorResponseForCanVerifyMfaOtpFailure(
                 DecisionError decisionError, ErrorResponse expectedErrorResponse) {
             setupUserProfileAndClient(Optional.of(generateUserProfile()));
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of()));
-            when(permissionDecisionManager.canVerifyOtp(eq(JourneyType.SIGN_IN), any()))
+            when(permissionDecisionManager.canVerifyMfaOtp(eq(JourneyType.SIGN_IN), any()))
                     .thenReturn(Result.failure(decisionError));
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -37,6 +37,7 @@ import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -105,6 +106,8 @@ class LoginHandlerReauthenticationRedisTest {
             mock(CommonPasswordsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -163,7 +166,8 @@ class LoginHandlerReauthenticationRedisTest {
                         commonPasswordsService,
                         null,
                         authSessionService,
-                        mfaMethodsService);
+                        mfaMethodsService,
+                        permissionDecisionManager);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -39,6 +39,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 
 import java.util.ArrayList;
@@ -110,6 +111,7 @@ class LoginHandlerReauthenticationRedisTest {
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final PermissionDecisionManager permissionDecisionManager =
             mock(PermissionDecisionManager.class);
+    private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -171,7 +173,8 @@ class LoginHandlerReauthenticationRedisTest {
                         null,
                         authSessionService,
                         mfaMethodsService,
-                        permissionDecisionManager);
+                        permissionDecisionManager,
+                        userActionsManager);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -34,7 +34,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -101,7 +100,6 @@ class LoginHandlerReauthenticationRedisTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final UserMigrationService userMigrationService = mock(UserMigrationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -170,7 +168,6 @@ class LoginHandlerReauthenticationRedisTest {
                         configurationService,
                         authenticationService,
                         clientService,
-                        codeStorageService,
                         userMigrationService,
                         auditService,
                         cloudwatchMetricsService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -47,6 +47,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 
@@ -158,6 +159,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final PermissionDecisionManager permissionDecisionManager =
             mock(PermissionDecisionManager.class);
+    private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(LoginHandler.class);
@@ -199,7 +201,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
-                        permissionDecisionManager);
+                        permissionDecisionManager,
+                        userActionsManager);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -330,11 +330,12 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     switch (countType) {
                         case ENTER_EMAIL -> ForbiddenReason
                                 .EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT;
+                        case ENTER_EMAIL_CODE -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT;
                         case ENTER_PASSWORD -> ForbiddenReason
                                 .EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT;
-                        case ENTER_MFA_CODE -> ForbiddenReason
+                        case ENTER_MFA_CODE, ENTER_SMS_CODE, ENTER_AUTH_APP_CODE -> ForbiddenReason
                                 .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
-                        default -> null;
                     };
 
             when(permissionDecisionManager.canReceivePassword(any(), any()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -45,6 +45,7 @@ import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -151,6 +152,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
             mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(LoginHandler.class);
@@ -189,7 +192,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         commonPasswordsService,
                         authenticationAttemptsService,
                         authSessionService,
-                        mfaMethodsService);
+                        mfaMethodsService,
+                        permissionDecisionManager);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -41,7 +41,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -150,7 +149,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
             mock(CloudwatchMetricsService.class);
     private final CommonPasswordsService commonPasswordsService =
             mock(CommonPasswordsService.class);
-    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
@@ -191,7 +189,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         configurationService,
                         authenticationService,
                         clientService,
-                        codeStorageService,
                         userMigrationService,
                         auditService,
                         cloudwatchMetricsService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -53,6 +53,7 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
@@ -158,6 +159,7 @@ class LoginHandlerTest {
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final PermissionDecisionManager permissionDecisionManager =
             mock(PermissionDecisionManager.class);
+    private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -224,7 +226,8 @@ class LoginHandlerTest {
                         authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
-                        permissionDecisionManager);
+                        permissionDecisionManager,
+                        userActionsManager);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -52,6 +52,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -151,6 +152,8 @@ class LoginHandlerTest {
             mock(CommonPasswordsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -214,7 +217,8 @@ class LoginHandlerTest {
                         commonPasswordsService,
                         authenticationAttemptsService,
                         authSessionService,
-                        mfaMethodsService);
+                        mfaMethodsService,
+                        permissionDecisionManager);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -46,7 +46,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -147,7 +146,6 @@ class LoginHandlerTest {
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final UserMigrationService userMigrationService = mock(UserMigrationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -223,7 +221,6 @@ class LoginHandlerTest {
                         configurationService,
                         authenticationService,
                         clientService,
-                        codeStorageService,
                         userMigrationService,
                         auditService,
                         cloudwatchMetricsService,
@@ -933,7 +930,6 @@ class LoginHandlerTest {
                                         mfaMethodType.equals(AUTH_APP)
                                                 ? DEFAULT_AUTH_APP_MFA_METHOD
                                                 : DEFAULT_SMS_MFA_METHOD)));
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(4);
         usingValidAuthSession();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -174,7 +175,8 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
             String eventName = eventEntry.getKey();
             Map<String, String> attributes = eventEntry.getValue();
 
-            AuditEventExpectation expectation = new AuditEventExpectation(eventName);
+            AuditEventExpectation expectation =
+                    new AuditEventExpectation(FrontendAuditableEvent.valueOf(eventName));
 
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
                 expectation.withAttribute(attributeEntry.getKey(), attributeEntry.getValue());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -182,7 +182,7 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
                 expectation.withAttribute(attributeEntry.getKey(), attributeEntry.getValue());
             }
 
-            expectation.verify(receivedEvents);
+            expectation.assertPublished(receivedEvents);
             assertNoTxmaAuditEventsReceived(txmaAuditQueue);
         }
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -438,13 +438,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                     : ErrorResponse.TOO_MANY_INVALID_PW_ENTERED));
             assertAuditEventExpectations(
                     txmaAuditQueue,
-                    List.of(
-                            isReauth
-                                    ? reauthFailedEventExpectation
-                                    : new AuditEventExpectation(lockoutEventExpectation)
-                                            .withAttribute(
-                                                    NUMBER_OF_ATTEMPTS_USER_ALLOWED_TO_LOGIN,
-                                                    "0")));
+                    List.of(isReauth ? reauthFailedEventExpectation : lockoutEventExpectation));
         }
 
         @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.testsupport;
+
+public interface AuditTestConstants {
+    String INTERNAL_SUBJECT_ID = "extensions.internalSubjectId";
+    String INCORRECT_PASSWORD_COUNT = "extensions.incorrectPasswordCount";
+    String ATTEMPT_NO_FAILED_AT = "extensions.attemptNoFailedAt";
+    String INCORRECT_EMAIL_ATTEMPT_COUNT = "extensions.incorrect_email_attempt_count";
+    String INCORRECT_OTP_CODE_ATTEMPT_COUNT = "extensions.incorrect_otp_code_attempt_count";
+    String INCORRECT_PASSWORD_ATTEMPT_COUNT = "extensions.incorrect_password_attempt_count";
+    String FAILURE_REASON = "extensions.failure-reason";
+    String RP_PAIRWISE_ID = "extensions.rpPairwiseId";
+    String NUMBER_OF_ATTEMPTS_USER_ALLOWED_TO_LOGIN =
+            "extensions.number_of_attempts_user_allowed_to_login";
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -182,6 +182,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         public boolean supportReauthSignoutEnabled() {
                             return true;
                         }
+
+                        @Override
+                        public boolean isAuthenticationAttemptsServiceEnabled() {
+                            return true;
+                        }
                     };
 
     protected static final ConfigurationService EMAIL_CHECK_AND_TXMA_ENABLED_CONFIGURATION_SERVICE =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -171,4 +171,18 @@ public class AuditAssertionsHelper {
                                         actualMetadataPairForMfaMethod),
                         () -> fail("Missing metadata key: " + field));
     }
+
+    public static void assertAuditEventExpectations(
+            SqsQueueExtension queue, List<AuditEventExpectation> expectedEvents) {
+        List<AuditableEvent> events =
+                expectedEvents.stream().map(AuditEventExpectation::getEvent).toList();
+
+        List<String> receivedEvents = assertTxmaAuditEventsReceived(queue, events);
+
+        for (AuditEventExpectation expectation : expectedEvents) {
+            expectation.verify(receivedEvents);
+        }
+
+        assertNoTxmaAuditEventsReceived(queue);
+    }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -180,7 +180,7 @@ public class AuditAssertionsHelper {
         List<String> receivedEvents = assertTxmaAuditEventsReceived(queue, events);
 
         for (AuditEventExpectation expectation : expectedEvents) {
-            expectation.verify(receivedEvents);
+            expectation.assertPublished(receivedEvents);
         }
 
         assertNoTxmaAuditEventsReceived(queue);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
@@ -37,7 +37,7 @@ public class AuditEventExpectation {
         return this;
     }
 
-    public void verify(List<String> receivedEvents) {
+    public void assertPublished(List<String> receivedEvents) {
         for (String event : receivedEvents) {
             var jsonEvent = JsonParser.parseString(event).getAsJsonObject();
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
@@ -19,6 +19,15 @@ public class AuditEventExpectation {
         this.expectedAttributes = new HashMap<>();
     }
 
+    public AuditEventExpectation(AuditEventExpectation expectation) {
+        this.event = expectation.event;
+        this.expectedAttributes = expectation.expectedAttributes;
+    }
+
+    public AuditableEvent getEvent() {
+        return event;
+    }
+
     private String getEventName() {
         return event.toString();
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
@@ -81,7 +81,9 @@ public class AuditEventExpectation {
                 "No matching audit event found for "
                         + this.getEventName()
                         + " with expected attributes: "
-                        + expectedAttributes);
+                        + expectedAttributes
+                        + " but received the following "
+                        + receivedEvents);
     }
 
     private JsonElement getJsonElementByPath(JsonObject json, String path) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -112,7 +112,8 @@ public enum ErrorResponse {
     USER_DOES_NOT_HAVE_ACCOUNT(1086, "Email from request does not have any user credentials"),
     FAILED_TO_RAISE_AUDIT_EVENT(1087, "Failed to raise an audit event"),
     STORAGE_LAYER_ERROR(1088, "Error retrieving account details"),
-    EMAIL_ADDRESS_DENIED(1089, "Email address is denied");
+    EMAIL_ADDRESS_DENIED(1089, "Email address is denied"),
+    UNHANDLED_NEGATIVE_DECISION(1090, "Permissions manager negative decision was not handled");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -87,8 +87,8 @@ public class CodeStorageService {
                 email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue());
     }
 
-    public void increaseIncorrectPasswordCount(String email) {
-        increaseCount(
+    public int increaseIncorrectPasswordCount(String email) {
+        return increaseCount(
                 email,
                 MULTIPLE_INCORRECT_PASSWORDS_PREFIX,
                 configurationService.getIncorrectPasswordLockoutCountTTL());
@@ -228,7 +228,7 @@ public class CodeStorageService {
                 String.format("No redis prefix key configured for %s", notificationType));
     }
 
-    private void increaseCount(String email, String prefix, long ttl) {
+    private int increaseCount(String email, String prefix, long ttl) {
         String encodedHash = HashHelper.hashSha256String(email);
         String key = prefix + encodedHash;
         Optional<String> count = Optional.ofNullable(redisConnectionService.getValue(key));
@@ -236,6 +236,7 @@ public class CodeStorageService {
         try {
             redisConnectionService.saveWithExpiry(key, String.valueOf(newCount), ttl);
             LOG.info("count increased from: {} to: {}", count, newCount);
+            return newCount;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -2,8 +2,6 @@ package uk.gov.di.authentication.shared.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.HashHelper;
@@ -132,24 +130,6 @@ public class CodeStorageService {
         deleteCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX);
     }
 
-    public long getMfaCodeBlockTimeToLive(
-            String email, MFAMethodType mfaMethodType, JourneyType journeyType) {
-        var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        long finalTtl = getTTL(email, codeBlockedKeyPrefix);
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(mfaMethodType, journeyType);
-        if (deprecatedCodeRequestType != null) {
-            long possibleOverrideTtl =
-                    getTTL(email, CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType);
-            finalTtl = Math.max(finalTtl, possibleOverrideTtl);
-        }
-
-        return finalTtl;
-    }
-
     public void saveBlockedForEmail(String email, String prefix, long codeBlockedTime) {
         String encodedHash = HashHelper.hashSha256String(email);
         String key = prefix + encodedHash;
@@ -211,6 +191,10 @@ public class CodeStorageService {
         }
     }
 
+    public long getTTL(String email, String prefix) {
+        return redisConnectionService.getTimeToLive(prefix + HashHelper.hashSha256String(email));
+    }
+
     private String getPrefixForNotificationType(NotificationType notificationType) {
         switch (notificationType) {
             case VERIFY_EMAIL:
@@ -259,9 +243,5 @@ public class CodeStorageService {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private long getTTL(String email, String prefix) {
-        return redisConnectionService.getTimeToLive(prefix + HashHelper.hashSha256String(email));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -2,10 +2,6 @@ package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 
@@ -18,7 +14,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 class CodeStorageServiceTest {
 
@@ -282,59 +277,6 @@ class CodeStorageServiceTest {
                                 MFAMethodType.AUTH_APP)))
                 .thenReturn(String.valueOf(3));
         assertThat(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL), equalTo(6));
-    }
-
-    @ParameterizedTest
-    @CsvSource({"AUTH_APP", "SMS"})
-    void shouldReturnMfaCodeBlockTimeForAuthAppAndSMS(MFAMethodType mfaMethodType) {
-        var codeRequestType =
-                CodeRequestType.getCodeRequestType(mfaMethodType, JourneyType.SIGN_IN);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        when(redisConnectionService.getTimeToLive(codeBlockedKeyPrefix + TEST_EMAIL_HASH))
-                .thenReturn(4L);
-        assertThat(
-                codeStorageService.getMfaCodeBlockTimeToLive(
-                        TEST_EMAIL, mfaMethodType, JourneyType.SIGN_IN),
-                equalTo(4L));
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @ParameterizedTest
-    @CsvSource({"AUTH_APP", "SMS"})
-    void shouldReturnMfaCodeBlockTimeForAuthAppAndSMSWithDeprecatedPrefix(
-            MFAMethodType mfaMethodType) {
-        var codeBlockedKeyPrefix =
-                CODE_BLOCKED_KEY_PREFIX
-                        + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                mfaMethodType, JourneyType.SIGN_IN);
-        when(redisConnectionService.getTimeToLive(codeBlockedKeyPrefix + TEST_EMAIL_HASH))
-                .thenReturn(4L);
-        assertThat(
-                codeStorageService.getMfaCodeBlockTimeToLive(
-                        TEST_EMAIL, mfaMethodType, JourneyType.SIGN_IN),
-                equalTo(4L));
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @ParameterizedTest
-    @CsvSource({"AUTH_APP", "SMS"})
-    void shouldReturnLargerMfaCodeBlockTimeForAuthAppAndSMSWithBothActiveAndDeprecatedPrefix(
-            MFAMethodType mfaMethodType) {
-        var activeCodeBlockedKeyPrefix =
-                CODE_BLOCKED_KEY_PREFIX
-                        + CodeRequestType.getCodeRequestType(mfaMethodType, JourneyType.SIGN_IN);
-        var deprecatedCodeBlockedKeyPrefix =
-                CODE_BLOCKED_KEY_PREFIX
-                        + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                mfaMethodType, JourneyType.SIGN_IN);
-        when(redisConnectionService.getTimeToLive(activeCodeBlockedKeyPrefix + TEST_EMAIL_HASH))
-                .thenReturn(4L);
-        when(redisConnectionService.getTimeToLive(deprecatedCodeBlockedKeyPrefix + TEST_EMAIL_HASH))
-                .thenReturn(6L);
-        assertThat(
-                codeStorageService.getMfaCodeBlockTimeToLive(
-                        TEST_EMAIL, mfaMethodType, JourneyType.SIGN_IN),
-                equalTo(6L));
     }
 
     @Test

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -26,16 +26,17 @@ public class PermissionDecisionManager implements PermissionDecisions {
     private final CodeStorageService codeStorageService;
     private final ConfigurationService configurationService;
 
-    public PermissionDecisionManager() {
-        this.configurationService = ConfigurationService.getInstance();
-        var redis = new RedisConnectionService(configurationService);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
+    public PermissionDecisionManager(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.codeStorageService =
+                new CodeStorageService(
+                        configurationService, new RedisConnectionService(configurationService));
     }
 
     public PermissionDecisionManager(
-            CodeStorageService codeStorageService, ConfigurationService configurationService) {
-        this.codeStorageService = codeStorageService;
+            ConfigurationService configurationService, CodeStorageService codeStorageService) {
         this.configurationService = configurationService;
+        this.codeStorageService = codeStorageService;
     }
 
     @Override

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -188,21 +188,8 @@ public class PermissionDecisionManager implements PermissionDecisions {
     }
 
     @Override
-    public Result<DecisionError, Decision> canVerifySmsOtp(
-            JourneyType journeyType, UserPermissionContext userPermissionContext) {
-        return Result.success(new Decision.Permitted(0));
-    }
-
-    @Override
     public Result<DecisionError, Decision> canVerifyMfaOtp(
             JourneyType journeyType, UserPermissionContext userPermissionContext) {
-        return canVerifyAuthAppOtp(journeyType, userPermissionContext);
-    }
-
-    @Override
-    public Result<DecisionError, Decision> canVerifyAuthAppOtp(
-            JourneyType journeyType, UserPermissionContext userPermissionContext) {
-
         try {
             var ttl =
                     codeStorageService.getMfaCodeBlockTimeToLive(

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -25,18 +26,32 @@ public class PermissionDecisionManager implements PermissionDecisions {
 
     private final CodeStorageService codeStorageService;
     private final ConfigurationService configurationService;
+    private final AuthenticationAttemptsService authenticationAttemptsService;
 
     public PermissionDecisionManager(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.codeStorageService =
                 new CodeStorageService(
                         configurationService, new RedisConnectionService(configurationService));
+        this.authenticationAttemptsService =
+                new AuthenticationAttemptsService(configurationService);
     }
 
     public PermissionDecisionManager(
             ConfigurationService configurationService, CodeStorageService codeStorageService) {
         this.configurationService = configurationService;
         this.codeStorageService = codeStorageService;
+        this.authenticationAttemptsService =
+                new AuthenticationAttemptsService(configurationService);
+    }
+
+    public PermissionDecisionManager(
+            ConfigurationService configurationService,
+            CodeStorageService codeStorageService,
+            AuthenticationAttemptsService authenticationAttemptsService) {
+        this.configurationService = configurationService;
+        this.codeStorageService = codeStorageService;
+        this.authenticationAttemptsService = authenticationAttemptsService;
     }
 
     @Override

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -194,7 +194,7 @@ public class PermissionDecisionManager implements PermissionDecisions {
     }
 
     @Override
-    public Result<DecisionError, Decision> canVerifyOtp(
+    public Result<DecisionError, Decision> canVerifyMfaOtp(
             JourneyType journeyType, UserPermissionContext userPermissionContext) {
         return canVerifyAuthAppOtp(journeyType, userPermissionContext);
     }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -296,11 +296,14 @@ public class PermissionDecisionManager implements PermissionDecisions {
                             switch (exceededType) {
                                 case ENTER_EMAIL -> ForbiddenReason
                                         .EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT;
+                                case ENTER_EMAIL_CODE -> ForbiddenReason
+                                        .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT;
                                 case ENTER_PASSWORD -> ForbiddenReason
                                         .EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT;
-                                case ENTER_MFA_CODE -> ForbiddenReason
+                                case ENTER_MFA_CODE,
+                                        ENTER_SMS_CODE,
+                                        ENTER_AUTH_APP_CODE -> ForbiddenReason
                                         .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
-                                default -> null;
                             },
                             reauthCounts.getOrDefault(exceededType, 0),
                             Instant.now().plusSeconds(configurationService.getLockoutDuration()),

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -152,15 +152,17 @@ public class PermissionDecisionManager implements PermissionDecisions {
         }
 
         try {
-            int attemptCount =
-                    codeStorageService.getIncorrectPasswordCount(
-                            userPermissionContext.emailAddress());
-
             boolean isBlocked =
                     codeStorageService.isBlockedForEmail(
                             userPermissionContext.emailAddress(),
                             CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX
                                     + JourneyType.PASSWORD_RESET);
+
+            int attemptCount =
+                    isBlocked
+                            ? configurationService.getMaxPasswordRetries()
+                            : codeStorageService.getIncorrectPasswordCount(
+                                    userPermissionContext.emailAddress());
 
             if (isBlocked) {
                 return Result.success(

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisions.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisions.java
@@ -64,7 +64,7 @@ public interface PermissionDecisions {
             JourneyType journeyType, UserPermissionContext userPermissionContext);
 
     @Experimental()
-    Result<DecisionError, Decision> canVerifyOtp(
+    Result<DecisionError, Decision> canVerifyMfaOtp(
             JourneyType journeyType, UserPermissionContext userPermissionContext);
 
     /**

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisions.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisions.java
@@ -63,28 +63,14 @@ public interface PermissionDecisions {
     Result<DecisionError, Decision> canSendSmsOtpNotification(
             JourneyType journeyType, UserPermissionContext userPermissionContext);
 
-    @Experimental()
+    /**
+     * Checks if a user is permitted to verify an MFA OTP.
+     *
+     * @param journeyType The type of authentication journey
+     * @param userPermissionContext The user's permission context
+     * @return A Result containing either a Decision or a DecisionError
+     */
     Result<DecisionError, Decision> canVerifyMfaOtp(
-            JourneyType journeyType, UserPermissionContext userPermissionContext);
-
-    /**
-     * Checks if a user is permitted to verify an SMS OTP.
-     *
-     * @param journeyType The type of authentication journey
-     * @param userPermissionContext The user's permission context
-     * @return A Result containing either a Decision or a DecisionError
-     */
-    Result<DecisionError, Decision> canVerifySmsOtp(
-            JourneyType journeyType, UserPermissionContext userPermissionContext);
-
-    /**
-     * Checks if a user is permitted to verify an authenticator app OTP.
-     *
-     * @param journeyType The type of authentication journey
-     * @param userPermissionContext The user's permission context
-     * @return A Result containing either a Decision or a DecisionError
-     */
-    Result<DecisionError, Decision> canVerifyAuthAppOtp(
             JourneyType journeyType, UserPermissionContext userPermissionContext);
 
     /**

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
@@ -18,21 +19,39 @@ public class UserActionsManager implements UserActions {
 
     private static final Logger LOG = LogManager.getLogger(UserActionsManager.class);
 
+    private final ConfigurationService configurationService;
     private final CodeStorageService codeStorageService;
     private final AuthSessionService authSessionService;
-    private final ConfigurationService configurationService;
+    private final AuthenticationAttemptsService authenticationAttemptsService;
 
-    public UserActionsManager() {
-        this.codeStorageService = new CodeStorageService(ConfigurationService.getInstance());
-        this.authSessionService = new AuthSessionService(ConfigurationService.getInstance());
-        this.configurationService = ConfigurationService.getInstance();
+    public UserActionsManager(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.codeStorageService = new CodeStorageService(configurationService);
+        this.authSessionService = new AuthSessionService(configurationService);
+        this.authenticationAttemptsService =
+                new AuthenticationAttemptsService(configurationService);
     }
 
     public UserActionsManager(
-            CodeStorageService codeStorageService, AuthSessionService authSessionService) {
+            ConfigurationService configurationService,
+            CodeStorageService codeStorageService,
+            AuthSessionService authSessionService) {
+        this.configurationService = configurationService;
         this.codeStorageService = codeStorageService;
         this.authSessionService = authSessionService;
-        this.configurationService = ConfigurationService.getInstance();
+        this.authenticationAttemptsService =
+                new AuthenticationAttemptsService(configurationService);
+    }
+
+    public UserActionsManager(
+            ConfigurationService configurationService,
+            CodeStorageService codeStorageService,
+            AuthSessionService authSessionService,
+            AuthenticationAttemptsService authenticationAttemptsService) {
+        this.configurationService = configurationService;
+        this.codeStorageService = codeStorageService;
+        this.authSessionService = authSessionService;
+        this.authenticationAttemptsService = authenticationAttemptsService;
     }
 
     @Override

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -3,14 +3,18 @@ package uk.gov.di.authentication.userpermissions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
+
+import java.time.temporal.ChronoUnit;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
@@ -101,6 +105,32 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectPasswordReceived(
             JourneyType journeyType, UserPermissionContext userPermissionContext) {
+        if (journeyType.equals(JourneyType.REAUTHENTICATION)) {
+            authenticationAttemptsService.createOrIncrementCount(
+                    userPermissionContext.internalSubjectId(),
+                    NowHelper.nowPlus(
+                                    configurationService.getReauthEnterPasswordCountTTL(),
+                                    ChronoUnit.SECONDS)
+                            .toInstant()
+                            .getEpochSecond(),
+                    journeyType,
+                    CountType.ENTER_PASSWORD);
+        } else {
+            var updatedCount =
+                    codeStorageService.increaseIncorrectPasswordCount(
+                            userPermissionContext.emailAddress());
+            if (updatedCount >= configurationService.getMaxPasswordRetries()) {
+                LOG.info("User has now exceeded max password retries, setting block");
+                codeStorageService.saveBlockedForEmail(
+                        userPermissionContext.emailAddress(),
+                        CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET,
+                        configurationService.getLockoutDuration());
+
+                codeStorageService.deleteIncorrectPasswordCount(
+                        userPermissionContext.emailAddress());
+            }
+        }
+
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
@@ -3,8 +3,11 @@ package uk.gov.di.authentication.userpermissions.example;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.PermissionDecisions;
 import uk.gov.di.authentication.userpermissions.UserActions;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
 
@@ -14,8 +17,20 @@ import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair
 public class ExampleSmsVerificationHandler {
     private static final String EXPECTED_OTP = "372615";
 
-    private PermissionDecisions permissionDecisions;
-    private UserActions userActions;
+    private final PermissionDecisions permissionDecisions;
+    private final UserActions userActions;
+
+    public ExampleSmsVerificationHandler() {
+        var configurationService = ConfigurationService.getInstance();
+        this.permissionDecisions = new PermissionDecisionManager(configurationService);
+        this.userActions = new UserActionsManager(configurationService);
+    }
+
+    public ExampleSmsVerificationHandler(
+            PermissionDecisions permissionDecisions, UserActions userActions) {
+        this.permissionDecisions = permissionDecisions;
+        this.userActions = userActions;
+    }
 
     public String handle(String submittedOtp) {
         JourneyType journeyType = JourneyType.SIGN_IN;

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
@@ -28,7 +28,7 @@ public class ExampleSmsVerificationHandler {
                         .withAuthSessionItem(new AuthSessionItem())
                         .build();
 
-        var checkResult = permissionDecisions.canVerifySmsOtp(journeyType, userPermissionContext);
+        var checkResult = permissionDecisions.canVerifyMfaOtp(journeyType, userPermissionContext);
         if (checkResult.isFailure()) {
             return (format("500: %s", checkResult.getFailure().name()));
         }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -536,7 +536,8 @@ class PermissionDecisionManagerTest {
                             EMAIL, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN))
                     .thenReturn(0L);
 
-            var result = permissionDecisionManager.canVerifyOtp(JourneyType.SIGN_IN, userContext);
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
             assertTrue(result.isSuccess());
             var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -424,7 +424,7 @@ class PermissionDecisionManagerTest {
     }
 
     @Nested
-    class CanVerifyAuthAppOtp {
+    class CanVerifyMfaOtp {
 
         @Test
         void shouldReturnPermittedWhenNotBlocked() {
@@ -434,7 +434,7 @@ class PermissionDecisionManagerTest {
                     .thenReturn(0L);
 
             var result =
-                    permissionDecisionManager.canVerifyAuthAppOtp(JourneyType.SIGN_IN, userContext);
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
             assertTrue(result.isSuccess());
             var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
@@ -450,7 +450,7 @@ class PermissionDecisionManagerTest {
                     .thenReturn(blockTtl);
 
             var result =
-                    permissionDecisionManager.canVerifyAuthAppOtp(JourneyType.SIGN_IN, userContext);
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
             assertTrue(result.isSuccess());
             var lockedOut =
@@ -469,7 +469,7 @@ class PermissionDecisionManagerTest {
                     .getMfaCodeBlockTimeToLive(EMAIL, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
 
             var result =
-                    permissionDecisionManager.canVerifyAuthAppOtp(JourneyType.SIGN_IN, userContext);
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
             assertTrue(result.isFailure());
             assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
@@ -510,7 +510,7 @@ class PermissionDecisionManagerTest {
             var userContext = createUserContext(0);
 
             var result =
-                    permissionDecisionManager.canVerifySmsOtp(JourneyType.SIGN_IN, userContext);
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
             assertTrue(result.isSuccess());
             var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
@@ -530,7 +530,7 @@ class PermissionDecisionManagerTest {
         }
 
         @Test
-        void canVerifyOtpShouldDelegateToCanVerifyAuthAppOtp() {
+        void canVerifyOtpShouldDelegateToCanVerifyMfaOtp() {
             var userContext = createUserContext(0);
             when(codeStorageService.getMfaCodeBlockTimeToLive(
                             EMAIL, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN))

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
@@ -31,9 +32,12 @@ class PermissionDecisionManagerTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
+    private final AuthenticationAttemptsService authenticationAttemptsService =
+            mock(AuthenticationAttemptsService.class);
 
     private final PermissionDecisionManager permissionDecisionManager =
-            new PermissionDecisionManager(codeStorageService, configurationService);
+            new PermissionDecisionManager(
+                    configurationService, codeStorageService, authenticationAttemptsService);
 
     @BeforeEach
     void setup() {

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -3,8 +3,12 @@ package uk.gov.di.authentication.userpermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -14,6 +18,9 @@ import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
+
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -306,6 +313,91 @@ class PermissionDecisionManagerTest {
 
             assertTrue(result.isFailure());
             assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
+        }
+
+        @Test
+        void shouldReturnPermittedForReauthenticationJourney() {
+            var userContext = createUserContext(3);
+            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                            userContext.internalSubjectId(),
+                            userContext.rpPairwiseId(),
+                            JourneyType.REAUTHENTICATION))
+                    .thenReturn(Map.of(CountType.ENTER_PASSWORD, 2));
+            when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+            when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+            when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+            var result =
+                    permissionDecisionManager.canReceivePassword(
+                            JourneyType.REAUTHENTICATION, userContext);
+
+            assertTrue(result.isSuccess());
+            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+            assertEquals(2, decision.attemptCount());
+        }
+
+        @ParameterizedTest
+        @MethodSource("countTypeToForbiddenReasonProvider")
+        void shouldReturnTemporarilyLockedOutForReauthenticationWhenCountExceeded(
+                CountType countType, ForbiddenReason expectedReason) {
+            var userContext = createUserContext(3);
+            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                            userContext.internalSubjectId(),
+                            userContext.rpPairwiseId(),
+                            JourneyType.REAUTHENTICATION))
+                    .thenReturn(Map.of(countType, 6));
+            when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+            when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+            when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+            var result =
+                    permissionDecisionManager.canReceivePassword(
+                            JourneyType.REAUTHENTICATION, userContext);
+
+            assertTrue(result.isSuccess());
+            var lockedOut =
+                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            assertEquals(expectedReason, lockedOut.forbiddenReason());
+            assertEquals(6, lockedOut.attemptCount());
+        }
+
+        static Stream<Arguments> countTypeToForbiddenReasonProvider() {
+            return Stream.of(
+                    Arguments.of(
+                            CountType.ENTER_PASSWORD,
+                            ForbiddenReason.EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT),
+                    Arguments.of(
+                            CountType.ENTER_EMAIL,
+                            ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT),
+                    Arguments.of(
+                            CountType.ENTER_MFA_CODE,
+                            ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT));
+        }
+
+        @Test
+        void shouldReturnErrorForReauthenticationJourneyWhenInternalSubjectIdIsNull() {
+            var userContext =
+                    new UserPermissionContext(null, "pairwise", EMAIL, new AuthSessionItem());
+
+            var result =
+                    permissionDecisionManager.canReceivePassword(
+                            JourneyType.REAUTHENTICATION, userContext);
+
+            assertTrue(result.isFailure());
+            assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+        }
+
+        @Test
+        void shouldReturnErrorForReauthenticationJourneyWhenRpPairwiseIdIsNull() {
+            var userContext =
+                    new UserPermissionContext("subject", null, EMAIL, new AuthSessionItem());
+
+            var result =
+                    permissionDecisionManager.canReceivePassword(
+                            JourneyType.REAUTHENTICATION, userContext);
+
+            assertTrue(result.isFailure());
+            assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionsTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionsTest.java
@@ -84,18 +84,6 @@ class PermissionDecisionsTest {
         @Override
         public Result<DecisionError, Decision> canVerifyMfaOtp(
                 JourneyType journeyType, UserPermissionContext userPermissionContext) {
-            return null;
-        }
-
-        @Override
-        public Result<DecisionError, Decision> canVerifySmsOtp(
-                JourneyType journeyType, UserPermissionContext userPermissionContext) {
-            return Result.success(new Decision.Permitted(0));
-        }
-
-        @Override
-        public Result<DecisionError, Decision> canVerifyAuthAppOtp(
-                JourneyType journeyType, UserPermissionContext userPermissionContext) {
             return Result.success(new Decision.Permitted(0));
         }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionsTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionsTest.java
@@ -82,7 +82,7 @@ class PermissionDecisionsTest {
         }
 
         @Override
-        public Result<DecisionError, Decision> canVerifyOtp(
+        public Result<DecisionError, Decision> canVerifyMfaOtp(
                 JourneyType journeyType, UserPermissionContext userPermissionContext) {
             return null;
         }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -67,6 +67,18 @@ class UserActionsManagerTest {
     }
 
     @Test
+    void passwordResetShouldHandleDifferentJourneyTypes() {
+        var result = userActionsManager.passwordReset(JourneyType.SIGN_IN, userPermissionContext);
+
+        verify(codeStorageService).deleteIncorrectPasswordCount(EMAIL);
+        verify(codeStorageService)
+                .deleteBlockForEmail(
+                        EMAIL,
+                        CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.SIGN_IN);
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
     void sentEmailOtpNotificationShouldIncrementPasswordResetCountForPasswordResetJourney() {
         var result =
                 userActionsManager.sentEmailOtpNotification(
@@ -98,17 +110,6 @@ class UserActionsManagerTest {
     }
 
     @Test
-    void sentEmailOtpNotificationShouldNotBlockForNonPasswordResetJourney() {
-        var result =
-                userActionsManager.sentEmailOtpNotification(
-                        JourneyType.SIGN_IN, userPermissionContext);
-
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(anyString(), anyString(), anyLong());
-        assertTrue(result.isSuccess());
-    }
-
-    @Test
     void sentEmailOtpNotificationShouldHandleExactlyMaxRetries() {
         var sessionWithExactMaxCount = authSession;
         for (int i = 0; i < 6; i++) {
@@ -131,14 +132,13 @@ class UserActionsManagerTest {
     }
 
     @Test
-    void passwordResetShouldHandleDifferentJourneyTypes() {
-        var result = userActionsManager.passwordReset(JourneyType.SIGN_IN, userPermissionContext);
+    void sentEmailOtpNotificationShouldNotBlockForNonPasswordResetJourney() {
+        var result =
+                userActionsManager.sentEmailOtpNotification(
+                        JourneyType.SIGN_IN, userPermissionContext);
 
-        verify(codeStorageService).deleteIncorrectPasswordCount(EMAIL);
-        verify(codeStorageService)
-                .deleteBlockForEmail(
-                        EMAIL,
-                        CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.SIGN_IN);
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(anyString(), anyString(), anyLong());
         assertTrue(result.isSuccess());
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
@@ -28,6 +29,8 @@ class UserActionsManagerTest {
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AuthenticationAttemptsService authenticationAttemptsService =
+            mock(AuthenticationAttemptsService.class);
     private UserActionsManager userActionsManager;
 
     private static final String EMAIL = "test@example.com";
@@ -39,7 +42,12 @@ class UserActionsManagerTest {
 
     @BeforeEach
     void setUp() {
-        userActionsManager = new UserActionsManager(codeStorageService, authSessionService);
+        userActionsManager =
+                new UserActionsManager(
+                        configurationService,
+                        codeStorageService,
+                        authSessionService,
+                        authenticationAttemptsService);
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
         when(configurationService.getLockoutDuration()).thenReturn(900L);
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandlerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandlerTest.java
@@ -53,7 +53,7 @@ class ExampleSmsVerificationHandlerTest {
     @Test
     void shouldReturnSuccessWhenOtpIsCorrect() {
         // Given
-        when(permissionDecisions.canVerifySmsOtp(any(), any()))
+        when(permissionDecisions.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActions.correctSmsOtpReceived(any(), any())).thenReturn(Result.success(null));
 
@@ -69,7 +69,7 @@ class ExampleSmsVerificationHandlerTest {
     @Test
     void shouldReturnErrorWhenOtpIsIncorrect() {
         // Given
-        when(permissionDecisions.canVerifySmsOtp(any(), any()))
+        when(permissionDecisions.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActions.incorrectSmsOtpReceived(any(), any())).thenReturn(Result.success(null));
 
@@ -87,7 +87,7 @@ class ExampleSmsVerificationHandlerTest {
         // Given
         Instant lockedUntil = Instant.now().plusSeconds(300);
         ForbiddenReason reason = ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
-        when(permissionDecisions.canVerifySmsOtp(any(), any()))
+        when(permissionDecisions.canVerifyMfaOtp(any(), any()))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(reason, 5, lockedUntil, false)));
@@ -103,7 +103,7 @@ class ExampleSmsVerificationHandlerTest {
     @Test
     void shouldReturnErrorWhenPermissionCheckFails() {
         // Given
-        when(permissionDecisions.canVerifySmsOtp(any(), any()))
+        when(permissionDecisions.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
 
         // When

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandlerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandlerTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.UserPermissionContext;
 
-import java.lang.reflect.Field;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,23 +30,10 @@ class ExampleSmsVerificationHandlerTest {
     private static final String INCORRECT_OTP = "000000";
 
     @BeforeEach
-    void setUp() throws Exception {
-        // Create mocks manually instead of using annotations
+    void setUp() {
         permissionDecisions = mock(PermissionDecisions.class);
         userActions = mock(UserActions.class);
-
-        handler = new ExampleSmsVerificationHandler();
-
-        // Use reflection to set the mocked dependencies
-        Field permissionDecisionsField =
-                ExampleSmsVerificationHandler.class.getDeclaredField("permissionDecisions");
-        permissionDecisionsField.setAccessible(true);
-        permissionDecisionsField.set(handler, permissionDecisions);
-
-        Field userActionsField =
-                ExampleSmsVerificationHandler.class.getDeclaredField("userActions");
-        userActionsField.setAccessible(true);
-        userActionsField.set(handler, userActions);
+        handler = new ExampleSmsVerificationHandler(permissionDecisions, userActions);
     }
 
     @Test


### PR DESCRIPTION
## What

This PR refactors LoginHandler lockout handling by centralising permission logic from the handler to the new dedicated management classes, improving lockout maintainability and consistency.

It starts by first improving and filling gaps in our integration tests for LoginHandler to protect against regression.

There are many small commits that do small things, interspersed with larger commits that move the lockout logic from the handler to the PermissionDecisionManager and UserActionsManager.

The end result is that the LoginHandler no longer cares about how lockouts are implemented, just that they can be checked and responded to if a lockout exists.

## How to review

1. Code Review, commit-by-commit and ignore whitespace recommended
1. Spot check that the lockouts are working

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.