### PR TITLE
ATO-2024 Multi-session recovery

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -83,7 +83,7 @@ public class IdentityContextService {
 
         var mismatchedEntity =
                 crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                        input.getQueryStringParameters(), clientSessionId, orchSession);
+                        input.getQueryStringParameters(), clientSessionId);
         if (mismatchedEntity.isPresent()) {
             throw new CrossBrowserStateMismatchException(mismatchedEntity.get());
         }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -150,7 +150,7 @@ public class IdentityContextServiceTest {
         usingValidClientSession();
         var request = createRequestEvent();
         when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                        request.getQueryStringParameters(), CLIENT_SESSION_ID, orchSession))
+                        request.getQueryStringParameters(), CLIENT_SESSION_ID))
                 .thenThrow(new NoSessionException("test"));
 
         assertThrows(NoSessionException.class, () -> service.buildContext(request));
@@ -324,7 +324,7 @@ public class IdentityContextServiceTest {
                         new ErrorObject("test-error"),
                         new OrchClientSessionItem("test-csid-2"));
         when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                        request.getQueryStringParameters(), CLIENT_SESSION_ID, orchSession))
+                        request.getQueryStringParameters(), CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(crossBrowserEntity));
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -216,30 +216,6 @@ public class IPVCallbackHandler
                     crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             input.getQueryStringParameters(), clientSessionIdFromCookie);
 
-            if (mismatchedEntity.isPresent()) {
-                if (orchSession
-                        .getClientSessions()
-                        .contains(mismatchedEntity.get().getClientSessionId())) {
-                    LOG.info("Recovering client session from state");
-                } else {
-                    var authRequestFromStateDerivedRP =
-                            AuthenticationRequest.parse(
-                                    mismatchedEntity
-                                            .get()
-                                            .getClientSession()
-                                            .getAuthRequestParams());
-                    attachLogFieldToLogs(
-                            CLIENT_ID, authRequestFromStateDerivedRP.getClientID().getValue());
-
-                    return ipvCallbackHelper.generateAuthenticationErrorResponse(
-                            authRequestFromStateDerivedRP,
-                            mismatchedEntity.get().getErrorObject(),
-                            false,
-                            mismatchedEntity.get().getClientSessionId(),
-                            AuditService.UNKNOWN);
-                }
-            }
-
             var clientSessionId =
                     mismatchedEntity
                             .map(CrossBrowserEntity::getClientSessionId)
@@ -252,6 +228,20 @@ public class IPVCallbackHandler
             var authRequest = AuthenticationRequest.parse(orchClientSession.getAuthRequestParams());
             var clientId = authRequest.getClientID().getValue();
             attachLogFieldToLogs(CLIENT_ID, clientId);
+
+            if (mismatchedEntity.isPresent()) {
+                if (orchSession.getClientSessions().contains(clientSessionId)) {
+                    LOG.info("Recovering client session from state");
+                } else {
+                    return ipvCallbackHelper.generateAuthenticationErrorResponse(
+                            authRequest,
+                            mismatchedEntity.get().getErrorObject(),
+                            false,
+                            clientSessionId,
+                            AuditService.UNKNOWN);
+                }
+            }
+
             var clientRegistry =
                     dynamoClientService
                             .getClient(clientId)
@@ -510,8 +500,23 @@ public class IPVCallbackHandler
                 return RedirectService.redirectToFrontendErrorPageWithErrorLog(
                         frontend.errorURI(), new Error("Failed to create redirectURI"));
             }
-            return generateApiGatewayProxyResponse(
-                    302, "", Map.of(ResponseHeaders.LOCATION, redirectURI.toString()), null);
+
+            // If we've recovered from a mismatched client session then we need to update the
+            // session cookie
+            var headers =
+                    clientSessionId.equals(clientSessionIdFromCookie)
+                            ? Map.of(ResponseHeaders.LOCATION, redirectURI.toString())
+                            : Map.of(
+                                    ResponseHeaders.LOCATION,
+                                    redirectURI.toString(),
+                                    ResponseHeaders.SET_COOKIE,
+                                    CookieHelper.buildCookieString(
+                                            CookieHelper.SESSION_COOKIE_NAME,
+                                            sessionId + "." + clientSessionId,
+                                            configurationService.getSessionCookieMaxAge(),
+                                            configurationService.getSessionCookieAttributes(),
+                                            configurationService.getDomainName()));
+            return generateApiGatewayProxyResponse(302, "", headers, null);
         } catch (NoSessionException e) {
             return RedirectService.redirectToFrontendErrorPageForNoSession(
                     frontend.errorIpvCallbackURI(), e);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -31,6 +31,7 @@ import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -200,12 +201,12 @@ public class IPVCallbackHandler
             var persistentId =
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
-            var clientSessionId = sessionCookiesIds.getClientSessionId();
-            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
-            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-            var orchClientSession =
+            var clientSessionIdFromCookie = sessionCookiesIds.getClientSessionId();
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionIdFromCookie);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionIdFromCookie);
+            var orchClientSessionFromCookie =
                     orchClientSessionService
