### PR TITLE
BAU: Refactor orch dynamo tests

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.oidc.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.oidc.entity.SlidingWindowData;
 import uk.gov.di.authentication.oidc.exceptions.ClientRateLimitDataException;
 import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
@@ -14,8 +13,6 @@ import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.helper.Constants.TEST_CLIENT_ID;
 
@@ -60,11 +57,5 @@ class ClientRateLimitDataServiceTest extends BaseDynamoServiceTest<SlidingWindow
                 new SlidingWindowData(TEST_CLIENT_ID, TEST_PERIOD_START).withTimeToLive(VALID_TTL);
         when(table.getItem(RATE_LIMIT_DATA_GET_REQUEST)).thenReturn(existingSlidingWindowData);
         return existingSlidingWindowData;
-    }
-
-    private void withFailedGet() {
-        doThrow(DynamoDbException.builder().message("Failed to get from table").build())
-                .when(table)
-                .getItem(any(GetItemEnhancedRequest.class));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.oidc.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.oidc.entity.SlidingWindowData;
@@ -23,16 +22,8 @@ import static uk.gov.di.orchestration.sharedtest.helper.Constants.TEST_CLIENT_ID
 class ClientRateLimitDataServiceTest extends BaseDynamoServiceTest<SlidingWindowData> {
     private static final LocalDateTime TEST_PERIOD_START =
             LocalDateTime.parse("2025-09-14T13:00:00");
-    private static final Key TEST_PARTITION_AND_SORT_KEY =
-            Key.builder()
-                    .partitionValue(TEST_CLIENT_ID)
-                    .sortValue(TEST_PERIOD_START.toString())
-                    .build();
     private static final GetItemEnhancedRequest RATE_LIMIT_DATA_GET_REQUEST =
-            GetItemEnhancedRequest.builder()
-                    .key(TEST_PARTITION_AND_SORT_KEY)
-                    .consistentRead(true)
-                    .build();
+            getRequestFor(TEST_CLIENT_ID, TEST_PERIOD_START.toString());
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private ClientRateLimitDataService clientRateLimitDataService;
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientRateLimitDataServiceTest.java
@@ -2,13 +2,12 @@ package uk.gov.di.authentication.oidc.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.oidc.entity.SlidingWindowData;
 import uk.gov.di.authentication.oidc.exceptions.ClientRateLimitDataException;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -18,11 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.helper.Constants.TEST_CLIENT_ID;
 
-class ClientRateLimitDataServiceTest {
+class ClientRateLimitDataServiceTest extends BaseDynamoServiceTest<SlidingWindowData> {
     private static final LocalDateTime TEST_PERIOD_START =
             LocalDateTime.parse("2025-09-14T13:00:00");
     private static final Key TEST_PARTITION_AND_SORT_KEY =
@@ -36,8 +34,6 @@ class ClientRateLimitDataServiceTest {
                     .consistentRead(true)
                     .build();
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
-    private final DynamoDbTable<SlidingWindowData> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
     private ClientRateLimitDataService clientRateLimitDataService;
 
     @BeforeEach

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
@@ -1,11 +1,15 @@
 package uk.gov.di.orchestration.sharedtest.basetest;
 
+import org.mockito.ArgumentMatchers;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 public abstract class BaseDynamoServiceTest<T> {
@@ -23,5 +27,29 @@ public abstract class BaseDynamoServiceTest<T> {
 
     private static GetItemEnhancedRequest getRequestFor(Key key) {
         return GetItemEnhancedRequest.builder().key(key).consistentRead(true).build();
+    }
+
+    protected void withFailedGet() {
+        doThrow(DynamoDbException.builder().message("Failed to get item from table").build())
+                .when(table)
+                .getItem(any(GetItemEnhancedRequest.class));
+    }
+
+    protected void withFailedPut() {
+        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
+                .when(table)
+                .putItem(ArgumentMatchers.<T>any());
+    }
+
+    protected void withFailedUpdate() {
+        doThrow(DynamoDbException.builder().message("Failed to update item in table").build())
+                .when(table)
+                .updateItem(ArgumentMatchers.<T>any());
+    }
+
+    protected void withFailedDelete() {
+        doThrow(DynamoDbException.builder().message("Failed to delete from table").build())
+                .when(table)
+                .deleteItem(ArgumentMatchers.<T>any());
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
@@ -1,0 +1,13 @@
+package uk.gov.di.orchestration.sharedtest.basetest;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import static org.mockito.Mockito.mock;
+
+public abstract class BaseDynamoServiceTest<T> {
+    protected final DynamoDbTable<T> table = mock(DynamoDbTable.class);
+    protected final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
+    protected final ConfigurationService configurationService = mock(ConfigurationService.class);
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.orchestration.sharedtest.basetest;
 
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
@@ -10,4 +12,16 @@ public abstract class BaseDynamoServiceTest<T> {
     protected final DynamoDbTable<T> table = mock(DynamoDbTable.class);
     protected final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
     protected final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    public static GetItemEnhancedRequest getRequestFor(String partitionKey) {
+        return getRequestFor(Key.builder().partitionValue(partitionKey).build());
+    }
+
+    public static GetItemEnhancedRequest getRequestFor(String partitionKey, String sortKey) {
+        return getRequestFor(Key.builder().partitionValue(partitionKey).sortValue(sortKey).build());
+    }
+
+    private static GetItemEnhancedRequest getRequestFor(Key key) {
+        return GetItemEnhancedRequest.builder().key(key).consistentRead(true).build();
+    }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DynamoClientServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DynamoClientServiceTest.java
@@ -6,11 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,22 +20,21 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.entity.ServiceType.MANDATORY;
 
-class DynamoClientServiceTest {
+class DynamoClientServiceTest extends BaseDynamoServiceTest<ClientRegistry> {
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name-one";
     private static final List<String> SCOPES = singletonList("openid");
     private static final String SERVICE_TYPE = String.valueOf(MANDATORY);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient =
             mock(DynamoDbEnhancedClient.class);
     private DynamoClientService dynamoClientService;
-    private final DynamoDbTable dynamoDbTable = mock(DynamoDbTable.class);
 
     @BeforeEach
     void setup() {
@@ -96,8 +96,9 @@ class DynamoClientServiceTest {
         var client = generatePopulatedClientRegistry();
 
         UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
-        when(dynamoDbTable.getItem((Key) any())).thenReturn(client);
-        when(dynamoDbEnhancedClient.table(any(), any())).thenReturn(dynamoDbTable);
+        when(table.getItem((Key) any())).thenReturn(client);
+        when(dynamoDbEnhancedClient.table(any(), eq(TableSchema.fromBean(ClientRegistry.class))))
+                .thenReturn(table);
         dynamoClientService =
                 spy(new DynamoClientService(configurationService, dynamoDbEnhancedClient));
 
@@ -124,8 +125,9 @@ class DynamoClientServiceTest {
                 .setIdentityVerificationSupported(true)
                 .setClaims(List.of("claim"));
 
-        when(dynamoDbTable.getItem((Key) any())).thenReturn(client);
-        when(dynamoDbEnhancedClient.table(any(), any())).thenReturn(dynamoDbTable);
+        when(table.getItem((Key) any())).thenReturn(client);
+        when(dynamoDbEnhancedClient.table(any(), eq(TableSchema.fromBean(ClientRegistry.class))))
+                .thenReturn(table);
         dynamoClientService =
                 spy(new DynamoClientService(configurationService, dynamoDbEnhancedClient));
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksCacheServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksCacheServiceTest.java
@@ -9,10 +9,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
 import uk.gov.di.orchestration.shared.utils.JwksUtils;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -23,11 +22,10 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
-class JwksCacheServiceTest {
+class JwksCacheServiceTest extends BaseDynamoServiceTest<JwksCacheItem> {
     private static final String JWKS_URL = "http://localhost/.well-known/jwks.json";
     private static final String KEY_ID_1 = "test-enc-key-1";
     private static final String KEY_ID_2 = "test-enc-key-2";
@@ -38,9 +36,6 @@ class JwksCacheServiceTest {
             Instant.now().plusSeconds(expiryInSeconds).getEpochSecond();
     private static final MockedStatic<JwksUtils> jwksUtilsMockedStatic =
             Mockito.mockStatic(JwksUtils.class);
-    private final DynamoDbTable<JwksCacheItem> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private JwksCacheService jwksCacheServiceSpy;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.OrchAuthCodeItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
@@ -20,9 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -225,23 +221,5 @@ class OrchAuthCodeServiceTest extends BaseDynamoServiceTest<OrchAuthCodeItem> {
                         .withTimeToLive(EXPIRED_TTL);
 
         when(table.getItem(AUTH_CODE_GET_REQUEST)).thenReturn(orchAuthCodeItem);
-    }
-
-    private void withFailedPut() {
-        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
-                .when(table)
-                .putItem(any(OrchAuthCodeItem.class));
-    }
-
-    private void withFailedGet() {
-        doThrow(DynamoDbException.builder().message("Failed to get from table").build())
-                .when(table)
-                .getItem(eq(AUTH_CODE_GET_REQUEST));
-    }
-
-    private void withFailedUpdate() {
-        doThrow(DynamoDbException.builder().message("Failed to update item in table").build())
-                .when(table)
-                .updateItem(any(OrchAuthCodeItem.class));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
@@ -3,15 +3,14 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.OrchAuthCodeItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.serialization.Json;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -25,11 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class OrchAuthCodeServiceTest {
+class OrchAuthCodeServiceTest extends BaseDynamoServiceTest<OrchAuthCodeItem> {
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_SESSION_ID = "test-client-session-id";
     private static final String EMAIL = "test-email";
@@ -49,9 +47,6 @@ class OrchAuthCodeServiceTest {
     private static final long AUTH_CODE_EXPIRY = 123L;
     private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "internal-pairwise-subject-id";
 
-    private final DynamoDbTable<OrchAuthCodeItem> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final Json objectMapper = SerializationService.getInstance();
     private OrchAuthCodeService orchAuthCodeService;
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
@@ -37,13 +36,7 @@ class OrchAuthCodeServiceTest extends BaseDynamoServiceTest<OrchAuthCodeItem> {
     private static final Instant CREATION_INSTANT = Instant.parse("2025-02-01T03:04:05.678Z");
     private static final long VALID_TTL = CREATION_INSTANT.plusSeconds(100).getEpochSecond();
     private static final long EXPIRED_TTL = CREATION_INSTANT.minusSeconds(100).getEpochSecond();
-    private static final Key AUTH_CODE_PARTITION_KEY =
-            Key.builder().partitionValue(AUTH_CODE).build();
-    private static final GetItemEnhancedRequest AUTH_CODE_GET_REQUEST =
-            GetItemEnhancedRequest.builder()
-                    .key(AUTH_CODE_PARTITION_KEY)
-                    .consistentRead(true)
-                    .build();
+    private static final GetItemEnhancedRequest AUTH_CODE_GET_REQUEST = getRequestFor(AUTH_CODE);
     private static final long AUTH_CODE_EXPIRY = 123L;
     private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "internal-pairwise-subject-id";
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
@@ -24,13 +23,8 @@ class OrchClientSessionServiceTest extends BaseDynamoServiceTest<OrchClientSessi
     private static final String CLIENT_NAME = "test-client-name";
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
-    private static final Key CLIENT_SESSION_ID_PARTITION_KEY =
-            Key.builder().partitionValue(CLIENT_SESSION_ID).build();
     private static final GetItemEnhancedRequest CLIENT_SESSION_GET_REQUEST =
-            GetItemEnhancedRequest.builder()
-                    .key(CLIENT_SESSION_ID_PARTITION_KEY)
-                    .consistentRead(true)
-                    .build();
+            getRequestFor(CLIENT_SESSION_ID);
     private OrchClientSessionService clientSessionService;
 
     @BeforeEach
@@ -124,12 +118,6 @@ class OrchClientSessionServiceTest extends BaseDynamoServiceTest<OrchClientSessi
                 new OrchClientSessionItem(CLIENT_SESSION_ID)
                         .withClientName(CLIENT_NAME)
                         .withTimeToLive(VALID_TTL);
-        when(table.getItem(
-                        GetItemEnhancedRequest.builder()
-                                .consistentRead(false)
-                                .key(CLIENT_SESSION_ID_PARTITION_KEY)
-                                .build()))
-                .thenReturn(existingSession);
         when(table.getItem(CLIENT_SESSION_GET_REQUEST)).thenReturn(existingSession);
         return existingSession;
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -2,13 +2,12 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchClientSessionException;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.time.Instant;
 
@@ -17,11 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class OrchClientSessionServiceTest {
+class OrchClientSessionServiceTest extends BaseDynamoServiceTest<OrchClientSessionItem> {
     private static final String CLIENT_SESSION_ID = "test-client-session-id";
     private static final String CLIENT_NAME = "test-client-name";
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
@@ -33,9 +31,6 @@ class OrchClientSessionServiceTest {
                     .key(CLIENT_SESSION_ID_PARTITION_KEY)
                     .consistentRead(true)
                     .build();
-    private final DynamoDbTable<OrchClientSessionItem> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private OrchClientSessionService clientSessionService;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchClientSessionException;
 import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
@@ -13,8 +12,6 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -128,29 +125,5 @@ class OrchClientSessionServiceTest extends BaseDynamoServiceTest<OrchClientSessi
                         .withClientName(CLIENT_NAME)
                         .withTimeToLive(EXPIRED_TTL);
         when(table.getItem(CLIENT_SESSION_GET_REQUEST)).thenReturn(existingSession);
-    }
-
-    private void withFailedPut() {
-        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
-                .when(table)
-                .putItem(any(OrchClientSessionItem.class));
-    }
-
-    private void withFailedGet() {
-        doThrow(DynamoDbException.builder().message("Failed to get from table").build())
-                .when(table)
-                .getItem(any(GetItemEnhancedRequest.class));
-    }
-
-    private void withFailedUpdate() {
-        doThrow(DynamoDbException.builder().message("Failed to update table").build())
-                .when(table)
-                .updateItem(any(OrchClientSessionItem.class));
-    }
-
-    private void withFailedDelete() {
-        doThrow(DynamoDbException.builder().message("Failed to delete from table").build())
-                .when(table)
-                .deleteItem(any(OrchClientSessionItem.class));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -31,13 +30,7 @@ class OrchSessionServiceTest extends BaseDynamoServiceTest<OrchSessionItem> {
     private static final String SESSION_ID = "test-session-id";
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
-    private static final Key SESSION_ID_PARTITION_KEY =
-            Key.builder().partitionValue(SESSION_ID).build();
-    private static final GetItemEnhancedRequest SESSION_GET_REQUEST =
-            GetItemEnhancedRequest.builder()
-                    .key(SESSION_ID_PARTITION_KEY)
-                    .consistentRead(true)
-                    .build();
+    private static final GetItemEnhancedRequest SESSION_GET_REQUEST = getRequestFor(SESSION_ID);
     private OrchSessionService orchSessionService;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
@@ -21,8 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,8 +69,8 @@ class OrchSessionServiceTest extends BaseDynamoServiceTest<OrchSessionItem> {
 
     @Test
     void deleteSessionThrowsOrchSessionExceptionWhenDeleteFails() {
-        var orchSession = withValidSession();
-        withFailedDelete(orchSession);
+        withValidSession();
+        withFailedDelete();
 
         var exception =
                 assertThrows(
@@ -175,17 +172,5 @@ class OrchSessionServiceTest extends BaseDynamoServiceTest<OrchSessionItem> {
     private void withExpiredSession() {
         when(table.getItem(SESSION_GET_REQUEST))
                 .thenReturn(new OrchSessionItem(SESSION_ID).withTimeToLive(EXPIRED_TTL));
-    }
-
-    private void withFailedDelete(OrchSessionItem orchSession) {
-        doThrow(DynamoDbException.builder().message("Failed to delete item").build())
-                .when(table)
-                .deleteItem(orchSession);
-    }
-
-    private void withFailedUpdate() {
-        doThrow(DynamoDbException.builder().message("Failed to update table").build())
-                .when(table)
-                .updateItem(any(OrchSessionItem.class));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -2,14 +2,13 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -25,11 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class OrchSessionServiceTest {
+class OrchSessionServiceTest extends BaseDynamoServiceTest<OrchSessionItem> {
     private static final String SESSION_ID = "test-session-id";
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
@@ -40,9 +38,6 @@ class OrchSessionServiceTest {
                     .key(SESSION_ID_PARTITION_KEY)
                     .consistentRead(true)
                     .build();
-    private final DynamoDbTable<OrchSessionItem> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private OrchSessionService orchSessionService;
 
     @BeforeEach

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
@@ -4,7 +4,6 @@ import com.nimbusds.oauth2.sdk.id.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.StateItem;
@@ -26,10 +25,8 @@ class StateStorageServiceTest extends BaseDynamoServiceTest<StateItem> {
     private static final State STATE = new State();
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
     private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
-    private static final Key STATE_PARTITION_KEY =
-            Key.builder().partitionValue(PREFIXED_SESSION_ID).build();
     private static final GetItemEnhancedRequest STATE_GET_REQUEST =
-            GetItemEnhancedRequest.builder().key(STATE_PARTITION_KEY).consistentRead(true).build();
+            getRequestFor(PREFIXED_SESSION_ID);
     private StateStorageService stateStorageService;
 
     @BeforeEach
@@ -100,12 +97,6 @@ class StateStorageServiceTest extends BaseDynamoServiceTest<StateItem> {
 
     private StateItem withValidStateItemInDynamo() {
         var stateItem = createValidStateItem();
-        when(table.getItem(
-                        GetItemEnhancedRequest.builder()
-                                .consistentRead(false)
-                                .key(STATE_PARTITION_KEY)
-                                .build()))
-                .thenReturn(stateItem);
         when(table.getItem(STATE_GET_REQUEST)).thenReturn(stateItem);
         return stateItem;
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.StateStorageException;
 import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
@@ -15,8 +14,6 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -81,18 +78,6 @@ class StateStorageServiceTest extends BaseDynamoServiceTest<StateItem> {
         assertThrows(
                 StateStorageException.class,
                 () -> stateStorageService.getState(PREFIXED_SESSION_ID));
-    }
-
-    private void withFailedPut() {
-        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
-                .when(table)
-                .putItem(any(StateItem.class));
-    }
-
-    private void withFailedGet() {
-        doThrow(DynamoDbException.builder().message("Failed to get item from table").build())
-                .when(table)
-                .getItem(any(GetItemEnhancedRequest.class));
     }
 
     private StateItem withValidStateItemInDynamo() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
@@ -4,13 +4,12 @@ import com.nimbusds.oauth2.sdk.id.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.StateStorageException;
+import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
 
 import java.time.Instant;
 
@@ -19,11 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class StateStorageServiceTest {
+class StateStorageServiceTest extends BaseDynamoServiceTest<StateItem> {
     private static final String PREFIXED_SESSION_ID = "state:test-session-id";
     private static final State STATE = new State();
     private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
@@ -32,9 +30,6 @@ class StateStorageServiceTest {
             Key.builder().partitionValue(PREFIXED_SESSION_ID).build();
     private static final GetItemEnhancedRequest STATE_GET_REQUEST =
             GetItemEnhancedRequest.builder().key(STATE_PARTITION_KEY).consistentRead(true).build();
-    private final DynamoDbTable<StateItem> table = mock(DynamoDbTable.class);
-    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private StateStorageService stateStorageService;
 
     @BeforeEach


### PR DESCRIPTION
### Wider context of change

While adding a new dynamo service, we noticed there is a lot of duplication across the dynamo service tests, mainly for setting up mocks.

### What’s changed

This PR extracts an abstract class `BaseDynamoServiceTest`, which takes a dynamo bean as a generic type, and sets up the relevant mocks. It also adds a helper method to create a get request for a given partition key (as we have to specify `consistentReads(true)` every time now we're always using consistent reads.

### Manual testing

Refactoring existing tests, so not needed.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

