### PR TITLE
ATO-1595: create orch sub environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
           ^(ci|.github|http|openAPI)/.*|\
           docker-compose.*|\
           .pre-commit-config.yaml|\
-          orchestration-canary-alarms.template.yaml|\
           checkov-policies.*|\
           .terraform-docs.yml|\
           account-management-api/api-contract(/.*)?$"

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -8,7 +8,7 @@ High level sequence diagrams for the Orchestration component are located [here](
 
 ## Infrastructure:
 
-Most of the infrastructure for the Orchestration component is defined in the [main cloudformation template](../../template.yaml) as well as a small template [snippet for anomaly alerts](../../orchestration-canary-alarms.template.yaml). However, there are still some resources defined in the Terraform (`./ci/terraform/...`).
+Most of the infrastructure for the Orchestration component is defined in the [main cloudformation template](../../template.yaml). However, there are still some resources defined in the Terraform (`./ci/terraform/...`).
 
 ## Code
 

--- a/template.yaml
+++ b/template.yaml
@@ -1785,19 +1785,35 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           ENVIRONMENT: !Sub ${Environment}
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
@@ -1979,10 +1995,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           ENVIRONMENT: !Sub ${Environment}
       Tags:
@@ -2170,10 +2194,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref IdTokenKmsAccessPolicy
@@ -2350,10 +2382,18 @@ Resources:
           DOC_APP_AUTHORISATION_CALLBACK_URI: !Sub
             - https://oidc.${ServiceDomain}/doc-app-callback
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DOC_APP_AUTHORISATION_CLIENT_ID:
             !FindInMap [
@@ -2394,18 +2434,34 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
@@ -2413,10 +2469,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -2653,20 +2717,36 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -2906,20 +2986,36 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-
@@ -2947,10 +3043,18 @@ Resources:
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -3165,10 +3269,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
@@ -3479,10 +3591,18 @@ Resources:
           CREDENTIAL_STORE_URI: !Sub
             - https://credential-store.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -3510,10 +3630,18 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           IPV_AUDIENCE: !If
             - IpvExists
@@ -3528,18 +3656,34 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_AUTHORISATION_CALLBACK_URI: !Sub
             - https://oidc.${ServiceDomain}/ipv-callback
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           IPV_AUTHORISATION_CLIENT_ID: authOrchestrator
           IPV_AUTHORISATION_URI: !If
@@ -3555,10 +3699,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}/authorize
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchIPVTokenSigningKmsKeyAlias
           IPV_JWKS_URL: !If
@@ -3574,10 +3726,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}/.well-known/jwks.json
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           ORCH_CLIENT_ID: orchestrationAuth
           ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS:
@@ -3591,10 +3751,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           AUTH_FRONTEND_BASE_URL: !If
             - UseAuthStub
@@ -3602,10 +3770,18 @@ Resources:
             - !Sub
               - https://signin.${ServiceDomain}/
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR:
             !If [AisAbortOnError, true, false]
@@ -4269,10 +4445,18 @@ Resources:
           DOC_APP_AUTHORISATION_CALLBACK_URI: !Sub
             - https://oidc.${ServiceDomain}/doc-app-callback
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DOC_APP_AUTHORISATION_CLIENT_ID:
             !FindInMap [
@@ -4307,12 +4491,16 @@ Resources:
               !Ref Environment,
               docAppSigningKeyArn,
             ]
-          DOMAIN_NAME:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              serviceDomain,
-            ]
+          DOMAIN_NAME: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - serviceDomain
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - serviceDomain
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
             - AccountId: !If
@@ -4346,10 +4534,18 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           AUTH_FRONTEND_BASE_URL: !If
             - UseAuthStub
@@ -4357,35 +4553,67 @@ Resources:
             - !Sub
               - https://signin.${ServiceDomain}/
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           OIDC_SERVICE_DOMAIN: !Sub
             - oidc.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           ORCH_CLIENT_ID: orchestrationAuth
           ORCH_REDIRECT_URI: !Sub
             - https://oidc.${ServiceDomain}/orchestration-redirect
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
@@ -4622,20 +4850,36 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -4861,10 +5105,18 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -4891,10 +5143,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -5114,10 +5374,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -5308,10 +5576,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -5500,20 +5776,36 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
@@ -5540,10 +5832,18 @@ Resources:
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED: true
           ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED: true
@@ -5572,10 +5872,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_AUTHORISATION_CALLBACK_URI: !If
             - IpvExists
@@ -5590,10 +5898,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}/ipv-callback
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_AUTHORISATION_CLIENT_ID: authOrchestrator
           IPV_AUTHORISATION_URI: !If
@@ -5609,10 +5925,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}/authorize
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_BACKEND_URI: !If
             - IpvExists
@@ -5627,10 +5951,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           IPV_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchIPVTokenSigningKmsKeyAlias
           IPV_JWKS_URL: !If
@@ -5646,10 +5978,18 @@ Resources:
             - !Sub
               - https://ipvstub.oidc.${ServiceDomain}/.well-known/jwks.json
               - ServiceDomain:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    serviceDomain,
+                  !If [
+                    UseSubEnvironment,
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref SubEnvironment,
+                      serviceDomain,
+                    ],
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      serviceDomain,
+                    ],
                   ]
           SPOT_QUEUE_URL: !If
             - IpvExists
@@ -5888,10 +6228,18 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -6016,28 +6364,52 @@ Resources:
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  serviceDomain,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    serviceDomain,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ],
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"

--- a/template.yaml
+++ b/template.yaml
@@ -2425,12 +2425,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - docAppBackendUri
-          DOC_APP_CRI_DATA_V2_ENDPOINT:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppCriDataV2Endpoint,
-            ]
+          DOC_APP_CRI_DATA_V2_ENDPOINT: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppCriDataV2Endpoint
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppCriDataV2Endpoint
           DOC_APP_CRI_DATA_ENDPOINT: unused
           DOC_APP_JWKS_URL: !Sub
             - ${DocAppBackendUri}/.well-known/jwks.json

--- a/template.yaml
+++ b/template.yaml
@@ -4536,12 +4536,16 @@ Resources:
               !Ref Environment,
               docAppClientId,
             ]
-          DOC_APP_AUTHORISATION_URI:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppAuthorisationUrl,
-            ]
+          DOC_APP_AUTHORISATION_URI: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppAuthorisationUrl
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppAuthorisationUrl
           DOC_APP_DOMAIN: !If
             - UseSubEnvironment
             - !FindInMap

--- a/template.yaml
+++ b/template.yaml
@@ -16,6 +16,9 @@ Parameters:
   Environment:
     Type: String
     Description: The name of the environment to deploy to
+  SubEnvironment:
+    Type: String
+    Description: When deploying to dev, optionally configure which sub-environment to deploy to i.e. orchdev1, orchdev2. This feature is not available for route-to-live environments.
   VpcStackName:
     Type: String
     Description: The name of the stack used to create the VPC
@@ -146,6 +149,30 @@ Mappings:
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:653994557586:key/8a74d461-33b1-455e-9539-3d8ad2916deb
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 3c2cb819-4dd1-4fbc-90f0-cbdc3ec24e50
+      authStubEnabled: false
+    orchdev1:
+      authApiId: "9il43udl10"
+      authExternalApiId: "i5ib7bm0pe"
+      authAccountId: "653994557586"
+      newauthAccountId: "975050272416"
+      authEnvironment: authdev3
+      serviceDomain: authdev3.dev.account.gov.uk
+      idTokenKeyArn: arn:aws:kms:eu-west-2:653994557586:key/853e9af8-2f07-439d-97da-c72fa5b238e9
+      idTokenKeyRsaArn: arn:aws:kms:eu-west-2:653994557586:key/17e5e566-4e99-43b4-ad59-e1ef924a582b
+      storageTokenKeyArn: arn:aws:kms:eu-west-2:653994557586:key/cf42638b-73a6-498f-a56f-e7ec341c276b
+      orchToAuthKeyArn: arn:aws:kms:eu-west-2:653994557586:key/22649b3a-4a9f-49c8-96ba-a517c49f9f37
+      backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:653994557586:authdev3-back-channel-logout-queue
+      docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
+      docAppDomain: https://dcmaw-cri.build.stubs.account.gov.uk
+      docAppCriDataV2Endpoint: credentials/issue
+      docAppAud: https://dcmaw-cri.build.stubs.account.gov.uk
+      docAppAuthorisationUrl: https://dcmaw-cri.build.stubs.account.gov.uk/authorize
+      docAppClientId: orch-dev
+      docAppCredentialTableKeyArn: arn:aws:kms:eu-west-2:653994557586:key/055d799b-c648-4232-801b-c83aef0f2bd1
+      docAppSigningKeyArn: arn:aws:kms:eu-west-2:653994557586:key/3e5dd566-314a-4be8-8976-d8177824f959
+      clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:653994557586:key/258b15a8-6157-439e-8018-24c59b91c8c5
+      orchToAuthTokenSigningKeyAlias: arn:aws:kms:eu-west-2:653994557586:key/22649b3a-4a9f-49c8-96ba-a517c49f9f37?
+      spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:653994557586:key/8a74d461-33b1-455e-9539-3d8ad2916deb
       authStubEnabled: false
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables

--- a/template.yaml
+++ b/template.yaml
@@ -3760,12 +3760,16 @@ Resources:
                     ],
                   ]
           ORCH_CLIENT_ID: orchestrationAuth
-          ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              orchToAuthKeyArn,
-            ]
+          ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - orchToAuthKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - orchToAuthKeyArn
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           OIDC_API_BASE_URL: !Sub
@@ -4651,12 +4655,16 @@ Resources:
                     serviceDomain,
                   ],
                 ]
-          ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              orchToAuthKeyArn,
-            ]
+          ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - orchToAuthKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - orchToAuthKeyArn
           ORCH_TO_AUTH_ENCRYPTION_KEY_PARAM: !If
             - UseAuthStub
             - !Sub /orch-stubs/${Environment}-auth-stub-auth-public-encryption-key
@@ -7804,10 +7812,18 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  orchToAuthKeyArn,
+              - !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    orchToAuthKeyArn,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    orchToAuthKeyArn,
+                  ],
                 ]
 
   BackChannelLogoutQueueWritePolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -2430,12 +2430,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
       Policies:
         - !Ref OrchDocAppCredentialTableReadAccessPolicy
         - !Ref OrchDocAppCredentialTableWriteAccessPolicy
