### PR TITLE
AUT-4556: Remove extensions.iss from *_BYPASSED audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -194,8 +194,7 @@ public class UpdateEmailHandler
                         pair("journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
                         pair(
                                 "assessment_checked_at_timestamp",
-                                NowHelper.toUnixTimestamp(NowHelper.now())),
-                        pair("iss", AuditService.COMPONENT_ID));
+                                NowHelper.toUnixTimestamp(NowHelper.now())));
             }
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -189,8 +189,7 @@ class UpdateEmailHandlerTest {
                             AuditService.MetadataPair.pair(
                                     "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
                             AuditService.MetadataPair.pair(
-                                    "assessment_checked_at_timestamp", mockedTimestamp),
-                            AuditService.MetadataPair.pair("iss", "AUTH"));
+                                    "assessment_checked_at_timestamp", mockedTimestamp));
         }
     }
 


### PR DESCRIPTION
## What

We've simplified the AUTH_EMAIL_FRAUD_CHECK_BYPASSED event by removing the iss extension property.

This is already done in the frontend-api, so here we remove it from the account-management-api.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
