### PR TITLE
ATO-1995: update rate limit from ManualUpdateClientRegistryHandler

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandler.java
@@ -2,13 +2,118 @@ package uk.gov.di.authentication.clientregistry.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.clientregistry.services.ManualUpdateClientRegistryValidationService;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
+import uk.gov.di.orchestration.shared.serialization.Json;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.ClientService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
 
-public class ManualUpdateClientRegistryHandler implements RequestHandler<String, Void> {
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
-    public ManualUpdateClientRegistryHandler() {}
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
+
+public class ManualUpdateClientRegistryHandler
+        implements RequestHandler<Object, Map<String, String>> {
+
+    private final ClientService clientService;
+    private final ManualUpdateClientRegistryValidationService validationService;
+    private final AuditService auditService;
+    private final Json objectMapper = SerializationService.getInstance();
+
+    private static final Logger LOG = LogManager.getLogger(ManualUpdateClientRegistryHandler.class);
+    private static final String RESULT_KEY = "result";
+    private static final String MESSAGE_KEY = "message";
+    private static final String RESULT_ERROR = "error";
+    private static final String RESULT_SUCCESS = "success";
+
+    public ManualUpdateClientRegistryHandler(
+            ClientService clientService,
+            ManualUpdateClientRegistryValidationService validationService,
+            AuditService auditService) {
+        this.clientService = clientService;
+        this.validationService = validationService;
+        this.auditService = auditService;
+    }
+
+    public ManualUpdateClientRegistryHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public ManualUpdateClientRegistryHandler(ConfigurationService configurationService) {
+        this.clientService = new DynamoClientService(configurationService);
+        this.validationService = new ManualUpdateClientRegistryValidationService();
+        this.auditService = new AuditService(configurationService);
+    }
 
     @Override
-    public Void handleRequest(String input, Context context) {
-        return null;
+    public Map<String, String> handleRequest(Object input, Context context) {
+        attachTraceId();
+
+        Map<String, String> response = new HashMap<>();
+
+        if (input == null || input.toString().isBlank()) {
+            LOG.error("No client config provided");
+            return getErrorResponse("No client config provided");
+        }
+
+        try {
+            var manualUpdateClientRegistryRequest =
+                    objectMapper.readValue(
+                            input.toString(), ManualUpdateClientRegistryRequest.class);
+            var clientId = manualUpdateClientRegistryRequest.clientId();
+
+            LOG.info("Manual update client registry request received");
+
+            if (!clientService.isValidClient(clientId)) {
+                LOG.warn("Invalid client id");
+                return getErrorResponse("Invalid client id");
+            }
+
+            Optional<ErrorObject> errorResponse =
+                    validationService.validateManualUpdateClientRegistryRequest(
+                            manualUpdateClientRegistryRequest);
+            if (errorResponse.isPresent()) {
+                LOG.warn(
+                        "Failed validation. ErrorCode: {}. ErrorDescription: {}",
+                        errorResponse.get().getCode(),
+                        errorResponse.get().getDescription());
+                return getErrorResponse(
+                        String.format(
+                                "Failed validation. ErrorCode: %s. ErrorDescription: %s",
+                                errorResponse.get().getCode(),
+                                errorResponse.get().getDescription()));
+            }
+
+            clientService.manualUpdateClient(clientId, manualUpdateClientRegistryRequest);
+
+            LOG.info("Client updated");
+            response.put(RESULT_KEY, RESULT_SUCCESS);
+            response.put(
+                    MESSAGE_KEY,
+                    String.format(
+                            "Successfully update client with values: %s",
+                            manualUpdateClientRegistryRequest.toString()));
+            return response;
+        } catch (Json.JsonException e) {
+            LOG.warn(
+                    "Invalid Client registration request. Missing parameters or incorrect type from request");
+            return getErrorResponse(
+                    "Invalid Client registration request. Missing parameters or incorrect type from request");
+        }
+    }
+
+    private Map<String, String> getErrorResponse(String errorMessage) {
+        Map<String, String> response = new HashMap<>();
+        response.put(RESULT_KEY, RESULT_ERROR);
+        response.put(MESSAGE_KEY, errorMessage);
+        return response;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -105,7 +105,7 @@ public class UpdateClientConfigHandler
                         400, errorResponse.get().toJSONObject().toJSONString());
             }
             ClientRegistry clientRegistry =
-                    clientService.updateClient(clientId, updateClientConfigRequest);
+                    clientService.updateSSEClient(clientId, updateClientConfigRequest);
             ClientRegistrationResponse clientRegistrationResponse =
                     new ClientRegistrationResponse(
                             clientRegistry.getClientName(),

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ManualUpdateClientRegistryValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ManualUpdateClientRegistryValidationService.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.clientregistry.services;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
+
+import java.util.Optional;
+
+public class ManualUpdateClientRegistryValidationService {
+
+    public static final ErrorObject INVALID_RATE_LIMIT =
+            new ErrorObject("invalid_rate_limit", "Invalid client rate limit");
+
+    public Optional<ErrorObject> validateManualUpdateClientRegistryRequest(
+            ManualUpdateClientRegistryRequest updateRequest) {
+        if (updateRequest.rateLimit() != null && !isRateLimitValid(updateRequest.rateLimit())) {
+            return Optional.of(INVALID_RATE_LIMIT);
+        }
+        return Optional.empty();
+    }
+
+    private boolean isRateLimitValid(String clientRateLimit) {
+        if (!clientRateLimit.isBlank()) {
+            try {
+                return Integer.parseInt(clientRateLimit) >= 0;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -72,7 +72,7 @@ class ClientRegistrationHandlerTest {
     private ClientRegistrationHandler handler;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new ClientRegistrationHandler(clientService, configValidationService, auditService);
@@ -83,7 +83,7 @@ class ClientRegistrationHandlerTest {
             new CaptureLoggingExtension(UpdateClientConfigHandler.class);
 
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         assertThat(logging.events(), not(hasItem(withMessageContaining(clientId))));
         verifyNoMoreInteractions(auditService);
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ManualUpdateClientRegistryHandlerTest.java
@@ -1,0 +1,159 @@
+package uk.gov.di.authentication.clientregistry.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.clientregistry.services.ManualUpdateClientRegistryValidationService;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ClientType;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.ClientService;
+import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.clientregistry.services.ManualUpdateClientRegistryValidationService.INVALID_RATE_LIMIT;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class ManualUpdateClientRegistryHandlerTest {
+
+    private static final String CLIENT_ID = "client-id";
+    private static final String VALID_RATE_LIMIT = "1";
+    private static final String RESULT_KEY = "result";
+    private static final String MESSAGE_KEY = "message";
+    private static final String RESULT_ERROR = "error";
+    private static final String RESULT_SUCCESS = "success";
+
+    private final Context context = mock(Context.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final ManualUpdateClientRegistryValidationService clientValidationService =
+            mock(ManualUpdateClientRegistryValidationService.class);
+    private final AuditService auditService = mock(AuditService.class);
+    private ManualUpdateClientRegistryHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler =
+                new ManualUpdateClientRegistryHandler(
+                        clientService, clientValidationService, auditService);
+    }
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(ManualUpdateClientRegistryHandler.class);
+
+    @AfterEach
+    void afterEach() {
+        assertThat(logging.events(), not(hasItem(withMessageContaining(CLIENT_ID))));
+        verifyNoMoreInteractions(auditService);
+    }
+
+    @Test
+    void shouldReturnResultSuccessForAValidRequest() {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
+        when(clientValidationService.validateManualUpdateClientRegistryRequest(
+                        any(ManualUpdateClientRegistryRequest.class)))
+                .thenReturn(Optional.empty());
+        when(clientService.manualUpdateClient(
+                        eq(CLIENT_ID), any(ManualUpdateClientRegistryRequest.class)))
+                .thenReturn(createClientRegistry());
+
+        String event =
+                format(
+                        "{\"client_id\": \"%s\", \"rate_limit\": \"%s\"}",
+                        CLIENT_ID, VALID_RATE_LIMIT);
+        var result = makeHandlerRequest(event);
+
+        assertThat(result.get(RESULT_KEY), equalTo(RESULT_SUCCESS));
+        assertThat(
+                result.get(MESSAGE_KEY),
+                equalTo("Successfully update client with values: ClientId=client-id, RateLimit=1"));
+    }
+
+    @Test
+    void shouldReturn400WhenRequestContainsNoParameters() {
+        String event = "";
+        var result = makeHandlerRequest(event);
+
+        assertThat(result.get(RESULT_KEY), equalTo(RESULT_ERROR));
+        assertThat(result.get(MESSAGE_KEY), equalTo("No client config provided"));
+    }
+
+    @Test
+    void shouldReturnResultErrorWhenRequestIsMissingClientID() {
+        String event = format("{\"rate_limit\": \"%s\"}", VALID_RATE_LIMIT);
+        var result = makeHandlerRequest(event);
+
+        assertThat(result.get(RESULT_KEY), equalTo(RESULT_ERROR));
+        assertThat(
+                result.get(MESSAGE_KEY),
+                equalTo(
+                        "Invalid Client registration request. Missing parameters or incorrect type from request"));
+    }
+
+    @Test
+    void shouldReturnResultErrorWhenClientIdIsInvalid() {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(false);
+
+        String event =
+                format(
+                        "{\"client_id\": \"%s\", \"rate_limit\": \"%s\"}",
+                        CLIENT_ID, VALID_RATE_LIMIT);
+        var result = makeHandlerRequest(event);
+
+        assertThat(result.get(RESULT_KEY), equalTo(RESULT_ERROR));
+        assertThat(result.get(MESSAGE_KEY), equalTo("Invalid client id"));
+    }
+
+    @Test
+    void shouldReturnResultErrorWhenRequestFailsValidation() {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
+        when(clientValidationService.validateManualUpdateClientRegistryRequest(
+                        any(ManualUpdateClientRegistryRequest.class)))
+                .thenReturn(Optional.of(INVALID_RATE_LIMIT));
+        when(clientService.manualUpdateClient(
+                        eq(CLIENT_ID), any(ManualUpdateClientRegistryRequest.class)))
+                .thenReturn(createClientRegistry());
+
+        String event = format("{\"client_id\": \"%s\", \"rate_limit\": \"%s\"}", CLIENT_ID, "-1");
+        var result = makeHandlerRequest(event);
+
+        assertThat(result.get(RESULT_KEY), equalTo(RESULT_ERROR));
+        assertThat(
+                result.get(MESSAGE_KEY),
+                equalTo(
+                        "Failed validation. ErrorCode: invalid_rate_limit. ErrorDescription: Invalid client rate limit"));
+    }
+
+    private ClientRegistry createClientRegistry() {
+        return new ClientRegistry()
+                .withClientID(CLIENT_ID)
+                .withPublicKey("public-key")
+                .withSubjectType("Public")
+                .withRedirectUrls(singletonList("http://localhost/redirect"))
+                .withContacts(singletonList("contant-name"))
+                .withPostLogoutRedirectUrls(singletonList("localhost/logout"))
+                .withClientType(ClientType.WEB.getValue())
+                .withClaims(List.of("claim"));
+    }
+
+    private Map<String, String> makeHandlerRequest(String event) {
+        return handler.handleRequest(event, context);
+    }
+}

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -84,7 +84,7 @@ class UpdateClientConfigHandlerTest {
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))
                 .thenReturn(Optional.empty());
-        when(clientService.updateClient(eq(CLIENT_ID), any(UpdateClientConfigRequest.class)))
+        when(clientService.updateSSEClient(eq(CLIENT_ID), any(UpdateClientConfigRequest.class)))
                 .thenReturn(createClientRegistry());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -62,7 +62,7 @@ class UpdateClientConfigHandlerTest {
     private UpdateClientConfigHandler handler;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new UpdateClientConfigHandler(clientService, clientValidationService, auditService);
@@ -73,13 +73,13 @@ class UpdateClientConfigHandlerTest {
             new CaptureLoggingExtension(UpdateClientConfigHandler.class);
 
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         assertThat(logging.events(), not(hasItem(withMessageContaining(CLIENT_ID, CLIENT_NAME))));
         verifyNoMoreInteractions(auditService);
     }
 
     @Test
-    public void shouldReturn200ForAValidRequest() throws Json.JsonException {
+    void shouldReturn200ForAValidRequest() throws Json.JsonException {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))
@@ -107,7 +107,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestIsMissingClientID() {
+    void shouldReturn400WhenRequestIsMissingClientID() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{\"client_name\": \"%s\"}", CLIENT_NAME));
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
@@ -118,7 +118,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestContainsNoParameters() {
+    void shouldReturn400WhenRequestContainsNoParameters() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("");
         event.setPathParameters(Map.of("clientId", CLIENT_ID));
@@ -130,7 +130,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn401WhenClientIdIsInvalid() {
+    void shouldReturn401WhenClientIdIsInvalid() {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(false);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -144,7 +144,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestFailsValidation() {
+    void shouldReturn400WhenRequestFailsValidation() {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))
@@ -165,7 +165,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestHasInvalidScope() {
+    void shouldReturn400WhenRequestHasInvalidScope() {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ManualUpdateClientRegistryValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ManualUpdateClientRegistryValidationServiceTest.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.clientregistry.services;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.clientregistry.services.ManualUpdateClientRegistryValidationService.INVALID_RATE_LIMIT;
+
+class ManualUpdateClientRegistryValidationServiceTest {
+
+    private final ManualUpdateClientRegistryValidationService validationService =
+            new ManualUpdateClientRegistryValidationService();
+
+    private static final String CLIENT_ID = "client-id";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", ""})
+    void shouldPassValidationForValidUpdateRequest(String clientRateLimit) {
+        Optional<ErrorObject> errorResponse =
+                validationService.validateManualUpdateClientRegistryRequest(
+                        ManualUpdateClientRegistryRequest(clientRateLimit));
+        assertThat(errorResponse, equalTo(Optional.empty()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"null", "-1", "1.5"})
+    void shouldReturnErrorForInvalidClientRateLimitInUpdateRequest(String clientRateLimit) {
+        Optional<ErrorObject> errorResponse =
+                validationService.validateManualUpdateClientRegistryRequest(
+                        ManualUpdateClientRegistryRequest(clientRateLimit));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_RATE_LIMIT)));
+    }
+
+    private ManualUpdateClientRegistryRequest ManualUpdateClientRegistryRequest(
+            String clientRateLimit) {
+        return new ManualUpdateClientRegistryRequest(CLIENT_ID, clientRateLimit);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ManualUpdateClientRegistryRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ManualUpdateClientRegistryRequest.java
@@ -1,0 +1,17 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.orchestration.shared.validation.Required;
+
+public record ManualUpdateClientRegistryRequest(
+        @SerializedName("client_id") @Expose @Required String clientId,
+        @SerializedName("rate_limit") @Expose String rateLimit) {
+
+    @Override
+    public String toString() {
+        var clientIdString = "ClientId=" + clientId;
+        var rateLimitString = rateLimit != null ? ", RateLimit=" + rateLimit : "";
+        return clientIdString + rateLimitString;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.services;
 
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
 
 import java.util.List;
@@ -43,6 +44,9 @@ public interface ClientService {
     ClientID generateClientID();
 
     ClientRegistry updateSSEClient(String clientId, UpdateClientConfigRequest updateRequest);
+
+    ClientRegistry manualUpdateClient(
+            String clientId, ManualUpdateClientRegistryRequest updateRequest);
 
     boolean isTestJourney(String clientID, String emailAddress);
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
@@ -42,7 +42,7 @@ public interface ClientService {
 
     ClientID generateClientID();
 
-    ClientRegistry updateClient(String clientId, UpdateClientConfigRequest updateRequest);
+    ClientRegistry updateSSEClient(String clientId, UpdateClientConfigRequest updateRequest);
 
     boolean isTestJourney(String clientID, String emailAddress);
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -119,7 +119,8 @@ public class DynamoClientService implements ClientService {
     }
 
     @Override
-    public ClientRegistry updateClient(String clientId, UpdateClientConfigRequest updateRequest) {
+    public ClientRegistry updateSSEClient(
+            String clientId, UpdateClientConfigRequest updateRequest) {
         ClientRegistry clientRegistry =
                 dynamoClientRegistryTable.getItem(Key.builder().partitionValue(clientId).build());
         Optional.ofNullable(updateRequest.getRedirectUris())

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ManualUpdateClientRegistryRequest;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.orchestration.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
@@ -159,6 +160,20 @@ public class DynamoClientService implements ClientService {
                 .ifPresent(clientRegistry::withPKCEEnforced);
         Optional.ofNullable(updateRequest.getLandingPageUrl())
                 .ifPresent(clientRegistry::withLandingPageUrl);
+        dynamoClientRegistryTable.putItem(clientRegistry);
+        return clientRegistry;
+    }
+
+    @Override
+    public ClientRegistry manualUpdateClient(
+            String clientId, ManualUpdateClientRegistryRequest updateRequest) {
+        ClientRegistry clientRegistry =
+                dynamoClientRegistryTable.getItem(Key.builder().partitionValue(clientId).build());
+        Optional.ofNullable(updateRequest.rateLimit())
+                .ifPresent(
+                        rateLimit ->
+                                clientRegistry.withRateLimit(
+                                        rateLimit.isBlank() ? null : Integer.parseInt(rateLimit)));
         dynamoClientRegistryTable.putItem(clientRegistry);
         return clientRegistry;
     }


### PR DESCRIPTION
### Wider context of change

For TSD to be able to update the client rate limit, we need a new lambda to manually update the client registry.

### What’s changed

Lambda logic and validation added.

### Manual testing

Tested on authdev3
- no `rate_limit` or `rate_limit = null` does not break and does not turn off rate limit
- only whole numbers are accepted
- `rate_limit = "''"` will turn off rate limit

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