@@ -2676,12 +2680,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -2925,12 +2933,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           BACK_CHANNEL_LOGOUT_QUEUE_URI: !GetAtt BackChannelLogoutQueue.QueueUrl
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
@@ -3139,12 +3151,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           BACK_CHANNEL_LOGOUT_QUEUE_URI: !GetAtt BackChannelLogoutQueue.QueueUrl
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
@@ -3448,12 +3464,16 @@ Resources:
                     - !Ref Environment
                     - authExternalApiId
                 VpcId: !ImportValue vpc-ExecuteApiGatewayEndpointId
-                AuthEnvironment:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authEnvironment,
-                  ]
+                AuthEnvironment: !If
+                  - UseSubEnvironment
+                  - !FindInMap
+                    - EnvironmentConfiguration
+                    - !Ref SubEnvironment
+                    - authEnvironment
+                  - !FindInMap
+                    - EnvironmentConfiguration
+                    - !Ref Environment
+                    - authEnvironment
           ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME: "AISException"
           BACK_CHANNEL_LOGOUT_QUEUE_URI: !GetAtt BackChannelLogoutQueue.QueueUrl
           CREDENTIAL_STORE_URI: !Sub
@@ -3476,12 +3496,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
@@ -4301,12 +4325,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           ENVIRONMENT: !Sub ${Environment}
           EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
@@ -4621,12 +4649,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -4846,12 +4878,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -5065,12 +5101,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -5255,12 +5295,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -5483,12 +5527,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           AUTH_FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain:
@@ -5827,12 +5875,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -5999,12 +6051,16 @@ Resources:
                   - EnvironmentConfiguration
                   - !Ref Environment
                   - authAccountId
-              AuthEnvironment:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authEnvironment,
-                ]
+              AuthEnvironment: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authEnvironment
       Policies:
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref OrchIdentityCredentialsTableWriteAccessPolicy
@@ -6981,12 +7037,16 @@ Resources:
                       - EnvironmentConfiguration
                       - !Ref Environment
                       - authAccountId
-                  AuthEnvironment:
-                    !FindInMap [
-                      EnvironmentConfiguration,
-                      !Ref Environment,
-                      authEnvironment,
-                    ]
+                  AuthEnvironment: !If
+                    - UseSubEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref SubEnvironment
+                      - authEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref Environment
+                      - authEnvironment
               - !GetAtt ClientRegistryTable.Arn
           - Sid: AllowClientRegistryTableKeyAccess
             Effect: Allow
@@ -7030,12 +7090,16 @@ Resources:
                       - EnvironmentConfiguration
                       - !Ref Environment
                       - authAccountId
-                  AuthEnvironment:
-                    !FindInMap [
-                      EnvironmentConfiguration,
-                      !Ref Environment,
-                      authEnvironment,
-                    ]
+                  AuthEnvironment: !If
+                    - UseSubEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref SubEnvironment
+                      - authEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref Environment
+                      - authEnvironment
               - !GetAtt ClientRegistryTable.Arn
           - Sid: AllowClientRegistryTableKeyAccess
             Effect: Allow

--- a/template.yaml
+++ b/template.yaml
@@ -2716,12 +2716,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - idTokenKeyArn
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyRsaArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyRsaArn
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -2989,12 +2993,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - idTokenKeyArn
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyRsaArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyRsaArn
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -4097,12 +4105,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - idTokenKeyArn
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyRsaArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyRsaArn
           DOC_APP_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4865,12 +4877,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - idTokenKeyArn
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyRsaArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyRsaArn
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -7696,10 +7712,18 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  idTokenKeyRsaArn,
+              - !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    idTokenKeyRsaArn,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    idTokenKeyRsaArn,
+                  ],
                 ]
 
   DocAppSigningKmsAccessPolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -4522,12 +4522,16 @@ Resources:
               !Ref Environment,
               docAppAuthorisationUrl,
             ]
-          DOC_APP_DOMAIN:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppDomain,
-            ]
+          DOC_APP_DOMAIN: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppDomain
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppDomain
           DOC_APP_JWKS_URL: !Sub
             - ${DocAppBackendUri}/.well-known/jwks.json
             - DocAppBackendUri:

--- a/template.yaml
+++ b/template.yaml
@@ -466,10 +466,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${AuthAccountId}:root
                   - AuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        authAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          authAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          authAccountId,
+                        ],
                       ]
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
@@ -535,10 +543,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -558,10 +574,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -582,10 +606,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -718,10 +750,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${AuthAccountId}:root
                   - AuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        authAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          authAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          authAccountId,
+                        ],
                       ]
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
@@ -774,10 +814,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -797,10 +845,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -851,10 +907,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${AuthAccountId}:root
                   - AuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        authAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          authAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          authAccountId,
+                        ],
                       ]
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
@@ -913,10 +977,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -1033,10 +1105,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${AuthAccountId}:root
                   - AuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        authAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          authAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          authAccountId,
+                        ],
                       ]
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
@@ -1092,10 +1172,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${AuthAccountId}:root
                     - AuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          authAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            authAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ],
                         ]
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
@@ -1634,12 +1722,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/.well-known/openid-configuration"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -1816,12 +1908,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/trustmark"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -2236,12 +2332,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -2287,12 +2387,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/doc-app-callback"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -2474,12 +2578,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -2510,12 +2618,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/POST/token"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -2715,12 +2827,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -2757,12 +2873,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/logout
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -2921,12 +3041,16 @@ Resources:
           ENVIRONMENT: !Sub ${Environment}
           DYNAMO_ARN_PREFIX: !Sub
             - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -3254,12 +3378,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -3407,12 +3535,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/orchestration-redirect"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -3688,12 +3820,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/.well-known/jwks.json"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -3864,12 +4000,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/.well-known/ipv-jwks.json"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4063,12 +4203,16 @@ Resources:
             ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -4169,12 +4313,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/authorize"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4375,12 +4523,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -4407,12 +4559,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/userinfo"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4592,12 +4748,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -4632,12 +4792,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/auth-code"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4803,12 +4967,16 @@ Resources:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -4839,12 +5007,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/PUT/connect/register/{clientId}"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4985,12 +5157,16 @@ Resources:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -5021,12 +5197,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/POST/connect/register"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -5205,12 +5385,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -5377,12 +5561,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/ipv-callback
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -5541,12 +5729,16 @@ Resources:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -5709,12 +5901,16 @@ Resources:
                 ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-"
-            - AccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  authAccountId,
-                ]
+            - AccountId: !If
+                - UseSubEnvironment
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref SubEnvironment
+                  - authAccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref Environment
+                  - authAccountId
               AuthEnvironment:
                 !FindInMap [
                   EnvironmentConfiguration,
@@ -5975,12 +6171,16 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/.well-known/storage-token-jwk.json
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
+        - AccountId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authAccountId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authAccountId
           ApiId: !If
             - UseSubEnvironment
             - !FindInMap
@@ -6683,12 +6883,16 @@ Resources:
             Resource:
               - !Sub
                 - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
-                - AccountId:
-                    !FindInMap [
-                      EnvironmentConfiguration,
-                      !Ref Environment,
-                      authAccountId,
-                    ]
+                - AccountId: !If
+                    - UseSubEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref SubEnvironment
+                      - authAccountId
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref Environment
+                      - authAccountId
                   AuthEnvironment:
                     !FindInMap [
                       EnvironmentConfiguration,
@@ -6728,12 +6932,16 @@ Resources:
             Resource:
               - !Sub
                 - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-client-registry
-                - AccountId:
-                    !FindInMap [
-                      EnvironmentConfiguration,
-                      !Ref Environment,
-                      authAccountId,
-                    ]
+                - AccountId: !If
+                    - UseSubEnvironment
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref SubEnvironment
+                      - authAccountId
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref Environment
+                      - authAccountId
                   AuthEnvironment:
                     !FindInMap [
                       EnvironmentConfiguration,

--- a/template.yaml
+++ b/template.yaml
@@ -2452,8 +2452,16 @@ Resources:
                     docAppBackendUri,
                   ],
                 ]
-          DOC_APP_AUD:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, docAppAud]
+          DOC_APP_AUD: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppAud
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppAud
           DOC_APP_NEW_AUD_CLAIM_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
@@ -4496,8 +4504,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           CUSTOM_DOC_APP_CLAIM_ENABLED: true
-          DOC_APP_AUD:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, docAppAud]
+          DOC_APP_AUD: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppAud
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppAud
           DOC_APP_AUTHORISATION_CALLBACK_URI: !Sub
             - https://oidc.${ServiceDomain}/doc-app-callback
             - ServiceDomain:

--- a/template.yaml
+++ b/template.yaml
@@ -482,10 +482,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
                   - NewAuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        newauthAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          newauthAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          newauthAccountId,
+                        ],
                       ]
             Action:
               - kms:Decrypt
@@ -559,10 +567,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
             - Sid: AllowOrchSessionTableCrossAccountDeleteAccess
               Effect: Allow
@@ -590,10 +606,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
             - Sid: AllowOrchSessionTableCrossAccountWriteAccess
               Effect: Allow
@@ -622,10 +646,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
 
   #endregion
@@ -766,10 +798,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
                   - NewAuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        newauthAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          newauthAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          newauthAccountId,
+                        ],
                       ]
             Action:
               - kms:Decrypt
@@ -830,10 +870,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
             - Sid: AllowClientSessionTableDeleteAccessPolicy
               Effect: Allow
@@ -861,10 +909,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
       Tags:
         - Key: Name
@@ -923,10 +979,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
                   - NewAuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        newauthAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          newauthAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          newauthAccountId,
+                        ],
                       ]
             Action:
               - kms:Decrypt
@@ -993,10 +1057,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
       Tags:
         - Key: Name
@@ -1121,10 +1193,18 @@ Resources:
                 - !Sub
                   - arn:aws:iam::${NewAuthAccountId}:root
                   - NewAuthAccountId:
-                      !FindInMap [
-                        EnvironmentConfiguration,
-                        !Ref Environment,
-                        newauthAccountId,
+                      !If [
+                        UseSubEnvironment,
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref SubEnvironment,
+                          newauthAccountId,
+                        ],
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          newauthAccountId,
+                        ],
                       ]
             Action:
               - kms:Decrypt
@@ -1188,10 +1268,18 @@ Resources:
                   - !Sub
                     - arn:aws:iam::${NewAuthAccountId}:root
                     - NewAuthAccountId:
-                        !FindInMap [
-                          EnvironmentConfiguration,
-                          !Ref Environment,
-                          newauthAccountId,
+                        !If [
+                          UseSubEnvironment,
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref SubEnvironment,
+                            newauthAccountId,
+                          ],
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            newauthAccountId,
+                          ],
                         ]
             - Fn::If:
                 - IsNotDevEnvironment

