### PR TITLE
BAU: Fix run-sonar-analysis GHA

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -353,16 +353,18 @@ jobs:
 
   run-orchestration-alerting-tests:
     runs-on: ubuntu-latest
-    if: needs.check-changed-files.outputs.orch_alerting_files_changed == 'true'
     needs:
       - check-changed-files
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.orch_alerting_files_changed == 'true'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
+        if: needs.check-changed-files.outputs.orch_alerting_files_changed == 'true'
         run: npm ci
         working-directory: ./orchestration-alerting
       - name: Run Unit Tests
+        if: needs.check-changed-files.outputs.orch_alerting_files_changed == 'true'
         run: npm test
         working-directory: ./orchestration-alerting
 
@@ -372,7 +374,6 @@ jobs:
       - run-unit-tests
       - run-integration-tests
       - run-account-management-and-delivery-receipts-tests
-      - run-orchestration-alerting-tests
       - check-changed-files
     if: github.event_name != 'merge_group'
     steps:


### PR DESCRIPTION
### What

I recently added the `run-orchestration-alerting-tests` action to the pre-merge checks. I made the `run-sonar-analysis` action depend on this action, but I accidentally configured the `run-orchestration-alerting-tests` action to skip if no files were changed, instead of having the steps skip. Since the action did not run, this skipped the `run-sonar-analysis` action too

I've removed the `run-orchestration-alerting-tests` dependency from the `run-sonar-analysis` action, as it wouldn't be running on it anyway.