### PR TITLE
Ato 2010/ensure scopes dont have commas

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -382,6 +382,20 @@ public class AuthorisationHandler
         }
         authRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
 
+        if (authRequest.getRequestObject() != null) {
+            var requestObjectScopes =
+                    authRequest.getRequestObject().getJWTClaimsSet().getStringClaim("scope");
+            if (requestObjectScopes.contains(",")) {
+                LOG.info(
+                        "Scope parameter in request object contains commas. Client ID: {}",
+                        clientId);
+            }
+        }
+        var queryParamScopes = input.getQueryStringParameters().get("scope");
+        if (queryParamScopes.contains(",")) {
+            LOG.info(
+                    "Scope parameter in query parameters contains commas. Client ID: {}", clientId);
+        }
         try {
             cloudwatchMetricsService.putEmbeddedValue(
                     "rpStateLength",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -157,7 +157,7 @@ class RequestObjectToAuthRequestHelperTest {
                   "rp_sid": "test-rp-sid",
                   "ui_locales": "en",
                   "vtr": ["Cl.Cm.P2"],
-                  "scope": "openid,email",
+                                  "scope": "openid email",
                   "claims": {
                     "userinfo": {
                       "https://vocab.account.gov.uk/v1/coreIdentityJWT": null,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -886,7 +886,7 @@ class AuthorisationHandlerTest {
                             Map.of(
                                     "client_id", "test-id",
                                     "redirect_uri", "http://localhost:8080",
-                                    "scope", "email,openid,profile",
+                                    "scope", "email openid profile",
                                     "response_type", "code"));
 
             event.setHttpMethod(method);
@@ -1988,7 +1988,7 @@ class AuthorisationHandlerTest {
                             Map.of(
                                     "client_id", "test-id",
                                     "redirect_uri", "http://incorrect-redirect-uri",
-                                    "scope", "email,openid,profile",
+                                    "scope", "email openid profile",
                                     "response_type", "code",
                                     "state", "test-state"));
 
@@ -2232,7 +2232,7 @@ class AuthorisationHandlerTest {
                             Map.of(
                                     "client_id", "test-id",
                                     "redirect_uri", "http://localhost:8080",
-                                    "scope", "email,openid,profile,non-existent-scope",
+                                    "scope", "email openid profile non-existent-scope",
                                     "response_type", "code",
                                     "state", "test-state"));
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -662,7 +662,7 @@ class LogoutServiceTest {
                         "redirect_uri",
                         List.of("http://localhost:8080"),
                         "scope",
-                        List.of("email,openid,profile"),
+                        List.of("email openid profile"),
                         "response_type",
                         List.of("code"),
                         "state",


### PR DESCRIPTION
### Wider context of change

We would like to upgrade nimbus, but in order to do so, we need to remove support scopes which are a comma-separated list. To check if any RPs are currently sending us comma-separated scopes, we should add some log lines. 
### What’s changed

This PR adds logging in AuthorisationHandler if the scope parameter contains commas. It will also log the client ID if this is the case.

I've also removed any uses of comma-separated scopes in tests.

### Manual testing

Will deploy to dev and test

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
- [ ] 