--- a/template.yaml
+++ b/template.yaml
@@ -4740,7 +4740,10 @@ Resources:
           ORCH_TO_AUTH_ENCRYPTION_KEY_PARAM: !If
             - UseAuthStub
             - !Sub /orch-stubs/${Environment}-auth-stub-auth-public-encryption-key
-            - !Sub ${Environment}-auth-public-encryption-key
+            - !If
+              - UseSubEnvironment
+              - !Sub ${SubEnvironment}-auth-public-encryption-key
+              - !Sub ${Environment}-auth-public-encryption-key
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true
@@ -7751,7 +7754,10 @@ Resources:
               - !If
                 - UseAuthStub
                 - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/orch-stubs/dev-auth-stub-auth-public-encryption-key
-                - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-auth-public-encryption-key
+                - !If
+                  - UseSubEnvironment
+                  - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${SubEnvironment}-auth-public-encryption-key
+                  - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-auth-public-encryption-key
           - Sid: AllowDecryptOfParameters
             Effect: Allow
             Action: kms:Decrypt

--- a/template.yaml
+++ b/template.yaml
@@ -2403,12 +2403,16 @@ Resources:
                     serviceDomain,
                   ],
                 ]
-          DOC_APP_AUTHORISATION_CLIENT_ID:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppClientId,
-            ]
+          DOC_APP_AUTHORISATION_CLIENT_ID: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppClientId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppClientId
           DOC_APP_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4530,12 +4534,16 @@ Resources:
                     serviceDomain,
                   ],
                 ]
-          DOC_APP_AUTHORISATION_CLIENT_ID:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppClientId,
-            ]
+          DOC_APP_AUTHORISATION_CLIENT_ID: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppClientId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppClientId
           DOC_APP_AUTHORISATION_URI: !If
             - UseSubEnvironment
             - !FindInMap

--- a/template.yaml
+++ b/template.yaml
@@ -7558,10 +7558,18 @@ Resources:
               - kms:CreateGrant
               - kms:DescribeKey
             Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  clientRegistryTableKeyArn,
+              - !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    clientRegistryTableKeyArn,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    clientRegistryTableKeyArn,
+                  ],
                 ]
               - !GetAtt ClientRegistryTableEncryptionKey.Arn
 
@@ -7611,10 +7619,18 @@ Resources:
               - kms:CreateGrant
               - kms:DescribeKey
             Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  clientRegistryTableKeyArn,
+              - !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    clientRegistryTableKeyArn,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    clientRegistryTableKeyArn,
+                  ],
                 ]
               - !GetAtt ClientRegistryTableEncryptionKey.Arn
 

--- a/template.yaml
+++ b/template.yaml
@@ -2415,12 +2415,16 @@ Resources:
               !Ref Environment,
               docAppSigningKeyArn,
             ]
-          DOC_APP_BACKEND_URI:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppBackendUri,
-            ]
+          DOC_APP_BACKEND_URI: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppBackendUri
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppBackendUri
           DOC_APP_CRI_DATA_V2_ENDPOINT:
             !FindInMap [
               EnvironmentConfiguration,
@@ -2431,10 +2435,18 @@ Resources:
           DOC_APP_JWKS_URL: !Sub
             - ${DocAppBackendUri}/.well-known/jwks.json
             - DocAppBackendUri:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  docAppBackendUri,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    docAppBackendUri,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    docAppBackendUri,
+                  ],
                 ]
           DOC_APP_AUD:
             !FindInMap [EnvironmentConfiguration, !Ref Environment, docAppAud]
@@ -4519,10 +4531,18 @@ Resources:
           DOC_APP_JWKS_URL: !Sub
             - ${DocAppBackendUri}/.well-known/jwks.json
             - DocAppBackendUri:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  docAppBackendUri,
+                !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    docAppBackendUri,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    docAppBackendUri,
+                  ],
                 ]
           DOC_APP_NEW_AUD_CLAIM_ENABLED: true
           DOC_APP_TOKEN_SIGNING_KEY_ALIAS:

--- a/template.yaml
+++ b/template.yaml
@@ -118,6 +118,15 @@ Conditions:
     ]
   UseSyncWaitForSpot: !Equals [dev, !Ref Environment]
   UseSingleFactorAccountDeletion: !Equals [dev, !Ref Environment]
+  UseSubEnvironment:
+    Fn::And:
+      - Fn::Equals:
+          - !Ref Environment
+          - dev
+      - Fn::Not:
+          - Fn::Equals:
+              - !Ref SubEnvironment
+              - none
 
 Mappings:
   EnvironmentConfiguration:
@@ -478,7 +487,10 @@ Resources:
   OrchSessionTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Orch-Session
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Orch-Session
+        - !Sub ${Environment}-Orch-Session
       AttributeDefinitions:
         - AttributeName: SessionId
           AttributeType: S
@@ -620,7 +632,10 @@ Resources:
   AuthUserInfoTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Auth-User-Info
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Auth-User-Info
+        - !Sub ${Environment}-Auth-User-Info
       AttributeDefinitions:
         - AttributeName: InternalCommonSubjectId
           AttributeType: S
@@ -723,7 +738,10 @@ Resources:
   ClientSessionTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Client-Session
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Client-Session
+        - !Sub ${Environment}-Client-Session
       AttributeDefinitions:
         - AttributeName: ClientSessionId
           AttributeType: S
@@ -853,7 +871,10 @@ Resources:
   ClientRegistryTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-client-registry
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-client-registry
+        - !Sub ${Environment}-client-registry
       AttributeDefinitions:
         - AttributeName: ClientID
           AttributeType: S
@@ -1032,7 +1053,10 @@ Resources:
   OrchIdentityCredentialsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Orch-Identity-Credentials
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Orch-Identity-Credentials
+        - !Sub ${Environment}-Orch-Identity-Credentials
       AttributeDefinitions:
         - AttributeName: ClientSessionId
           AttributeType: S
@@ -1173,7 +1197,10 @@ Resources:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: It would be harmful to restore old keys from a backup of this data, and keys will be fetched if not present anyway.
     Properties:
-      TableName: !Sub ${Environment}-RpPublicKeyCache
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-RpPublicKeyCache
+        - !Sub ${Environment}-RpPublicKeyCache
       AttributeDefinitions:
         - AttributeName: clientId
           AttributeType: S
@@ -1235,7 +1262,10 @@ Resources:
   StateStorageTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-State-Storage
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-State-Storage
+        - !Sub ${Environment}-State-Storage
       AttributeDefinitions:
         - AttributeName: PrefixedSessionId
           AttributeType: S
@@ -1293,7 +1323,10 @@ Resources:
   DocAppCredentialTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Orch-Doc-App-Credential
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Orch-Doc-App-Credential
+        - !Sub ${Environment}-Orch-Doc-App-Credential
       AttributeDefinitions:
         - AttributeName: SubjectID
           AttributeType: S
@@ -1371,7 +1404,10 @@ Resources:
   JwksCacheTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Jwks-Cache
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Jwks-Cache
+        - !Sub ${Environment}-Jwks-Cache
       AttributeDefinitions:
         - AttributeName: JwksUrl
           AttributeType: S
@@ -1407,7 +1443,10 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not required
     # checkov:skip=CKV_AWS_117: Lambda needs to exist outside our VPC so default AWS Lambda service VPC is OK
     Properties:
-      FunctionName: !Sub ${Environment}-FetchJwksFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-FetchJwksFunction
+        - !Sub ${Environment}-FetchJwksFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.FetchJwksHandler::handleRequest
@@ -1424,7 +1463,10 @@ Resources:
   FetchJwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-fetch-jwks-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-fetch-jwks-lambda
+        - !Sub /aws/lambda/${Environment}-fetch-jwks-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -1439,11 +1481,17 @@ Resources:
   FetchJwksFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-fetchjwks-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-fetchjwks-errors
+        - !Sub ${Environment}-fetchjwks-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref FetchJwksFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-fetchjwks-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-fetchjwks-error-count
+            - !Sub ${Environment}-fetchjwks-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -1457,10 +1505,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} FetchJwksFunction lambda. ACCOUNT: di-orchestration-${Environment}"
-      AlarmName: !Sub ${Environment}-fetchjwks-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-fetchjwks-alarm
+        - !Sub ${Environment}-fetchjwks-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-fetchjwks-error-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-fetchjwks-error-count
+        - !Sub ${Environment}-fetchjwks-error-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -1469,7 +1523,10 @@ Resources:
   FetchJwksFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-fetchjwks-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-fetchjwks-error-rate-alarm
+        - !Sub ${Environment}-fetchjwks-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} FetchJwksFunction lambda. ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: true
       AlarmActions:
@@ -1493,7 +1550,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-FetchJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-FetchJwksFunction
+                    - !Sub ${Environment}-FetchJwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1505,7 +1565,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-FetchJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-FetchJwksFunction
+                    - !Sub ${Environment}-FetchJwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1519,7 +1582,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-OpenIdConfigurationFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-OpenIdConfigurationFunction
+        - !Sub ${Environment}-OpenIdConfigurationFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest
@@ -1580,7 +1646,10 @@ Resources:
   OpenIdConfigurationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-openid-configuration-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-openid-configuration-lambda
+        - !Sub /aws/lambda/${Environment}-openid-configuration-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -1595,11 +1664,17 @@ Resources:
   OpenIdConfigurationFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-openid-configuration-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-openid-configuration-errors
+        - !Sub ${Environment}-openid-configuration-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref OpenIdConfigurationFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-openid-configuration-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-openid-configuration-error-count
+            - !Sub ${Environment}-openid-configuration-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -1613,10 +1688,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} openid-configuration lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-openid-configuration-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-openid-configuration-alarm
+        - !Sub ${Environment}-openid-configuration-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-openid-configuration-error-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-openid-configuration-error-count
+        - !Sub ${Environment}-openid-configuration-error-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -1625,7 +1706,10 @@ Resources:
   OpenIdConfigurationFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-openid-configuration-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-openid-configuration-error-rate-alarm
+        - !Sub ${Environment}-openid-configuration-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} openid-configuration lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -1649,7 +1733,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-OpenIdConfigurationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-OpenIdConfigurationFunction
+                    - !Sub ${Environment}-OpenIdConfigurationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1661,7 +1748,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-OpenIdConfigurationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-OpenIdConfigurationFunction
+                    - !Sub ${Environment}-OpenIdConfigurationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1674,7 +1764,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-TrustmarkFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-TrustmarkFunction
+        - !Sub ${Environment}-TrustmarkFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest
@@ -1727,7 +1820,10 @@ Resources:
   TrustmarkFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-trustmark-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-trustmark-lambda
