### PR TITLE
ATO-1777: Send Slack messages to 2 channels for orch PagerDuty alerts

### DIFF
--- a/orchestration-alerting/slackNotifications.js
+++ b/orchestration-alerting/slackNotifications.js
@@ -107,16 +107,15 @@ const handler = async function (event, context) {
   const isEnabledForProd = process.env.DEPLOY_ENVIRONMENT === "production";
   const isPagerDutyAlarm = snsMessage.AlarmName.includes("pagerduty");
   if (isPagerDutyAlarm && isEnabledForProd) {
+    console.log("PagerDuty alarm, sending 2 notifications");
     messageRequestBody.channel =
       process.env.SLACK_CHANNEL_ID ||
       (await getParameter("pagerduty-slack-channel-id"));
-  } else {
-    messageRequestBody.channel =
-      process.env.SLACK_CHANNEL_ID ||
-      (await getParameter(
-        process.env.DEPLOY_ENVIRONMENT + "-slack-channel-id",
-      ));
+    await sendAlertToSlack(messageRequestBody);
   }
+  messageRequestBody.channel =
+    process.env.SLACK_CHANNEL_ID ||
+    (await getParameter(process.env.DEPLOY_ENVIRONMENT + "-slack-channel-id"));
 
   console.log("Sending alert to slack");
   await sendAlertToSlack(messageRequestBody);


### PR DESCRIPTION
### Wider context of change

We recently added PagerDuty alarms that, when triggered, notify PagerDuty and send a slack message to the `pagerduty-slack-channel-id`. We would also like to send this slack message to `production-slack-channel-id` for increased observability. 

### What’s changed

This PR does a bit of refactoring in `slackNotifications.js`, allowing for you to send multiple slack messages in one invocation of the lambda. If a pagerduty alarm is triggered, it will send a slack message to the `pagerduty-slack-channel-id` channel first, then it will send a slack message to `production-slack-channel-id`

### Manual testing

Tested by enabling the pagerduty alarms in dev. Saw 2 slack messages get sent to 2 different channels from the lambda.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