-                            .getClientSession(clientSessionId)
+                            .getClientSession(clientSessionIdFromCookie)
                             .orElseThrow(
                                     () ->
                                             new IPVCallbackNoSessionException(
@@ -213,23 +214,40 @@ public class IPVCallbackHandler
 
             var mismatchedEntity =
                     crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            input.getQueryStringParameters(), clientSessionId, orchSession);
+                            input.getQueryStringParameters(), clientSessionIdFromCookie);
 
             if (mismatchedEntity.isPresent()) {
+                if (orchSession
+                        .getClientSessions()
+                        .contains(mismatchedEntity.get().getClientSessionId())) {
+                    LOG.info("Recovering client session from state");
+                } else {
+                    var authRequestFromStateDerivedRP =
+                            AuthenticationRequest.parse(
+                                    mismatchedEntity
+                                            .get()
+                                            .getClientSession()
+                                            .getAuthRequestParams());
+                    attachLogFieldToLogs(
+                            CLIENT_ID, authRequestFromStateDerivedRP.getClientID().getValue());
 
-                var authRequestFromStateDerivedRP =
-                        AuthenticationRequest.parse(
-                                mismatchedEntity.get().getClientSession().getAuthRequestParams());
-                attachLogFieldToLogs(
-                        CLIENT_ID, authRequestFromStateDerivedRP.getClientID().getValue());
-
-                return ipvCallbackHelper.generateAuthenticationErrorResponse(
-                        authRequestFromStateDerivedRP,
-                        mismatchedEntity.get().getErrorObject(),
-                        false,
-                        mismatchedEntity.get().getClientSessionId(),
-                        AuditService.UNKNOWN);
+                    return ipvCallbackHelper.generateAuthenticationErrorResponse(
+                            authRequestFromStateDerivedRP,
+                            mismatchedEntity.get().getErrorObject(),
+                            false,
+                            mismatchedEntity.get().getClientSessionId(),
+                            AuditService.UNKNOWN);
+                }
             }