+        - !Sub /aws/lambda/${Environment}-trustmark-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -1742,11 +1838,17 @@ Resources:
   TrustmarkFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-trustmark-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-trustmark-errors
+        - !Sub ${Environment}-trustmark-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref TrustmarkFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-trustmark-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-trustmark-error-count
+            - !Sub ${Environment}-trustmark-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -1760,10 +1862,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-trustmark-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-trustmark-alarm
+        - !Sub ${Environment}-trustmark-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-trustmark-error-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-trustmark-error-count
+        - !Sub ${Environment}-trustmark-error-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -1772,7 +1880,10 @@ Resources:
   TrustmarkFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-trustmark-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-trustmark-error-rate-alarm
+        - !Sub ${Environment}-trustmark-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -1796,7 +1907,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TrustmarkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TrustmarkFunction
+                    - !Sub ${Environment}-TrustmarkFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1808,7 +1922,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TrustmarkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TrustmarkFunction
+                    - !Sub ${Environment}-TrustmarkFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1822,7 +1939,10 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: Lambda needs open egress so isn't in VPC
     Properties:
-      FunctionName: !Sub ${Environment}-BackChannelLogoutRequestFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-BackChannelLogoutRequestFunction
+        - !Sub ${Environment}-BackChannelLogoutRequestFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.BackChannelLogoutRequestHandler::handleRequest
@@ -1877,7 +1997,10 @@ Resources:
   BackChannelLogoutRequestFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-backchannel-logout-request-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-backchannel-logout-request-lambda
+        - !Sub /aws/lambda/${Environment}-backchannel-logout-request-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -1892,11 +2015,17 @@ Resources:
   BackChannelLogoutRequestFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-backchannel-logout-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-backchannel-logout-request-errors
+        - !Sub ${Environment}-backchannel-logout-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref BackChannelLogoutRequestFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-backchannel-logout-request-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-backchannel-logout-request-count
+            - !Sub ${Environment}-backchannel-logout-request-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -1913,10 +2042,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} backchannel logout request lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/OoDyFAE"
-      AlarmName: !Sub ${Environment}-backchannel-logout-request-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-backchannel-logout-request-alarm
+        - !Sub ${Environment}-backchannel-logout-request-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-backchannel-logout-request-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-backchannel-logout-request-count
+        - !Sub ${Environment}-backchannel-logout-request-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -1925,7 +2060,10 @@ Resources:
   BackChannelLogoutRequestFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-backchannel-logout-request-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-backchannel-logout-request-error-rate-alarm
+        - !Sub ${Environment}-backchannel-logout-request-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 25 has been reached in the ${Environment} backchannel logout request lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/OoDyFAE"
       ActionsEnabled: !If
         - IsIntegrationOrProduction
@@ -1952,7 +2090,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-BackChannelLogoutRequestFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-BackChannelLogoutRequestFunction
+                    - !Sub ${Environment}-BackChannelLogoutRequestFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1964,7 +2105,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-BackChannelLogoutRequestFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-BackChannelLogoutRequestFunction
+                    - !Sub ${Environment}-BackChannelLogoutRequestFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -1977,7 +2121,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-DocAppCallbackFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-DocAppCallbackFunction
+        - !Sub ${Environment}-DocAppCallbackFunction
       AutoPublishAlias: latest
       CodeUri: ./doc-checking-app-api/build/distributions/doc-checking-app-api.zip
       Handler: uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest
@@ -2101,7 +2248,10 @@ Resources:
   DocAppCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-doc-app-callback-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-doc-app-callback-lambda
+        - !Sub /aws/lambda/${Environment}-doc-app-callback-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -2133,11 +2283,17 @@ Resources:
   DocAppCallbackFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-doc-app-callback-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-doc-app-callback-request-errors
+        - !Sub ${Environment}-doc-app-callback-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref DocAppCallbackFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-doc-app-callback-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-doc-app-callback-count
+            - !Sub ${Environment}-doc-app-callback-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -2151,10 +2307,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "20 or more errors have occurred in the ${Environment} doc app callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-doc-app-callback-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-doc-app-callback-alarm
+        - !Sub ${Environment}-doc-app-callback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-doc-app-callback-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-doc-app-callback-count
+        - !Sub ${Environment}-doc-app-callback-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -2163,7 +2325,10 @@ Resources:
   DocAppCallbackFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-doc-app-callback-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-doc-app-callback-error-rate-alarm
+        - !Sub ${Environment}-doc-app-callback-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} doc app callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -2187,7 +2352,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-DocAppCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-DocAppCallbackFunction
+                    - !Sub ${Environment}-DocAppCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2199,7 +2367,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-DocAppCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-DocAppCallbackFunction
+                    - !Sub ${Environment}-DocAppCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2213,7 +2384,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-TokenFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-TokenFunction
+        - !Sub ${Environment}-TokenFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest
@@ -2324,7 +2498,10 @@ Resources:
   TokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-token-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-token-lambda
+        - !Sub /aws/lambda/${Environment}-token-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -2339,11 +2516,17 @@ Resources:
   TokenFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-token-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-token-request-errors
+        - !Sub ${Environment}-token-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref TokenFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-token-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-token-count
+            - !Sub ${Environment}-token-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -2357,10 +2540,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} token lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-token-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-token-alarm
+        - !Sub ${Environment}-token-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-token-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-token-count
+        - !Sub ${Environment}-token-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -2369,7 +2558,10 @@ Resources:
   TokenFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-token-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-token-error-rate-alarm
+        - !Sub ${Environment}-token-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} token lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -2393,7 +2585,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TokenFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TokenFunction
+                    - !Sub ${Environment}-TokenFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2405,7 +2600,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TokenFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TokenFunction
+                    - !Sub ${Environment}-TokenFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2419,7 +2617,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-LogoutFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-LogoutFunction
+        - !Sub ${Environment}-LogoutFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest
@@ -2536,7 +2737,10 @@ Resources:
   LogoutFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-logout-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-logout-lambda
+        - !Sub /aws/lambda/${Environment}-logout-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -2551,11 +2755,17 @@ Resources:
   LogoutFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-logout-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-logout-request-errors
+        - !Sub ${Environment}-logout-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref LogoutFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-logout-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-logout-count
+            - !Sub ${Environment}-logout-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -2569,10 +2779,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} logout lambda.ACCOUNT: di-orchestration-${Environment}"
-      AlarmName: !Sub ${Environment}-logout-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-logout-alarm
+        - !Sub ${Environment}-logout-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-logout-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-logout-count
+        - !Sub ${Environment}-logout-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -2581,7 +2797,10 @@ Resources:
   LogoutFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-logout-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-logout-error-rate-alarm
+        - !Sub ${Environment}-logout-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} logout lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: true
       AlarmActions:
@@ -2605,7 +2824,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-LogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-LogoutFunction
+                    - !Sub ${Environment}-LogoutFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2617,7 +2839,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-LogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-LogoutFunction
+                    - !Sub ${Environment}-LogoutFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2629,7 +2854,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: Lambda is triggered by SQS so DLQ not needed
     Properties:
-      FunctionName: !Sub ${Environment}-GlobalLogoutFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-GlobalLogoutFunction
+        - !Sub ${Environment}-GlobalLogoutFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.GlobalLogoutHandler::handleRequest
@@ -2697,7 +2925,10 @@ Resources:
   GlobalLogoutFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-global-logout-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-global-logout-lambda
+        - !Sub /aws/lambda/${Environment}-global-logout-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -2712,11 +2943,17 @@ Resources:
   GlobalLogoutFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-global-logout-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-global-logout-request-errors
+        - !Sub ${Environment}-global-logout-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref GlobalLogoutFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-global-logout-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-global-logout-count
+            - !Sub ${Environment}-global-logout-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -2730,10 +2967,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} global logout lambda.ACCOUNT: di-orchestration-${Environment}"
-      AlarmName: !Sub ${Environment}-global-logout-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-global-logout-alarm
+        - !Sub ${Environment}-global-logout-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-global-logout-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-global-logout-count
+        - !Sub ${Environment}-global-logout-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -2742,7 +2985,10 @@ Resources:
   GlobalLogoutFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-global-logout-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-global-logout-error-rate-alarm
+        - !Sub ${Environment}-global-logout-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} global logout lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: true
       AlarmActions:
@@ -2766,7 +3012,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-GlobalLogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-GlobalLogoutFunction
+                    - !Sub ${Environment}-GlobalLogoutFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2778,7 +3027,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-GlobalLogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-GlobalLogoutFunction
+                    - !Sub ${Environment}-GlobalLogoutFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -2801,7 +3053,10 @@ Resources:
     Condition: IsDevOrBuild
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${Environment}-GlobalLogoutTestQueue
+      QueueName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-GlobalLogoutTestQueue
+        - !Sub ${Environment}-GlobalLogoutTestQueue
       MaximumMessageSize: 2048
       MessageRetentionPeriod: 1209600
       ReceiveMessageWaitTimeSeconds: 10
@@ -2815,7 +3070,10 @@ Resources:
     Condition: IsDevOrBuild
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${Environment}-GlobalLogoutTestDlq
+      QueueName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-GlobalLogoutTestDlq
+        - !Sub ${Environment}-GlobalLogoutTestDlq
       KmsMasterKeyId: !GetAtt GlobalLogoutTestQueueEncryptionKey.Arn
       KmsDataKeyReusePeriodSeconds: 300
       MessageRetentionPeriod: 259200
@@ -2843,7 +3101,10 @@ Resources:
     Condition: IsDevOrBuild
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-global-logout-test-dlq-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-global-logout-test-dlq-alarm
+        - !Sub ${Environment}-global-logout-test-dlq-alarm
       AlarmDescription: !Sub "${Environment} global logout test DLQ has a message.ACCOUNT: di-orchestration-${Environment}."
       ActionsEnabled: true
       AlarmActions:
@@ -2873,7 +3134,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-AuthenticationCallbackFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+        - !Sub ${Environment}-AuthenticationCallbackFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest
@@ -3111,7 +3375,10 @@ Resources:
   AuthenticationCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-authentication-callback-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-authentication-callback-lambda
+        - !Sub /aws/lambda/${Environment}-authentication-callback-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -3126,11 +3393,17 @@ Resources:
   AuthenticationCallbackFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-authentication-callback-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-request-errors
