### PR TITLE
ATO-2014/Add refresh token store dynamo classes

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchRefreshTokenServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchRefreshTokenServiceIntegrationTest.java
@@ -1,0 +1,85 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.shared.exceptions.OrchRefreshTokenException;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchRefreshTokenExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrchRefreshTokenServiceIntegrationTest {
+    private static final String JWT_ID = "test-jwt-id";
+    private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "test-internal-pairwise-subject-id";
+    private static final String TOKEN = "test-token";
+    private static final String AUTH_CODE = "test-auth-code";
+    private static final boolean IS_USED = false;
+
+    @RegisterExtension
+    protected static final OrchRefreshTokenExtension orchRefreshTokenExtension =
+            new OrchRefreshTokenExtension();
+
+    @Test
+    void shouldStoreOrchRefreshTokenWithAllFieldsSet() {
+        orchRefreshTokenExtension.saveRefreshToken(
+                JWT_ID, INTERNAL_PAIRWISE_SUBJECT_ID, TOKEN, AUTH_CODE);
+
+        var refreshToken = orchRefreshTokenExtension.getRefreshToken(JWT_ID);
+
+        assertTrue(refreshToken.isPresent());
+        assertEquals(JWT_ID, refreshToken.get().getJwtId());
+        assertEquals(
+                INTERNAL_PAIRWISE_SUBJECT_ID, refreshToken.get().getInternalPairwiseSubjectId());
+        assertEquals(TOKEN, refreshToken.get().getToken());
+        assertEquals(AUTH_CODE, refreshToken.get().getAuthCode());
+        assertEquals(IS_USED, refreshToken.get().getIsUsed());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNoRefreshTokenExistsForJwtId() {
+        orchRefreshTokenExtension.saveRefreshToken(
+                JWT_ID, INTERNAL_PAIRWISE_SUBJECT_ID, TOKEN, AUTH_CODE);
+        var refreshToken = orchRefreshTokenExtension.getRefreshToken("different-jwt-id");
+        assertTrue(refreshToken.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenRefreshTokenForJwtIdIsAlreadyUsed() {
+        orchRefreshTokenExtension.saveRefreshToken(
+                JWT_ID, INTERNAL_PAIRWISE_SUBJECT_ID, TOKEN, AUTH_CODE);
+
+        var refreshToken = orchRefreshTokenExtension.getRefreshToken("different-jwt-id");
+        assertTrue(refreshToken.isEmpty());
+    }
+
+    @Test
+    void shouldReturnRefreshTokenForAuthCode() {
+        orchRefreshTokenExtension.saveRefreshToken(
+                JWT_ID, INTERNAL_PAIRWISE_SUBJECT_ID, TOKEN, AUTH_CODE);
+        var refreshToken = orchRefreshTokenExtension.getRefreshTokenForAuthCode(AUTH_CODE);
+        assertTrue(refreshToken.isPresent());
+        assertEquals(JWT_ID, refreshToken.get().getJwtId());
+        assertEquals(
+                INTERNAL_PAIRWISE_SUBJECT_ID, refreshToken.get().getInternalPairwiseSubjectId());
+        assertEquals(TOKEN, refreshToken.get().getToken());
+        assertEquals(AUTH_CODE, refreshToken.get().getAuthCode());
+        assertEquals(IS_USED, refreshToken.get().getIsUsed());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNoRefreshTokenExistsForAuthCode() {
+        orchRefreshTokenExtension.saveRefreshToken(
+                JWT_ID, INTERNAL_PAIRWISE_SUBJECT_ID, TOKEN, AUTH_CODE);
+        var refreshToken =
+                orchRefreshTokenExtension.getRefreshTokenForAuthCode("different-auth-code");
+        assertTrue(refreshToken.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenFailingToSaveRefreshToken() {
+        assertThrows(
+                OrchRefreshTokenException.class,
+                () -> orchRefreshTokenExtension.saveRefreshToken(null, null, null, null));
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchRefreshTokenExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchRefreshTokenExtension.java
@@ -1,0 +1,55 @@
+package uk.gov.di.orchestration.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.orchestration.shared.entity.OrchRefreshTokenItem;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.OrchRefreshTokenService;
+import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class OrchRefreshTokenExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String TABLE_NAME = "local-Refresh-Token";
+    public static final String ORCH_REFRESH_TOKEN_ID_FIELD = "JwtId";
+    private OrchRefreshTokenService orchRefreshTokenService;
+    private final ConfigurationService configurationService;
+
+    public OrchRefreshTokenExtension() {
+        this.configurationService =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        orchRefreshTokenService = new OrchRefreshTokenService(configurationService);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, TABLE_NAME, ORCH_REFRESH_TOKEN_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        createTableWithPartitionKey(
+                TABLE_NAME,
+                ORCH_REFRESH_TOKEN_ID_FIELD,
+                createGlobalSecondaryIndex("AuthCodeIndex", "AuthCode"));
+    }
+
+    public void saveRefreshToken(
+            String jwtId, String internalPairwiseSubjectId, String token, String authCode) {
+        orchRefreshTokenService.saveRefreshToken(jwtId, internalPairwiseSubjectId, token, authCode);
+    }
+
+    public Optional<OrchRefreshTokenItem> getRefreshToken(String jwtId) {
+        return orchRefreshTokenService.getRefreshToken(jwtId);
+    }
+
+    public Optional<OrchRefreshTokenItem> getRefreshTokenForAuthCode(String authCode) {
+        return orchRefreshTokenService.getRefreshTokenForAuthCode(authCode);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchRefreshTokenItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchRefreshTokenItem.java
@@ -1,0 +1,89 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+
+@DynamoDbBean
+public class OrchRefreshTokenItem {
+    private static final String ATTRIBUTE_JWT_ID = "JwtId";
+    private static final String ATTRIBUTE_INTERNAL_PAIRWISE_SUBJECT_ID =
+            "InternalPairwiseSubjectId";
+    private static final String ATTRIBUTE_TOKEN = "Token";
+    private static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
+    private static final String ATTRIBUTE_IS_USED = "IsUsed";
+
+    private String jwtId;
+    private String internalPairwiseSubjectId;
+    private String token;
+    private String authCode;
+    private boolean isUsed = false;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_JWT_ID)
+    public String getJwtId() {
+        return jwtId;
+    }
+
+    public void setJwtId(String jwtId) {
+        this.jwtId = jwtId;
+    }
+
+    public OrchRefreshTokenItem withJwtId(String jwtId) {
+        this.jwtId = jwtId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_INTERNAL_PAIRWISE_SUBJECT_ID)
+    public String getInternalPairwiseSubjectId() {
+        return internalPairwiseSubjectId;
+    }
+
+    public void setInternalPairwiseSubjectId(String internalPairwiseSubjectId) {
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+    }
+
+    public OrchRefreshTokenItem withInternalPairwiseSubjectId(String internalPairwiseSubjectId) {
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TOKEN)
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public OrchRefreshTokenItem withToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "AuthCodeIndex")
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_CODE)
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public OrchRefreshTokenItem withAuthCode(String authCode) {
+        this.authCode = authCode;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_IS_USED)
+    public boolean getIsUsed() {
+        return isUsed;
+    }
+
+    public void setIsUsed(boolean isUsed) {
+        this.isUsed = isUsed;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchRefreshTokenException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchRefreshTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class OrchRefreshTokenException extends RuntimeException {
+
+    public OrchRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenService.java
@@ -1,0 +1,96 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.orchestration.shared.entity.OrchRefreshTokenItem;
+import uk.gov.di.orchestration.shared.exceptions.OrchRefreshTokenException;
+
+import java.util.List;
+import java.util.Optional;
+
+public class OrchRefreshTokenService extends BaseDynamoService<OrchRefreshTokenItem> {
+    private static final Logger LOG = LogManager.getLogger(OrchAuthCodeService.class);
+    private static final String AUTH_CODE_INDEX = "AuthCodeIndex";
+
+    public OrchRefreshTokenService(ConfigurationService configurationService) {
+        super(OrchRefreshTokenItem.class, "Refresh-Token", configurationService, true);
+    }
+
+    public OrchRefreshTokenService(
+            DynamoDbClient dynamoDbClient, DynamoDbTable<OrchRefreshTokenItem> dynamoDbTable) {
+        super(dynamoDbTable, dynamoDbClient);
+    }
+
+    public Optional<OrchRefreshTokenItem> getRefreshToken(String jwtId) {
+        Optional<OrchRefreshTokenItem> orchRefreshToken = Optional.empty();
+        try {
+            orchRefreshToken = get(jwtId);
+        } catch (Exception e) {
+            logAndThrowOrchRefreshTokenException("Failed to get Orch refresh token from Dynamo", e);
+        }
+
+        if (orchRefreshToken.isEmpty()) {
+            LOG.info("No Orch refresh token found with jwtId {}", jwtId);
+            return Optional.empty();
+        }
+
+        var unusedOrchRefreshToken = orchRefreshToken.filter(s -> !s.getIsUsed());
+        if (unusedOrchRefreshToken.isEmpty()) {
+            LOG.info("Orch refresh token item with Jwt ID: {} has isUsed = true", jwtId);
+            return Optional.empty();
+        }
+        return orchRefreshToken;
+    }
+
+    public Optional<OrchRefreshTokenItem> getRefreshTokenForAuthCode(String authCode) {
+        List<OrchRefreshTokenItem> queryResults;
+        try {
+            queryResults = queryIndex(AUTH_CODE_INDEX, authCode);
+        } catch (Exception e) {
+            logAndThrowOrchRefreshTokenException(
+                    "Failed to get Orch refresh token from Dynamo for auth code", e);
+            return Optional.empty();
+        }
+        if (queryResults.isEmpty()) {
+            LOG.info("No Orch refresh token found with authCode {}", authCode);
+            return Optional.empty();
+        }
+        var unusedRefreshTokens = queryResults.stream().filter(s -> !s.getIsUsed()).toList();
+        if (unusedRefreshTokens.isEmpty()) {
+            LOG.info("Orch refresh token item with Auth Code: {} has isUsed = true", authCode);
+            return Optional.empty();
+        }
+        return Optional.of(unusedRefreshTokens.get(0));
+    }
+
+    public void saveRefreshToken(
+            String jwtId, String internalPairwiseSubjectId, String token, String authCode) {
+        try {
+            put(
+                    new OrchRefreshTokenItem()
+                            .withJwtId(jwtId)
+                            .withInternalPairwiseSubjectId(internalPairwiseSubjectId)
+                            .withToken(token)
+                            .withAuthCode(authCode));
+        } catch (Exception e) {
+            logAndThrowOrchRefreshTokenException(
+                    "Failed to save Orch refresh token item to Dynamo", e);
+        }
+    }
+
+    public void deleteRefreshToken(String jwtId) {
+        try {
+            delete(jwtId);
+        } catch (Exception e) {
+            logAndThrowOrchRefreshTokenException(
+                    "Failed to delete Orch refresh token item from Dynamo", e);
+        }
+    }
+
+    private void logAndThrowOrchRefreshTokenException(String message, Exception e) {
+        LOG.error("{}. Error message: {}", message, e.getMessage());
+        throw new OrchRefreshTokenException(message);
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -6996,6 +6996,134 @@ Resources:
               - kms:DescribeKey
             Resource: !GetAtt CrossBrowserTableEncryptionKey.Arn
   #endregion
+
+  #region refresh token data table
+  RefreshTokenTableEncryptionKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    Properties:
+      Description: KMS encryption key for Refresh Token DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+  RefreshTokenTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    Properties:
+      TableName: !Sub ${Environment}-Refresh-Token
+      AttributeDefinitions:
+        - AttributeName: JwtId
+          AttributeType: S
+        - AttributeName: AuthCode
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        - IndexName: AuthCodeIndex
+          KeySchema:
+            - AttributeName: AuthCode
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      KeySchema:
+        - AttributeName: JwtId
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt RefreshTokenTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: RefreshTokenTable
+  RefreshTokenTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowRefreshTokenTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+              - dynamodb:Query
+            Resource:
+              - !Sub ${RefreshTokenTable.Arn}/index/*
+              - !GetAtt RefreshTokenTable.Arn
+          - Sid: AllowRefreshTokenTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource: !GetAtt RefreshTokenTableEncryptionKey.Arn
+  RefreshTokenTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowRefreshTokenTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:UpdateItem
+              - dynamodb:PutItem
+            Resource: !GetAtt RefreshTokenTable.Arn
+          - Sid: AllowRefreshTokenTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: !GetAtt RefreshTokenTableEncryptionKey.Arn
+  RefreshTokenTableDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowRefreshTokenTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource: !GetAtt RefreshTokenTable.Arn
+          - Sid: AllowRefreshTokenTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource: !GetAtt RefreshTokenTableEncryptionKey.Arn
+
+  #endregion
+
   #region IPV token signing key pair
 
   OrchIPVTokenSigningKmsKeyAlias:


### PR DESCRIPTION
### Wider context of change

Migrating Refresh Token Store from redis to dynamo.

### What’s changed

- add dynamo classes for refresh tokens
- include delete method

### Manual testing

TO DO - deploy to dev and test with temporary logging

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