+
+            var clientSessionId =
+                    mismatchedEntity
+                            .map(CrossBrowserEntity::getClientSessionId)
+                            .orElse(clientSessionIdFromCookie);
+            var orchClientSession =
+                    mismatchedEntity
+                            .map(CrossBrowserEntity::getClientSession)
+                            .orElse(orchClientSessionFromCookie);
 
             var authRequest = AuthenticationRequest.parse(orchClientSession.getAuthRequestParams());
             var clientId = authRequest.getClientID().getValue();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -930,7 +930,7 @@ class IPVCallbackHandlerTest {
     class EnhancedCrossBrowserHandling {
 
         private final String clientSessionIdFromState = "state-client-session-id";
-        private final OrchClientSessionItem clientSessionFromState =
+        private final OrchClientSessionItem orchClientSessionFromState =
                 new OrchClientSessionItem(
                                 clientSessionIdFromState,
                                 authRequestParams,
@@ -950,9 +950,17 @@ class IPVCallbackHandlerTest {
 
         @BeforeEach
         void setup() throws ParseException {
+            // Set up default session (from cookie)
             usingValidSession();
             usingValidClientSession();
             usingValidAuthUserInfo();
+
+            // Set up other client session from state
+            when(orchClientSessionService.getClientSession(clientSessionIdFromState))
+                    .thenReturn(Optional.of(orchClientSessionFromState));
+            when(authUserInfoStorageService.getAuthenticationUserInfo(
+                            TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER, clientSessionIdFromState))
+                    .thenReturn(Optional.of(authUserInfo));
 
             when(ipvCallbackHelper.generateAuthenticationErrorResponse(
                             any(), any(), anyBoolean(), anyString(), anyString()))
@@ -966,12 +974,10 @@ class IPVCallbackHandlerTest {
 
         @Test
         void itDoesNotReturnToTheRpIfCrossBrowserServiceReturnsEmptyForMismatchInClientSessionIDs()
-                throws NoSessionException,
-                        UnsuccessfulCredentialResponseException,
-                        Json.JsonException {
+                throws Exception {
 
             when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            anyMap(), anyString(), any()))
+                            anyMap(), anyString()))
                     .thenReturn(Optional.empty());
 
             Map<String, Object> userIdentityAdditionalClaims = new HashMap<>();
@@ -1009,25 +1015,9 @@ class IPVCallbackHandlerTest {
                                     new UserInfo(new JSONObject(claims)), clientRegistry));
 
             assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_URI);
-            verify(ipvCallbackHelper)
-                    .queueSPOTRequest(
-                            any(),
-                            anyString(),
-                            eq(authUserInfo),
-                            eq(new Subject(TEST_RP_PAIRWISE_ID)),
-                            any(UserInfo.class),
-                            eq(CLIENT_ID.getValue()));
-            verify(ipvCallbackHelper)
-                    .saveIdentityClaimsToDynamo(
-                            any(String.class),
-                            any(Subject.class),
-                            any(UserInfo.class),
-                            any(Long.class));
 
-            verifyAuditEvent(IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SPOT_REQUESTED);
+            verifySPOTRequestQueued();
+            verifyAllAuditEvents();
         }
 
         @Test
@@ -1035,13 +1025,13 @@ class IPVCallbackHandlerTest {
                 throws NoSessionException, Json.JsonException {
 
             when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            anyMap(), anyString(), any()))
+                            anyMap(), anyString()))
                     .thenReturn(
                             Optional.of(
                                     new CrossBrowserEntity(
                                             clientSessionIdFromState,
                                             errorObject,
-                                            clientSessionFromState)));
+                                            orchClientSessionFromState)));
 
             Map<String, String> queryParams = new HashMap<>();
             queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
@@ -1068,6 +1058,50 @@ class IPVCallbackHandlerTest {
                             any(Subject.class),
                             any(UserInfo.class),
                             any(Long.class));
+        }
+
+        @Test
+        void itDoesNotReturnToTheRpIfMismatchedClientSessionIsRecoverable() throws Exception {
+            // Use orch session linked to both client sessions
+            var combinedOrchSession =
+                    new OrchSessionItem(SESSION_ID)
+                            .withInternalCommonSubjectId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
+                            .addClientSession(CLIENT_SESSION_ID)
+                            .addClientSession(clientSessionIdFromState);
+            when(orchSessionService.getSession(SESSION_ID))
+                    .thenReturn(Optional.of(combinedOrchSession));
+
+            when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
+                            anyMap(), anyString()))
+                    .thenReturn(
+                            Optional.of(
+                                    new CrossBrowserEntity(
+                                            clientSessionIdFromState,
+                                            errorObject,
+                                            orchClientSessionFromState)));
+
+            var claims =
+                    new HashMap<String, Object>(
+                            Map.of(
+                                    "sub",
+                                    "sub-val",
+                                    "vot",
+                                    "P2",
+                                    "vtm",
+                                    OIDC_BASE_URL + "/trustmark",
+                                    IdentityClaims.CORE_IDENTITY.getValue(),
+                                    CORE_IDENTITY_CLAIM,
+                                    IdentityClaims.CREDENTIAL_JWT.getValue(),
+                                    CREDENTIAL_JWT_CLAIM));
+
+            var response =
+                    makeHandlerRequest(
+                            getApiGatewayProxyRequestEvent(
+                                    new UserInfo(new JSONObject(claims)), clientRegistry));
+
+            assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_URI);
+            verifySPOTRequestQueued();
+            verifyAllAuditEvents(clientSessionIdFromState);
         }
     }
 
@@ -1137,7 +1171,7 @@ class IPVCallbackHandlerTest {
             verify(identityProgressService, times(1))
                     .pollForStatus(eq(CLIENT_SESSION_ID), any(AuditContext.class));
 
-            verifyAllAuditEventsSubmitted();
+            verifyAllAuditEvents();
         }
 
         @Test
@@ -1157,7 +1191,7 @@ class IPVCallbackHandlerTest {
             verify(identityProgressService, times(1))
                     .pollForStatus(eq(CLIENT_SESSION_ID), any(AuditContext.class));
 
-            verifyAllAuditEventsSubmitted();
+            verifyAllAuditEvents();
         }
 
         @Test
