### PR TITLE
ATO-1875: Add method to get list from secrets manager

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -26,7 +26,8 @@ dependencies {
             configurations.cloudwatch,
             configurations.gson,
             configurations.apache,
-            configurations.open_telemetry
+            configurations.open_telemetry,
+            configurations.secretsmanager
 
     implementation("software.amazon.awssdk:cloudwatchlogs:${dependencyVersions.aws_sdk_v2_version}")
 


### PR DESCRIPTION
### Wider context of change

### What’s changed:
- Adds a method to get a secret value from secrets manager
- Method is currently only implemented in tests 

### Manual testing:
- Method not yet used so no manual testing required

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [X] Lambdas have correct permissions for the resources they're accessing: See https://github.com/govuk-one-login/authentication-api/pull/7145

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [X] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [X] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [X] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [X] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [X] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
