### PR TITLE
ATO-1993: create Manual Update Client Registry Lambda

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandler.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.clientregistry.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class ManualUpdateClientRegistryHandler implements RequestHandler<String, Void> {
+
+    public ManualUpdateClientRegistryHandler() {}
+
+    @Override
+    public Void handleRequest(String input, Context context) {
+        return null;
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1121,9 +1121,9 @@ Resources:
         - Key: Name
           Value: DocAppCredentialTable
 
-    #endregion
+  #endregion
 
-    #region Jwks Cache DynamoDB Table
+  #region Jwks Cache DynamoDB Table
 
   JwksCacheTableEncryptionKey:
     Type: AWS::KMS::Key
@@ -1183,7 +1183,7 @@ Resources:
         - Key: Name
           Value: JwksCacheTable
 
-    #endregion
+  #endregion
 
   #region Fetch JWKS Lambda
 
@@ -2453,7 +2453,6 @@ Resources:
     Type: AWS::Serverless::Function
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: Lambda is triggered by SQS so DLQ not needed
-
     Properties:
       FunctionName: !Sub ${Environment}-GlobalLogoutFunction
       AutoPublishAlias: latest
@@ -4750,6 +4749,72 @@ Resources:
             Stat: Sum
             Unit: Count
   #endregion
+
+  # region Manual Update Client Registry Lambda
+
+  ManualUpdateClientRegistryFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
+    # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
+    Properties:
+      FunctionName: !Sub ${Environment}-ManualUpdateClientRegistryFunction
+      AutoPublishAlias: latest
+      CodeUri: ./client-registry-api/build/distributions/client-registry-api.zip
+      Handler: uk.gov.di.authentication.clientregistry.lambda.ManualUpdateClientRegistryHandler::handleRequest
+      LoggingConfig:
+        LogGroup: !Ref ManualUpdateClientRegistryFunctionLogGroup
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+          ENVIRONMENT: !Sub ${Environment}
+          TXMA_AUDIT_QUEUE_URL:
+            Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
+          DYNAMO_ARN_PREFIX: !Sub
+            - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
+            - AccountId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  authAccountId,
+                ]
+              AuthEnvironment:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  authEnvironment,
+                ]
+          OIDC_API_BASE_URL: !Sub
+            - https://oidc.${ServiceDomain}/
+            - ServiceDomain:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  serviceDomain,
+                ]
+      Policies:
+        - !Ref ClientRegistryTableReadAccessPolicy
+        - !Ref ClientRegistryTableWriteAccessPolicy
+        - !Ref TxmaQueueSendPermissionPolicy
+      Tags:
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
+
+  ManualUpdateClientRegistryFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${Environment}-manual-update-client-registry-lambda
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      RetentionInDays: 30
+
+  # endregion
 
   #region Stub SPOT Request Queue
   StubSpotRequestQueueKey:


### PR DESCRIPTION
### Wider context of change

For TSD to be able to update the client rate limit, we need a new lambda to manually update the client registry.

### What’s changed

New lambda

### Manual testing

Deployed to dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