@@ -1177,7 +1211,7 @@ class IPVCallbackHandlerTest {
             verify(identityProgressService, times(1))
                     .pollForStatus(eq(CLIENT_SESSION_ID), any(AuditContext.class));
 
-            verifyAllAuditEventsSubmitted();
+            verifyAllAuditEvents();
         }
 
         @Test
@@ -1197,7 +1231,7 @@ class IPVCallbackHandlerTest {
             verify(identityProgressService, times(1))
                     .pollForStatus(eq(CLIENT_SESSION_ID), any(AuditContext.class));
 
-            verifyAllAuditEventsSubmitted();
+            verifyAllAuditEvents();
         }
 
         @Test
@@ -1223,32 +1257,7 @@ class IPVCallbackHandlerTest {
             verify(identityProgressService, times(1))
                     .pollForStatus(eq(CLIENT_SESSION_ID), any(AuditContext.class));
 
-            verifyAllAuditEventsSubmitted();
-        }
-
-        void verifyAllAuditEventsSubmitted() {
-            verifyAuditEvent(IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED);
-            verifyAuditEvent(IPVAuditableEvent.IPV_SPOT_REQUESTED);
-            verifyNoMoreInteractions(auditService);
-        }
-
-        void verifySPOTRequestQueued() throws Exception {
-            verify(ipvCallbackHelper)
-                    .queueSPOTRequest(
-                            any(),
-                            anyString(),
-                            eq(authUserInfo),
-                            eq(new Subject(TEST_RP_PAIRWISE_ID)),
-                            any(UserInfo.class),
-                            eq(CLIENT_ID.getValue()));
-            verify(ipvCallbackHelper)
-                    .saveIdentityClaimsToDynamo(
-                            any(String.class),
-                            any(Subject.class),
-                            any(UserInfo.class),
-                            any(Long.class));
+            verifyAllAuditEvents();
         }
     }
 
@@ -1479,18 +1488,52 @@ class IPVCallbackHandlerTest {
                 .build();
     }
 
+    private void verifySPOTRequestQueued() throws Exception {
+        verify(ipvCallbackHelper)
+                .queueSPOTRequest(
+                        any(),
+                        anyString(),
+                        eq(authUserInfo),
+                        eq(new Subject(TEST_RP_PAIRWISE_ID)),
+                        any(UserInfo.class),
+                        eq(CLIENT_ID.getValue()));
+        verify(ipvCallbackHelper)
+                .saveIdentityClaimsToDynamo(
+                        any(String.class),
+                        any(Subject.class),
+                        any(UserInfo.class),
+                        any(Long.class));
+    }
+
     private void verifyAuditEvent(IPVAuditableEvent auditableEvent) {
+        verifyAuditEvent(auditableEvent, CLIENT_SESSION_ID);
+    }
+
+    private void verifyAuditEvent(IPVAuditableEvent auditableEvent, String clientSessionId) {
         verify(auditService)
                 .submitAuditEvent(
                         auditableEvent,
                         CLIENT_ID.getValue(),
                         TxmaAuditUser.user()
-                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withGovukSigninJourneyId(clientSessionId)
                                 .withSessionId(SESSION_ID)
                                 .withUserId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
                                 .withEmail(TEST_EMAIL_ADDRESS)
                                 .withPhone(authUserInfo.getPhoneNumber())
                                 .withPersistentSessionId(PERSISTENT_SESSION_ID));
+    }
+
+    private void verifyAllAuditEvents() {
+        verifyAllAuditEvents(CLIENT_SESSION_ID);
+    }
+
+    private void verifyAllAuditEvents(String clientSessionId) {
+        verifyAuditEvent(IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED, clientSessionId);
+        verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED, clientSessionId);
+        verifyAuditEvent(
+                IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED, clientSessionId);
+        verifyAuditEvent(IPVAuditableEvent.IPV_SPOT_REQUESTED, clientSessionId);
+        verifyNoMoreInteractions(auditService);
     }
 
     private APIGatewayProxyRequestEvent getApiGatewayProxyRequestEvent(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -61,6 +61,7 @@ import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
@@ -90,6 +91,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -1100,6 +1102,14 @@ class IPVCallbackHandlerTest {
                                     new UserInfo(new JSONObject(claims)), clientRegistry));
 
             assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_URI);
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.SET_COOKIE),
+                    startsWith(
+                            "%s=%s.%s"
+                                    .formatted(
+                                            CookieHelper.SESSION_COOKIE_NAME,
+                                            SESSION_ID,
+                                            clientSessionIdFromState)));
             verifySPOTRequestQueued();
             verifyAllAuditEvents(clientSessionIdFromState);
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.NotNull;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserItem;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
-import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 
 import java.util.Map;
