### PR TITLE
ATO-1985: Stop reading from redis in CrossBrowserOrchestrationService

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -291,7 +291,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     @Test
     void
             shouldRedirectToRPWhenNoSessionCookieAndCallToNoSessionOrchestrationServiceReturnsNoSessionEntity() {
-        redis.addClientSessionAndStateToRedis(ORCH_TO_AUTH_STATE, CLIENT_SESSION_ID);
+        crossBrowserStorageExtension.store(ORCH_TO_AUTH_STATE, CLIENT_SESSION_ID);
 
         var response =
                 makeRequest(
@@ -962,10 +962,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         var requestObject = validateAndDecryptRequestObject(response);
         var stateString = requestObject.getJWTClaimsSet().getStringClaim("state");
         var state = new State(stateString);
-        var clientSessionIdFromRedis = redis.getFromRedis("state:" + stateString);
         var clientSessionIdFromDynamo =
                 crossBrowserStorageExtension.getClientSessionIdFromState(state).orElseThrow();
-        assertEquals(CLIENT_SESSION_ID, clientSessionIdFromRedis);
         assertEquals(CLIENT_SESSION_ID, clientSessionIdFromDynamo);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1209,7 +1209,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var decryptedJWT = decryptJWT((EncryptedJWT) authRequest.getRequestObject());
             var orchToAuthStateString = decryptedJWT.getJWTClaimsSet().getStringClaim("state");
             var orchToAuthState = new State(orchToAuthStateString);
-            var clientSessionFromRedis = redis.getFromRedis("state:" + orchToAuthStateString);
             var clientSessionFromDynamo =
                     crossBrowserStorageExtension
                             .getClientSessionIdFromState(orchToAuthState)
@@ -1217,7 +1216,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
             var clientSessionId = getClientSessionId(response);
 
-            assertEquals(clientSessionId, clientSessionFromRedis);
             assertEquals(clientSessionId, clientSessionFromDynamo);
         }
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
@@ -174,14 +174,7 @@ public class CrossBrowserOrchestrationService {
 
     private Optional<String> getClientSessionIdFromState(State state) {
         LOG.info("Getting clientSessionId using state");
-        var clientSessionIdFromRedis =
-                Optional.ofNullable(
-                        redisConnectionService.getValue(STATE_STORAGE_PREFIX + state.getValue()));
-        var clientSessionIdFromDynamo = crossBrowserStorageService.getClientSessionId(state);
-        LOG.info(
-                "Is clientSessionId from redis equal to clientSessionId from dynamo? {}",
-                Objects.equals(clientSessionIdFromRedis, clientSessionIdFromDynamo));
-        return clientSessionIdFromRedis;
+        return crossBrowserStorageService.getClientSessionId(state);
     }
 
     private boolean isAccessDeniedErrorAndStatePresent(Map<String, String> queryStringParameters) {


### PR DESCRIPTION
### Wider context of change

At this point we should be confident that the cross browser data stored in dynamo is the same as data stored in redis (from the logs we added in the previous ticket). Now we can safely remove redis from the CrossBrowserOrchestrationService, starting with removing the reads from redis.

### Manual Testing

Tested in dev by forcing cross browser errors (clearing cookies and hitting the callback endpoints directly with the correct query params). All 3 types of journey (auth only, identity, docapp) got the clientSessionId from the state successfully.

### What’s changed

This PR stops reading from redis in CrossBrowserOrchestrationService. It also removes unused test assertions and setup.

A follow-up PR will remove the instances where we are writing to redis.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