+        - !Sub ${Environment}-authentication-callback-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref AuthenticationCallbackFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-authentication-callback-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-authentication-callback-count
+            - !Sub ${Environment}-authentication-callback-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3144,10 +3417,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "20 or more errors have occurred in the ${Environment} authentication callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-authentication-callback-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-alarm
+        - !Sub ${Environment}-authentication-callback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-authentication-callback-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-count
+        - !Sub ${Environment}-authentication-callback-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3156,7 +3435,10 @@ Resources:
   AuthenticationCallbackFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-authentication-callback-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-error-rate-alarm
+        - !Sub ${Environment}-authentication-callback-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} authentication callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -3180,7 +3462,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthenticationCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+                    - !Sub ${Environment}-AuthenticationCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3192,7 +3477,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthenticationCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+                    - !Sub ${Environment}-AuthenticationCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3200,11 +3488,17 @@ Resources:
   AuthenticationCallbackAisErrorFailOpenMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-ais-error-fail-open
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ais-error-fail-open
+        - !Sub ${Environment}-ais-error-fail-open
       FilterPattern: '{$.AISException = 1 && $.AbortOnError = "false"}'
       LogGroupName: !Ref AuthenticationCallbackFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-ais-error-fail-open-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-ais-error-fail-open-count
+            - !Sub ${Environment}-ais-error-fail-open-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3218,10 +3512,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more Account Intervention Service errors have occurred in ${Environment}-AuthenticationCallbackFunction. Assuming no intervention and continuing with user journey. ACCOUNT: di-orchestration-${Environment}"
-      AlarmName: !Sub ${Environment}-authentication-callback-ais-error-fail-open-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-ais-error-fail-open-alarm
+        - !Sub ${Environment}-authentication-callback-ais-error-fail-open-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-ais-error-fail-open-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ais-error-fail-open-count
+        - !Sub ${Environment}-ais-error-fail-open-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3230,11 +3530,17 @@ Resources:
   AuthenticationCallbackAisErrorAbortMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-ais-error-abort
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ais-error-abort
+        - !Sub ${Environment}-ais-error-abort
       FilterPattern: '{$.AISException = 1 && $.AbortOnError = "true"}'
       LogGroupName: !Ref AuthenticationCallbackFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-ais-error-abort-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-ais-error-abort-count
+            - !Sub ${Environment}-ais-error-abort-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3248,10 +3554,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more Account Intervention Service errors have occurred in ${Environment}-AuthenticationCallbackFunction. Aborting user journey - P1 alarm. ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/l/cp/7Z2cm5rQ"
-      AlarmName: !Sub ${Environment}-authentication-callback-ais-error-abort-p1-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authentication-callback-ais-error-abort-p1-alarm
+        - !Sub ${Environment}-authentication-callback-ais-error-abort-p1-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-ais-error-abort-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ais-error-abort-count
+        - !Sub ${Environment}-ais-error-abort-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3266,7 +3578,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-JwksFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-JwksFunction
+        - !Sub ${Environment}-JwksFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest
@@ -3333,7 +3648,10 @@ Resources:
   JwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-jwks-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-jwks-lambda
+        - !Sub /aws/lambda/${Environment}-jwks-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -3348,11 +3666,17 @@ Resources:
   JwksFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-jwks-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-jwks-errors
+        - !Sub ${Environment}-jwks-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref JwksFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-jwks-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-jwks-error-count
+            - !Sub ${Environment}-jwks-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3366,10 +3690,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} jwks lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-jwks-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-jwks-alarm
+        - !Sub ${Environment}-jwks-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-jwks-error-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-jwks-error-count
+        - !Sub ${Environment}-jwks-error-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3378,7 +3708,10 @@ Resources:
   JwksFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-jwks-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-jwks-error-rate-alarm
+        - !Sub ${Environment}-jwks-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} jwks lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -3402,7 +3735,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-JwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-JwksFunction
+                    - !Sub ${Environment}-JwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3414,7 +3750,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-JwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-JwksFunction
+                    - !Sub ${Environment}-JwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3426,7 +3765,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-IpvJwksFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-IpvJwksFunction
+        - !Sub ${Environment}-IpvJwksFunction
       AutoPublishAlias: latest
       CodeUri: ./ipv-api/build/distributions/ipv-api.zip
       Handler: uk.gov.di.authentication.ipv.lambda.IpvJwksHandler::handleRequest
@@ -3474,7 +3816,10 @@ Resources:
   IpvJwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-ipv-jwks-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-ipv-jwks-lambda
+        - !Sub /aws/lambda/${Environment}-ipv-jwks-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -3489,18 +3834,27 @@ Resources:
   IpvJwksFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-ipv-jwks-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-jwks-errors
+        - !Sub ${Environment}-ipv-jwks-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref IpvJwksFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-ipv-jwks-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-ipv-jwks-error-count
+            - !Sub ${Environment}-ipv-jwks-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
   IpvJwksFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-ipv-jwks-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-jwks-error-rate-alarm
+        - !Sub ${Environment}-ipv-jwks-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} ipv jwks lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -3524,7 +3878,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvJwksFunction
+                    - !Sub ${Environment}-IpvJwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3536,7 +3893,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvJwksFunction
+                    - !Sub ${Environment}-IpvJwksFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3549,7 +3909,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-AuthorisationFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthorisationFunction
+        - !Sub ${Environment}-AuthorisationFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest
@@ -3750,7 +4113,10 @@ Resources:
   AuthorisationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-authorisation-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-authorisation-lambda
+        - !Sub /aws/lambda/${Environment}-authorisation-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -3765,11 +4131,17 @@ Resources:
   AuthorisationFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-authorisation-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authorisation-errors
+        - !Sub ${Environment}-authorisation-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref AuthorisationFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-authorisation-error-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-authorisation-error-count
+            - !Sub ${Environment}-authorisation-error-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3783,10 +4155,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} authorisation lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/PADNHwE"
-      AlarmName: !Sub ${Environment}-authorisation-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authorisation-alarm
+        - !Sub ${Environment}-authorisation-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-authorisation-error-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authorisation-error-count
+        - !Sub ${Environment}-authorisation-error-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3795,7 +4173,10 @@ Resources:
   AuthorisationFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-authorisation-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-authorisation-error-rate-alarm
+        - !Sub ${Environment}-authorisation-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} authorisation lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -3819,7 +4200,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthorisationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3831,7 +4215,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthorisationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -3845,7 +4232,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-UserInfoFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-UserInfoFunction
+        - !Sub ${Environment}-UserInfoFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest
@@ -3953,7 +4343,10 @@ Resources:
   UserInfoFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-userinfo-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-userinfo-lambda
+        - !Sub /aws/lambda/${Environment}-userinfo-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -3968,11 +4361,17 @@ Resources:
   UserInfoFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-userinfo-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-userinfo-request-errors
+        - !Sub ${Environment}-userinfo-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref UserInfoFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-userinfo-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-userinfo-count
+            - !Sub ${Environment}-userinfo-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -3986,10 +4385,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} userinfo lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-userinfo-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-userinfo-alarm
+        - !Sub ${Environment}-userinfo-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-userinfo-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-userinfo-count
+        - !Sub ${Environment}-userinfo-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -3998,7 +4403,10 @@ Resources:
   UserInfoFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-userinfo-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-userinfo-error-rate-alarm
+        - !Sub ${Environment}-userinfo-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} userinfo lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -4022,7 +4430,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-UserInfoFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-UserInfoFunction
+                    - !Sub ${Environment}-UserInfoFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4034,7 +4445,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-UserInfoFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-UserInfoFunction
+                    - !Sub ${Environment}-UserInfoFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4048,7 +4462,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-AuthCodeFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthCodeFunction
+        - !Sub ${Environment}-AuthCodeFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest
@@ -4143,7 +4560,10 @@ Resources:
   AuthCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-auth-code-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-auth-code-lambda
+        - !Sub /aws/lambda/${Environment}-auth-code-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -4158,11 +4578,17 @@ Resources:
   AuthCodeFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-auth-code-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-auth-code-errors
+        - !Sub ${Environment}-auth-code-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref AuthCodeFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-auth-code-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-auth-code-count
+            - !Sub ${Environment}-auth-code-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -4176,10 +4602,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} auth code lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-auth-code-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-auth-code-alarm
+        - !Sub ${Environment}-auth-code-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-auth-code-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-auth-code-count
+        - !Sub ${Environment}-auth-code-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -4188,7 +4620,10 @@ Resources:
   AuthCodeFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-auth-code-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-auth-code-error-rate-alarm
+        - !Sub ${Environment}-auth-code-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} auth code lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -4212,7 +4647,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthCodeFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthCodeFunction
+                    - !Sub ${Environment}-AuthCodeFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4224,7 +4662,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthCodeFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthCodeFunction
+                    - !Sub ${Environment}-AuthCodeFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4410,7 +4851,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-ClientRegistrationFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ClientRegistrationFunction
+        - !Sub ${Environment}-ClientRegistrationFunction
       AutoPublishAlias: latest
       CodeUri: ./client-registry-api/build/distributions/client-registry-api.zip
       Handler: uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler::handleRequest
@@ -4490,7 +4934,10 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: IsNotProduction
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-register-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-register-lambda
+        - !Sub /aws/lambda/${Environment}-register-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -4506,11 +4953,17 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Condition: IsNotProduction
     Properties:
-      FilterName: !Sub ${Environment}-register-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-register-request-errors
+        - !Sub ${Environment}-register-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref ClientRegistrationFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-register-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-register-count
+            - !Sub ${Environment}-register-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -4522,10 +4975,16 @@ Resources:
       AlarmActions:
         - !Ref SlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} register lambda.ACCOUNT: di-orchestration-${Environment}"
-      AlarmName: !Sub ${Environment}-register-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-register-alarm
+        - !Sub ${Environment}-register-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-register-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-register-count
+        - !Sub ${Environment}-register-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -4535,7 +4994,10 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotProduction
     Properties:
-      AlarmName: !Sub ${Environment}-register-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-register-error-rate-alarm
+        - !Sub ${Environment}-register-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} register lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: true
       AlarmActions:
@@ -4556,7 +5018,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-ClientRegistrationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-ClientRegistrationFunction
+                    - !Sub ${Environment}-ClientRegistrationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4568,7 +5033,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-ClientRegistrationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-ClientRegistrationFunction
+                    - !Sub ${Environment}-ClientRegistrationFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4582,7 +5050,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-IpvCallbackFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-IpvCallbackFunction
+        - !Sub ${Environment}-IpvCallbackFunction
       AutoPublishAlias: latest
       CodeUri: ./ipv-api/build/distributions/ipv-api.zip
       Handler: uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest
@@ -4810,7 +5281,10 @@ Resources:
   IpvCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-ipv-callback-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-ipv-callback-lambda
