### PR TITLE
Deny Dynamo Data access to all SSO role except Approved admin Staging

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -575,6 +575,39 @@ data "aws_iam_policy_document" "cross_account_table_resource_policy_document" {
     }
     resources = ["*"]
   }
+
+  dynamic "statement" {
+    for_each = var.environment == "staging" ? [1] : []
+    content {
+      sid    = "DenyNonAdminTeamRolesAccess"
+      effect = "Deny"
+      principals {
+        identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+        type        = "AWS"
+      }
+      actions = [
+        "dynamodb:BatchGetItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*"]
+      }
+      condition {
+        test     = "StringNotLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*"]
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "new_auth_cross_account_table_resource_policy_document" {
@@ -595,6 +628,39 @@ data "aws_iam_policy_document" "new_auth_cross_account_table_resource_policy_doc
       type        = "AWS"
     }
     resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.environment == "staging" ? [1] : []
+    content {
+      sid    = "DenyNonAdminTeamRolesAccess"
+      effect = "Deny"
+      principals {
+        identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+        type        = "AWS"
+      }
+      actions = [
+        "dynamodb:BatchGetItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*"]
+      }
+      condition {
+        test     = "StringNotLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*"]
+      }
+    }
   }
 }
 
@@ -741,7 +807,41 @@ data "aws_iam_policy_document" "auth_cross_account_table_resource_policy_documen
     }
     resources = ["*"]
   }
+
+  dynamic "statement" {
+    for_each = var.environment == "staging" ? [1] : []
+    content {
+      sid    = "DenyNonAdminTeamRolesAccess"
+      effect = "Deny"
+      principals {
+        identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+        type        = "AWS"
+      }
+      actions = [
+        "dynamodb:BatchGetItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*"]
+      }
+      condition {
+        test     = "StringNotLike"
+        variable = "aws:PrincipalARN"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*"]
+      }
+    }
+  }
 }
+
 
 data "aws_iam_policy_document" "auth_cross_account_table_delete_item_policy_document" {
   #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints


### PR DESCRIPTION

## What

AUT-4787: Deny Dynamo Data access to all SSO role except Approved admin role in Staging 

## How to review


1. Code Review
1. Deploy to authdev's  with `./deploy-authdev3.sh -a` Should show no Infra changes 