@@ -89,9 +88,7 @@ public class CrossBrowserOrchestrationService {
     }
 
     public Optional<CrossBrowserEntity> generateEntityForMismatchInClientSessionId(
-            Map<String, String> queryStringParameters,
-            String clientSessionIdFromCookie,
-            OrchSessionItem orchSession)
+            Map<String, String> queryStringParameters, String clientSessionIdFromCookie)
             throws NoSessionException {
         if (!isStatePresentInQueryParams(queryStringParameters)) {
             LOG.warn("No state value in query params");
@@ -131,12 +128,6 @@ public class CrossBrowserOrchestrationService {
             attachLogFieldToLogs(CLIENT_ID, clientIdFromClientSession(orchClientSession));
         } catch (Exception e) {
             LOG.warn("Failed to attach client details to logs");
-        }
-
-        if (!isAccessDeniedErrorPresent(queryStringParameters)) {
-            LOG.info(
-                    "Client session may be recoverable. Client session linked to active session: {}",
-                    orchSession.getClientSessions().contains(clientSessionIdFromState));
         }
 
         var errorObject =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserItem;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
-import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 
@@ -46,8 +45,6 @@ class CrossBrowserOrchestrationServiceTest {
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
-    private static final OrchSessionItem ORCH_SESSION_ITEM =
-            new OrchSessionItem("a-session-id").addClientSession(CLIENT_SESSION_ID);
 
     private CrossBrowserOrchestrationService crossBrowserOrchestrationService;
 
@@ -241,7 +238,7 @@ class CrossBrowserOrchestrationServiceTest {
                     () ->
                             crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
-                                            queryParams, CLIENT_SESSION_ID, ORCH_SESSION_ITEM));
+                                            queryParams, CLIENT_SESSION_ID));
         }
 
         @Test
@@ -258,7 +255,7 @@ class CrossBrowserOrchestrationServiceTest {
 
             var noSessionEntity =
                     crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            queryParams, IdGenerator.generate(), ORCH_SESSION_ITEM);
+                            queryParams, IdGenerator.generate());
 
             assertTrue(noSessionEntity.isPresent());
             assertThat(
@@ -292,7 +289,7 @@ class CrossBrowserOrchestrationServiceTest {
             queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
             var noSessionEntity =
                     crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            queryParams, cookieClientSessionID, ORCH_SESSION_ITEM);
+                            queryParams, cookieClientSessionID);
 
             assertTrue(noSessionEntity.isPresent());
             assertThat(
@@ -325,7 +322,7 @@ class CrossBrowserOrchestrationServiceTest {
             queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
             var noSessionEntity =
                     crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
-                            queryParams, CLIENT_SESSION_ID, ORCH_SESSION_ITEM);
+                            queryParams, CLIENT_SESSION_ID);
 
             assertTrue(noSessionEntity.isEmpty());
         }
@@ -346,7 +343,7 @@ class CrossBrowserOrchestrationServiceTest {
                     () ->
                             crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
-                                            queryParams, CLIENT_SESSION_ID, ORCH_SESSION_ITEM));
+                                            queryParams, CLIENT_SESSION_ID));
         }
 
         @Test
@@ -368,7 +365,7 @@ class CrossBrowserOrchestrationServiceTest {
                     () ->
                             crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
-                                            queryParams, CLIENT_SESSION_ID, ORCH_SESSION_ITEM));
+                                            queryParams, CLIENT_SESSION_ID));
         }
     }
 


### PR DESCRIPTION
### Wider context of change

https://govukverify.atlassian.net/browse/ATO-2024

The V2 App introduces a new scenario where the app login session clashes with the original client session. In some cases (where the browser is the same) we may still be able to recover.

### What’s changed

If

- The client session in the state does not match the client session in the cookie
- AND the client session in the state is an active client session
- AND the client session in the state is linked to the active orch session

Then we continue processing and redirect to the RP using that client session.

### Manual testing

TBD

### Checklist

- [ ] Successfully deployed to authdev

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6889