+        - !Sub /aws/lambda/${Environment}-ipv-callback-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -4825,11 +5299,17 @@ Resources:
   IpvCallbackFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-ipv-callback-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-callback-request-errors
+        - !Sub ${Environment}-ipv-callback-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref IpvCallbackFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-ipv-callback-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-ipv-callback-count
+            - !Sub ${Environment}-ipv-callback-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -4843,10 +5323,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "20 or more errors have occurred in the ${Environment} ipv-callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-ipv-callback-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-callback-alarm
+        - !Sub ${Environment}-ipv-callback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-ipv-callback-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-callback-count
+        - !Sub ${Environment}-ipv-callback-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -4855,7 +5341,10 @@ Resources:
   IpvCallbackFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-ipv-callback-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ipv-callback-error-rate-alarm
+        - !Sub ${Environment}-ipv-callback-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} ipv-callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -4879,7 +5368,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvCallbackFunction
+                    - !Sub ${Environment}-IpvCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4891,7 +5383,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvCallbackFunction
+                    - !Sub ${Environment}-IpvCallbackFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -4904,7 +5399,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-ManualUpdateClientRegistryFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ManualUpdateClientRegistryFunction
+        - !Sub ${Environment}-ManualUpdateClientRegistryFunction
       AutoPublishAlias: latest
       CodeUri: ./client-registry-api/build/distributions/client-registry-api.zip
       Handler: uk.gov.di.authentication.clientregistry.lambda.ManualUpdateClientRegistryHandler::handleRequest
@@ -4957,7 +5455,10 @@ Resources:
   ManualUpdateClientRegistryFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-manual-update-client-registry-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-manual-update-client-registry-lambda
+        - !Sub /aws/lambda/${Environment}-manual-update-client-registry-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -4976,7 +5477,10 @@ Resources:
               - lambda:InvokeFunction
               - lambda:GetFunction
             Resource:
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Environment}-ManualUpdateClientRegistryFunction
+              - !If
+                - UseSubEnvironment
+                - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${SubEnvironment}-ManualUpdateClientRegistryFunction
+                - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Environment}-ManualUpdateClientRegistryFunction
 
   ManualUpdateClientRegistryFunctionInvokeRole:
     Type: AWS::IAM::Role
@@ -5019,7 +5523,10 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: UseSpotStub
     Properties:
-      QueueName: !Sub ${Environment}-stub-spot-request-queue
+      QueueName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-stub-spot-request-queue
+        - !Sub ${Environment}-stub-spot-request-queue
       MaximumMessageSize: 256000
       MessageRetentionPeriod: 1209600
       ReceiveMessageWaitTimeSeconds: 10
@@ -5035,7 +5542,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-SpotResponseFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-SpotResponseFunction
+        - !Sub ${Environment}-SpotResponseFunction
       AutoPublishAlias: latest
       CodeUri: ./ipv-api/build/distributions/ipv-api.zip
       Handler: uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest
@@ -5119,7 +5629,10 @@ Resources:
   SpotResponseFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-spot-response-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-spot-response-lambda
+        - !Sub /aws/lambda/${Environment}-spot-response-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -5134,11 +5647,17 @@ Resources:
   SpotResponseFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-spot-response-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-spot-response-request-errors
+        - !Sub ${Environment}-spot-response-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref SpotResponseFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-spot-response-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-spot-response-count
+            - !Sub ${Environment}-spot-response-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -5152,10 +5671,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} spot response lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-spot-response-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-spot-response-alarm
+        - !Sub ${Environment}-spot-response-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-spot-response-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-spot-response-count
+        - !Sub ${Environment}-spot-response-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -5164,7 +5689,10 @@ Resources:
   SpotResponseFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-spot-response-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-spot-response-error-rate-alarm
+        - !Sub ${Environment}-spot-response-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} spot response lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -5188,7 +5716,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-SpotResponseFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-SpotResponseFunction
+                    - !Sub ${Environment}-SpotResponseFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -5200,7 +5731,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-SpotResponseFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-SpotResponseFunction
+                    - !Sub ${Environment}-SpotResponseFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -5211,7 +5745,10 @@ Resources:
   BackChannelLogoutQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${Environment}-BackChannelLogoutQueue
+      QueueName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-BackChannelLogoutQueue
+        - !Sub ${Environment}-BackChannelLogoutQueue
       MaximumMessageSize: 2048
       MessageRetentionPeriod: 1209600
       ReceiveMessageWaitTimeSeconds: 10
@@ -5224,7 +5761,10 @@ Resources:
   BackChannelLogoutDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${Environment}-BackChannelLogoutDlq
+      QueueName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-BackChannelLogoutDlq
+        - !Sub ${Environment}-BackChannelLogoutDlq
       KmsMasterKeyId: !GetAtt BackChannelLogoutQueueEncryptionKey.Arn
       KmsDataKeyReusePeriodSeconds: 300
       MessageRetentionPeriod: 259200
@@ -5242,7 +5782,10 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotIntegration
     Properties:
-      AlarmName: !Sub ${Environment}-backchannel-logout-dlq-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-backchannel-logout-dlq-alarm
+        - !Sub ${Environment}-backchannel-logout-dlq-alarm
       AlarmDescription: !Sub "${Environment} backchannel logout DLQ has 5 or more messages.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/spaces/Orch/pages/5292228639/Runbook+Backchannel+Logout+DLQ+Alarm"
       ActionsEnabled: true
       AlarmActions:
@@ -5272,7 +5815,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     Properties:
-      FunctionName: !Sub ${Environment}-StorageTokenJwkFunction
+      FunctionName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-StorageTokenJwkFunction
+        - !Sub ${Environment}-StorageTokenJwkFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.StorageTokenJwkHandler::handleRequest
@@ -5325,7 +5871,10 @@ Resources:
   StorageTokenJwkFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${Environment}-storage-token-jwk-lambda
+      LogGroupName: !If
+        - UseSubEnvironment
+        - !Sub /aws/lambda/${SubEnvironment}-storage-token-jwk-lambda
+        - !Sub /aws/lambda/${Environment}-storage-token-jwk-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 30
 
@@ -5340,11 +5889,17 @@ Resources:
   StorageTokenJwkFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-storage-token-jwk-request-errors
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-storage-token-jwk-request-errors
+        - !Sub ${Environment}-storage-token-jwk-request-errors
       FilterPattern: '{($.level = "ERROR")}'
       LogGroupName: !Ref StorageTokenJwkFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-storage-token-jwk-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-storage-token-jwk-count
+            - !Sub ${Environment}-storage-token-jwk-count
           MetricNamespace: LambdaErrorsNamespace
           MetricValue: 1
 
@@ -5358,10 +5913,16 @@ Resources:
           - !Ref SlackEvents
           - !Ref OrchProdSlackEvents
       AlarmDescription: !Sub "10 or more errors have occurred in the ${Environment} storage-token-jwk lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
-      AlarmName: !Sub ${Environment}-storage-token-jwk-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-storage-token-jwk-alarm
+        - !Sub ${Environment}-storage-token-jwk-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: !Sub ${Environment}-storage-token-jwk-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-storage-token-jwk-count
+        - !Sub ${Environment}-storage-token-jwk-count
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
@@ -5370,7 +5931,10 @@ Resources:
   StorageTokenJwkFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-storage-token-jwk-error-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-storage-token-jwk-error-rate-alarm
+        - !Sub ${Environment}-storage-token-jwk-error-rate-alarm
       AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} storage-token-jwk lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       ActionsEnabled: true
       AlarmActions:
@@ -5394,7 +5958,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-StorageTokenJwkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-StorageTokenJwkFunction
+                    - !Sub ${Environment}-StorageTokenJwkFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -5406,7 +5973,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-StorageTokenJwkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-StorageTokenJwkFunction
+                    - !Sub ${Environment}-StorageTokenJwkFunction
             Period: 60
             Stat: Sum
             Unit: Count
@@ -6199,7 +6769,10 @@ Resources:
               - ssm:GetParameter
               - ssm:GetParameters
             Resource:
-              - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-ipv-capacity
+              - !If
+                - UseSubEnvironment
+                - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${SubEnvironment}-ipv-capacity
+                - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${Environment}-ipv-capacity
           - Sid: AllowDecryptOfParameters
             Effect: Allow
             Action: kms:Decrypt
@@ -6487,7 +7060,10 @@ Resources:
         Statement:
           - Effect: Allow
             Action: lambda:InvokeFunction
-            Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction:latest
+            Resource: !If
+              - UseSubEnvironment
+              - !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${SubEnvironment}-FetchJwksFunction:latest
+              - !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction:latest
 
   JwksCacheTableReadWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -6981,7 +7557,10 @@ Resources:
   OrchAuthCodeTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Orch-Auth-Code
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Orch-Auth-Code
+        - !Sub ${Environment}-Orch-Auth-Code
       AttributeDefinitions:
         - AttributeName: AuthCode
           AttributeType: S
@@ -7076,7 +7655,10 @@ Resources:
   ClientRateLimitTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Client-Rate-Limit
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Client-Rate-Limit
+        - !Sub ${Environment}-Client-Rate-Limit
       AttributeDefinitions:
         - AttributeName: ClientId
           AttributeType: S
@@ -7105,21 +7687,33 @@ Resources:
   ClientRateLimitMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterName: !Sub ${Environment}-client-rate-limit-filter
+      FilterName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-client-rate-limit-filter
+        - !Sub ${Environment}-client-rate-limit-filter
       FilterPattern: '{($.message = "Client with ID * has exceeded rate limit. Current count: *. Limit *")}'
       LogGroupName: !Ref AuthorisationFunctionLogGroup
       MetricTransformations:
-        - MetricName: !Sub ${Environment}-client-rate-limit-count
+        - MetricName: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-client-rate-limit-count
+            - !Sub ${Environment}-client-rate-limit-count
           MetricNamespace: ClientRateLimitCount
           MetricValue: 1
 
   ClientRateLimitAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-client-rate-limit-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-client-rate-limit-alarm
+        - !Sub ${Environment}-client-rate-limit-alarm
       AlarmDescription: !Sub "1 or more clients have hit their rate limit for ${Environment}.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/h4DKTQE"
       Namespace: ClientRateLimitCount
-      MetricName: !Sub ${Environment}-client-rate-limit-count
+      MetricName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-client-rate-limit-count
+        - !Sub ${Environment}-client-rate-limit-count
       Statistic: Sum
       Period: 60
       EvaluationPeriods: 1
@@ -7257,7 +7851,10 @@ Resources:
   CrossBrowserTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Cross-Browser
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Cross-Browser
+        - !Sub ${Environment}-Cross-Browser
       AttributeDefinitions:
         - AttributeName: State
           AttributeType: S
@@ -7389,7 +7986,10 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      TableName: !Sub ${Environment}-Access-Token
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Access-Token
+        - !Sub ${Environment}-Access-Token
       AttributeDefinitions:
         - AttributeName: ClientAndRpPairwiseId
           AttributeType: S
@@ -7508,7 +8108,10 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      TableName: !Sub ${Environment}-Refresh-Token
+      TableName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-Refresh-Token
+        - !Sub ${Environment}-Refresh-Token
       AttributeDefinitions:
         - AttributeName: JwtId
           AttributeType: S
@@ -7579,7 +8182,10 @@ Resources:
   OrchIPVTokenSigningKmsKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Sub "alias/${Environment}-orch-ipv-token-auth-kms-key-alias"
+      AliasName: !If
+        - UseSubEnvironment
+        - !Sub "alias/${SubEnvironment}-orch-ipv-token-auth-kms-key-alias"
+        - !Sub "alias/${Environment}-orch-ipv-token-auth-kms-key-alias"
       TargetKeyId: !Ref OrchIPVTokenSigningKmsKey
 
   OrchIPVTokenSigningKmsKey:
@@ -7611,12 +8217,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-FetchJwksFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-FetchJwksFunction
+            - !Sub ${Environment}-FetchJwksFunction
 
   FetchJwksErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-FetchJwks-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-FetchJwks-error-anomaly-alarm
+        - !Sub ${Environment}-FetchJwks-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} FetchJwks lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7635,7 +8247,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-FetchJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-FetchJwksFunction
+                    - !Sub ${Environment}-FetchJwksFunction
             Period: 60
             Stat: Average
 
@@ -7651,12 +8266,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-OpenIdConfigurationFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-OpenIdConfigurationFunction
+            - !Sub ${Environment}-OpenIdConfigurationFunction
 
   OpenIdConfigurationErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-OpenIdConfiguration-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-OpenIdConfiguration-error-anomaly-alarm
+        - !Sub ${Environment}-OpenIdConfiguration-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} OpenIdConfiguration lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7675,7 +8296,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-OpenIdConfigurationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-OpenIdConfigurationFunction
+                    - !Sub ${Environment}-OpenIdConfigurationFunction
             Period: 60
             Stat: Average
 
@@ -7691,12 +8315,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-TrustmarkFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-TrustmarkFunction
+            - !Sub ${Environment}-TrustmarkFunction
 
   TrustmarkFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-trustmark-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-trustmark-error-anomaly-alarm
+        - !Sub ${Environment}-trustmark-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7715,7 +8345,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TrustmarkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TrustmarkFunction
+                    - !Sub ${Environment}-TrustmarkFunction
             Period: 60
             Stat: Average
 
@@ -7730,12 +8363,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-DocAppCallbackFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-DocAppCallbackFunction
+            - !Sub ${Environment}-DocAppCallbackFunction
 
   DocAppCallbackErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-DocAppCallback-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-DocAppCallback-error-anomaly-alarm
+        - !Sub ${Environment}-DocAppCallback-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} DocAppCallback lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7754,7 +8393,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-DocAppCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-DocAppCallbackFunction
+                    - !Sub ${Environment}-DocAppCallbackFunction
             Period: 60
             Stat: Average
   #endregion
@@ -7768,12 +8410,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-TokenFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-TokenFunction
+            - !Sub ${Environment}-TokenFunction
 
   TokenFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-TokenFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-TokenFunction-error-anomaly-alarm
+        - !Sub ${Environment}-TokenFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} TokenFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7792,7 +8440,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-TokenFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-TokenFunction
+                    - !Sub ${Environment}-TokenFunction
             Period: 60
             Stat: Average
   #endregion
@@ -7806,12 +8457,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-LogoutFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-LogoutFunction
+            - !Sub ${Environment}-LogoutFunction
 
   LogoutFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-LogoutFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-LogoutFunction-error-anomaly-alarm
+        - !Sub ${Environment}-LogoutFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} LogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7830,7 +8487,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-LogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-LogoutFunction
+                    - !Sub ${Environment}-LogoutFunction
             Period: 60
             Stat: Average
   #endregion
@@ -7844,12 +8504,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-AuthenticationCallbackFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+            - !Sub ${Environment}-AuthenticationCallbackFunction
 
   AuthenticationCallbackFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-AuthenticationCallbackFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthenticationCallbackFunction-error-anomaly-alarm
+        - !Sub ${Environment}-AuthenticationCallbackFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthenticationCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7868,7 +8534,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthenticationCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+                    - !Sub ${Environment}-AuthenticationCallbackFunction
             Period: 60
             Stat: Average
 
@@ -7883,12 +8552,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-JwksFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-JwksFunction
+            - !Sub ${Environment}-JwksFunction
 
   JwksFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-JwksFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-JwksFunction-error-anomaly-alarm
+        - !Sub ${Environment}-JwksFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} JwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7907,7 +8582,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-JwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-JwksFunction
+                    - !Sub ${Environment}-JwksFunction
             Period: 60
             Stat: Average
 
@@ -7922,12 +8600,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-AuthorisationFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-AuthorisationFunction
+            - !Sub ${Environment}-AuthorisationFunction
 
   AuthorisationFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-AuthorisationFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthorisationFunction-error-anomaly-alarm
+        - !Sub ${Environment}-AuthorisationFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthorisationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7946,7 +8630,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthorisationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
             Period: 60
             Stat: Average
 
@@ -7961,12 +8648,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-UserInfoFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-UserInfoFunction
+            - !Sub ${Environment}-UserInfoFunction
 
   UserInfoFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-UserInfoFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-UserInfoFunction-error-anomaly-alarm
+        - !Sub ${Environment}-UserInfoFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UserInfoFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -7985,7 +8678,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-UserInfoFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-UserInfoFunction
+                    - !Sub ${Environment}-UserInfoFunction
             Period: 60
             Stat: Average
 
@@ -8000,12 +8696,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-AuthCodeFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-AuthCodeFunction
+            - !Sub ${Environment}-AuthCodeFunction
 
   AuthCodeFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-AuthCodeFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-AuthCodeFunction-error-anomaly-alarm
+        - !Sub ${Environment}-AuthCodeFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthCodeFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8024,7 +8726,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-AuthCodeFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthCodeFunction
+                    - !Sub ${Environment}-AuthCodeFunction
             Period: 60
             Stat: Average
 
@@ -8081,13 +8786,19 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-ClientRegistrationFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-ClientRegistrationFunction
+            - !Sub ${Environment}-ClientRegistrationFunction
 
   ClientRegistrationFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotProduction
     Properties:
-      AlarmName: !Sub ${Environment}-ClientRegistrationFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-ClientRegistrationFunction-error-anomaly-alarm
+        - !Sub ${Environment}-ClientRegistrationFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} ClientRegistrationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8106,7 +8817,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-ClientRegistrationFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-ClientRegistrationFunction
+                    - !Sub ${Environment}-ClientRegistrationFunction
             Period: 60
             Stat: Average
 
@@ -8121,12 +8835,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-IpvCallbackFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-IpvCallbackFunction
+            - !Sub ${Environment}-IpvCallbackFunction
 
   IpvCallbackFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-IpvCallbackFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-IpvCallbackFunction-error-anomaly-alarm
+        - !Sub ${Environment}-IpvCallbackFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8145,7 +8865,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvCallbackFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvCallbackFunction
+                    - !Sub ${Environment}-IpvCallbackFunction
             Period: 60
             Stat: Average
 
@@ -8166,7 +8889,10 @@ Resources:
   SpotResponseFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-SpotResponseFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-SpotResponseFunction-error-anomaly-alarm
+        - !Sub ${Environment}-SpotResponseFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} SpotResponseFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8185,7 +8911,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-SpotResponseFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-SpotResponseFunction
+                    - !Sub ${Environment}-SpotResponseFunction
             Period: 60
             Stat: Average
 
@@ -8200,12 +8929,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-StorageTokenJwkFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-StorageTokenJwkFunction
+            - !Sub ${Environment}-StorageTokenJwkFunction
 
   StorageTokenJwkFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-StorageTokenJwkFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-StorageTokenJwkFunction-error-anomaly-alarm
+        - !Sub ${Environment}-StorageTokenJwkFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} StorageTokenJwkFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8224,7 +8959,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-StorageTokenJwkFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-StorageTokenJwkFunction
+                    - !Sub ${Environment}-StorageTokenJwkFunction
             Period: 60
             Stat: Average
   #endregion
@@ -8238,12 +8976,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-IpvJwksFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-IpvJwksFunction
+            - !Sub ${Environment}-IpvJwksFunction
 
   IpvJwksFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-IpvJwksFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-IpvJwksFunction-error-anomaly-alarm
+        - !Sub ${Environment}-IpvJwksFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8262,7 +9006,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-IpvJwksFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IpvJwksFunction
+                    - !Sub ${Environment}-IpvJwksFunction
             Period: 60
             Stat: Average
   #endregion
@@ -8276,12 +9023,18 @@ Resources:
       Stat: Average
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Environment}-GlobalLogoutFunction
+          Value: !If
+            - UseSubEnvironment
+            - !Sub ${SubEnvironment}-GlobalLogoutFunction
+            - !Sub ${Environment}-GlobalLogoutFunction
 
   GlobalLogoutFunctionErrorAnomalyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub ${Environment}-GlobalLogoutFunction-error-anomaly-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-GlobalLogoutFunction-error-anomaly-alarm
+        - !Sub ${Environment}-GlobalLogoutFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} GlobalLogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
@@ -8300,7 +9053,10 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${Environment}-GlobalLogoutFunction
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-GlobalLogoutFunction
+                    - !Sub ${Environment}-GlobalLogoutFunction
             Period: 60
             Stat: Average
   #endregion
@@ -8397,7 +9153,10 @@ Resources:
       AlarmActions:
         - !Ref SlackEvents
       AlarmDescription: !Sub "Auth journey completion rate has dropped below 80% in ${Environment}.ACCOUNT: di-orchestration-${Environment}."
-      AlarmName: !Sub ${Environment}-auth-journey-completion-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-auth-journey-completion-rate-alarm
+        - !Sub ${Environment}-auth-journey-completion-rate-alarm
       ComparisonOperator: LessThanOrEqualToThreshold
       EvaluationPeriods: 1
       Threshold: 80
@@ -8416,9 +9175,15 @@ Resources:
                 - Name: journeyType
                   Value: auth
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-AuthenticationCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+                    - !Sub ${Environment}-AuthenticationCallbackFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-AuthenticationCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthenticationCallbackFunction
+                    - !Sub ${Environment}-AuthenticationCallbackFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300
@@ -8435,9 +9200,15 @@ Resources:
                 - Name: isIdentityJourney
                   Value: false
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300
@@ -8451,7 +9222,10 @@ Resources:
       AlarmActions:
         - !Ref SlackEvents
       AlarmDescription: !Sub "Identity journey completion rate has dropped below 50% in ${Environment}.ACCOUNT: di-orchestration-${Environment}."
-      AlarmName: !Sub ${Environment}-identity-journey-completion-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-identity-journey-completion-rate-alarm
+        - !Sub ${Environment}-identity-journey-completion-rate-alarm
       ComparisonOperator: LessThanOrEqualToThreshold
       EvaluationPeriods: 1
       Threshold: 50
@@ -8470,9 +9244,15 @@ Resources:
                 - Name: journeyType
                   Value: identity
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-IPVCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IPVCallbackFunction
+                    - !Sub ${Environment}-IPVCallbackFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-IPVCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-IPVCallbackFunction
+                    - !Sub ${Environment}-IPVCallbackFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300
@@ -8489,9 +9269,15 @@ Resources:
                 - Name: isIdentityJourney
                   Value: true
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300
@@ -8505,7 +9291,10 @@ Resources:
       AlarmActions:
         - !Ref SlackEvents
       AlarmDescription: !Sub "Doc app journey completion rate has dropped below 30% in ${Environment}.ACCOUNT: di-orchestration-${Environment}."
-      AlarmName: !Sub ${Environment}-docapp-journey-completion-rate-alarm
+      AlarmName: !If
+        - UseSubEnvironment
+        - !Sub ${SubEnvironment}-docapp-journey-completion-rate-alarm
+        - !Sub ${Environment}-docapp-journey-completion-rate-alarm
       ComparisonOperator: LessThanOrEqualToThreshold
       EvaluationPeriods: 1
       Threshold: 30
@@ -8524,9 +9313,15 @@ Resources:
                 - Name: journeyType
                   Value: docapp
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-DocAppCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-DocAppCallbackFunction
+                    - !Sub ${Environment}-DocAppCallbackFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-DocAppCallbackFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-DocAppCallbackFunction
+                    - !Sub ${Environment}-DocAppCallbackFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300
@@ -8543,9 +9338,15 @@ Resources:
                 - Name: isIdentityJourney
                   Value: false
                 - Name: LogGroup
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceName
-                  Value: !Sub "${Environment}-AuthorisationFunction"
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Sub ${SubEnvironment}-AuthorisationFunction
+                    - !Sub ${Environment}-AuthorisationFunction
                 - Name: ServiceType
                   Value: "AWS::Lambda::Function"
             Period: 300

--- a/template.yaml
+++ b/template.yaml
@@ -3805,12 +3805,16 @@ Resources:
                   ]
           ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR:
             !If [AisAbortOnError, true, false]
-          STORAGE_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              storageTokenKeyArn,
-            ]
+          STORAGE_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - storageTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - storageTokenKeyArn
           SEND_STORAGE_TOKEN_TO_IPV_ENABLED: true
           JWK_CACHE_EXPIRATION_IN_SECONDS: 300
           SINGLE_FACTOR_ACCOUNT_DELETION_ENABLED: !If
@@ -6708,12 +6712,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          STORAGE_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              storageTokenKeyArn,
-            ]
+          STORAGE_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - storageTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - storageTokenKeyArn
       Policies:
         - !Ref StorageTokenSigningKmsAccessPolicy
       Tags:
@@ -7756,10 +7764,18 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  storageTokenKeyArn,
+              - !If [
+                  UseSubEnvironment,
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    storageTokenKeyArn,
+                  ],
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    storageTokenKeyArn,
+                  ],
                 ]
 
   IpvTokenSigningKmsAccessPolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -3225,12 +3225,16 @@ Resources:
             - "https://authstub.oidc.authdev3.dev.account.gov.uk/"
             - !Sub
               - https://${AuthExternalApiId}-${VpcId}.execute-api.eu-west-2.amazonaws.com/${AuthEnvironment}/
-              - AuthExternalApiId:
-                  !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    authExternalApiId,
-                  ]
+              - AuthExternalApiId: !If
+                  - UseSubEnvironment
+                  - !FindInMap
+                    - EnvironmentConfiguration
+                    - !Ref SubEnvironment
+                    - authExternalApiId
+                  - !FindInMap
+                    - EnvironmentConfiguration
+                    - !Ref Environment
+                    - authExternalApiId
                 VpcId: !ImportValue vpc-ExecuteApiGatewayEndpointId
                 AuthEnvironment:
                   !FindInMap [

--- a/template.yaml
+++ b/template.yaml
@@ -2413,12 +2413,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - docAppClientId
-          DOC_APP_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppSigningKeyArn,
-            ]
+          DOC_APP_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppSigningKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppSigningKeyArn
           DOC_APP_BACKEND_URI: !If
             - UseSubEnvironment
             - !FindInMap
@@ -4155,12 +4159,16 @@ Resources:
               - EnvironmentConfiguration
               - !Ref Environment
               - idTokenKeyRsaArn
-          DOC_APP_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppSigningKeyArn,
-            ]
+          DOC_APP_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppSigningKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppSigningKeyArn
       Policies:
         - !Ref IdTokenKmsAccessPolicy
         - !Ref IdTokenKmsRsaAccessPolicy
@@ -4581,12 +4589,16 @@ Resources:
                   ],
                 ]
           DOC_APP_NEW_AUD_CLAIM_ENABLED: true
-          DOC_APP_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              docAppSigningKeyArn,
-            ]
+          DOC_APP_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - docAppSigningKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - docAppSigningKeyArn
           DOMAIN_NAME: !If
             - UseSubEnvironment
             - !FindInMap
@@ -7813,12 +7825,16 @@ Resources:
             Action:
               - kms:Sign
               - kms:GetPublicKey
-            Resource:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                docAppSigningKeyArn,
-              ]
+            Resource: !If
+              - UseSubEnvironment
+              - !FindInMap
+                - EnvironmentConfiguration
+                - !Ref SubEnvironment
+                - docAppSigningKeyArn
+              - !FindInMap
+                - EnvironmentConfiguration
+                - !Ref Environment
+                - docAppSigningKeyArn
 
   StorageTokenSigningKmsAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -2185,12 +2185,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -2702,12 +2706,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -2971,12 +2979,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4075,12 +4087,16 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4524,12 +4540,16 @@ Resources:
                   - !Ref Environment
                   - authEnvironment
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
@@ -4835,12 +4855,16 @@ Resources:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
           IDENTITY_ENABLED: true # Note that this sets whether the ipv api is turned on or not, it is not an indicator of whether a full identity journey can be completed
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
+          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - idTokenKeyArn
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - idTokenKeyArn
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -7646,11 +7670,19 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource:
-              - !FindInMap [
+              !If [
+                UseSubEnvironment,
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref SubEnvironment,
+                  idTokenKeyArn,
+                ],
+                !FindInMap [
                   EnvironmentConfiguration,
                   !Ref Environment,
                   idTokenKeyArn,
-                ]
+                ],
+              ]
 
   IdTokenKmsRsaAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -1640,8 +1640,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   OpenIdConfigurationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1814,8 +1822,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   TrustmarkFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2277,8 +2293,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   DocAppCallbackFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -2492,8 +2516,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   TokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2731,8 +2763,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   LogoutFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3369,8 +3409,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   AuthenticationCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3642,8 +3690,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   JwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3810,8 +3866,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   IpvJwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4107,8 +4171,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   AuthorisationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4337,8 +4409,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   UserInfoFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4554,8 +4634,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   AuthCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4753,8 +4841,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   UpdateClientConfigFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4927,8 +5023,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   ClientRegistrationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -5275,8 +5379,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   IpvCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -5865,8 +5977,16 @@ Resources:
               !Ref Environment,
               authAccountId,
             ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+          ApiId: !If
+            - UseSubEnvironment
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref SubEnvironment
+              - authApiId
+            - !FindInMap
+              - EnvironmentConfiguration
+              - !Ref Environment
+              - authApiId
 
   StorageTokenJwkFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/template.yaml
+++ b/template.yaml
@@ -2223,12 +2223,16 @@ Resources:
       FunctionName: !Ref BackChannelLogoutRequestFunction.Alias
       Action: lambda:InvokeFunction
       Principal: sqs.amazonaws.com
-      SourceArn:
-        !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          backchannelLogoutQueueArn,
-        ]
+      SourceArn: !If
+        - UseSubEnvironment
+        - !FindInMap
+          - EnvironmentConfiguration
+          - !Ref SubEnvironment
+          - backchannelLogoutQueueArn
+        - !FindInMap
+          - EnvironmentConfiguration
+          - !Ref Environment
+          - backchannelLogoutQueueArn
 
   BackChannelLogoutRequestFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
### Wider context of change

We want to create sub environments in orch for dev. This is converting the current setup to adapt to sub environments

### What’s changed

Template file checks whether it should use SubEnvironment or Environment. There are a few places I've decided don't need different values for dev and a few assumptions I've made.

#### Assumption

1. Only dev will have sub envs

#### Values that are different between dev sub envs

- serviceDomain
- idTokenKeyArn
- idTokenKeyRsaArn
- storageTokenKeyArn
- orchToAuthKeyArn
- backchannelLogoutQueueArn
- docAppBackendUri
- docAppDomain
- docAppCriDataV2Endpoint
- docAppAud
- docAppAuthorisationUrl
- docAppClientId
- docAppCredentialTableKeyArn
- docAppSigningKeyArn
- clientRegistryTableKeyArn
- orchToAuthTokenSigningKeyAlias
- spotRequestQueueKmsArn
- authStubEnabled

#### Values that are the same for dev sub envs

- dynatraceSecretArn
- dynatraceLayerArn
- authEnvironment
- authApiId
- authExternalApiId
- authAccountId
- newauthAccountId
- txmaEventEncryptionKeyArn
- defaultProvisionedConcurrency
- aisUriSecretId
- RedisParametersAccessPolicy (and it's resources)
- Slack setup
- UpdateClientConfig

#### Things to consider for the future

1. What happens when auth stub is up and running? I assume we'll need unique instances of the stub for each sub env and I don't want to have to have nested `!If` statements for `UseAuthStub` and `UseSubEnvironment` if I can avoid it
2. Is it an issue if multiple sub environments point to authdev3? 
3. Is it an issue if multiple sub environments point to the same ipv stub?

### Manual testing



### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
