### PR TITLE
BAU: make generic OAuth service

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
@@ -27,6 +27,7 @@ public final class Constants {
     public static final URI TEST_CALLBACK_URI = URI.create("https://oidc.example.com/callback");
     public static final String TEST_SIGNING_KEY_ALIAS = "alias/oauth-signing-key";
     public static final String TEST_PRIVATE_KEY_JWT_AUDIENCE = TEST_TOKEN_URI.toString();
+    public static final String TEST_STATE_PREFIX = "state::";
     public static final Instant FIXED_TIMESTAMP = Instant.parse("2021-09-01T22:10:00.012Z");
     public static final Clock FIXED_CLOCK = fixed(FIXED_TIMESTAMP, ZoneId.of("UTC"));
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
@@ -1,14 +1,32 @@
 package uk.gov.di.orchestration.sharedtest.helper;
 
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.id.State;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static java.time.Clock.fixed;
 
 public final class Constants {
     private Constants() {}
 
     public static final State STATE = new State();
+    public static final AuthorizationCode AUTHORIZATION_CODE = new AuthorizationCode();
     public static final String ENVIRONMENT = "test";
     public static final String TEST_CLIENT_ID = "test-client-id";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
     public static final String CLIENT_NAME = "test-client";
+    public static final String TEST_BACKEND_URI = "https://api.example.com/oauth";
+    public static final URI TEST_AUTHORIZE_URI = URI.create(TEST_BACKEND_URI + "/authorize");
+    public static final URI TEST_TOKEN_URI = URI.create(TEST_BACKEND_URI + "/token");
+    public static final URI TEST_USERINFO_URI = URI.create(TEST_BACKEND_URI + "/token");
+    public static final URI TEST_CALLBACK_URI = URI.create("https://oidc.example.com/callback");
+    public static final String TEST_SIGNING_KEY_ALIAS = "alias/oauth-signing-key";
+    public static final String TEST_PRIVATE_KEY_JWT_AUDIENCE = TEST_TOKEN_URI.toString();
+    public static final Instant FIXED_TIMESTAMP = Instant.parse("2021-09-01T22:10:00.012Z");
+    public static final Clock FIXED_CLOCK = fixed(FIXED_TIMESTAMP, ZoneId.of("UTC"));
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
@@ -9,4 +9,5 @@ public record OAuthConfiguration(
         URI userInfoURI,
         URI redirectURI,
         String signingKeyAlias,
-        String privateKeyJwtAudience) {}
+        String privateKeyJwtAudience,
+        String statePrefix) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
@@ -1,5 +1,8 @@
 package uk.gov.di.orchestration.shared.entity;
 
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
 import java.net.URI;
 
 public record OAuthConfiguration(
@@ -10,4 +13,20 @@ public record OAuthConfiguration(
         URI redirectURI,
         String signingKeyAlias,
         String privateKeyJwtAudience,
-        String statePrefix) {}
+        String statePrefix) {
+    public static final String IPV_STATE_STORAGE_PREFIX = "state:";
+
+    public static OAuthConfiguration getIPVConfig(ConfigurationService configurationService) {
+        return new OAuthConfiguration(
+                configurationService.getIPVAuthorisationClientId(),
+                configurationService.getIPVAuthorisationURI(),
+                ConstructUriHelper.buildURI(
+                        configurationService.getIPVBackendURI().toString(), "token"),
+                ConstructUriHelper.buildURI(
+                        configurationService.getIPVBackendURI().toString(), "user-identity"),
+                configurationService.getIPVAuthorisationCallbackURI(),
+                configurationService.getIPVTokenSigningKeyAlias(),
+                configurationService.getIPVAudience(),
+                IPV_STATE_STORAGE_PREFIX);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OAuthConfiguration.java
@@ -1,0 +1,12 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import java.net.URI;
+
+public record OAuthConfiguration(
+        String clientId,
+        URI authorizationURI,
+        URI tokenURI,
+        URI userInfoURI,
+        URI redirectURI,
+        String signingKeyAlias,
+        String privateKeyJwtAudience) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/BaseCallbackValidationError.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/BaseCallbackValidationError.java
@@ -1,0 +1,26 @@
+package uk.gov.di.orchestration.shared.oauth;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+public record BaseCallbackValidationError(String code, String description)
+        implements CallbackValidationError {
+
+    public static final BaseCallbackValidationError NO_QUERY_PARAMS =
+            new BaseCallbackValidationError(
+                    OAuth2Error.INVALID_REQUEST_CODE, "No query parameters present");
+
+    public static final BaseCallbackValidationError NO_STATE =
+            new BaseCallbackValidationError(
+                    OAuth2Error.INVALID_REQUEST_CODE,
+                    "No state param present in Authorisation response");
+
+    public static final BaseCallbackValidationError INVALID_STATE =
+            new BaseCallbackValidationError(
+                    OAuth2Error.INVALID_REQUEST_CODE,
+                    "Invalid state param present in Authorisation response");
+
+    public static final BaseCallbackValidationError NO_CODE_IN_PARAMS =
+            new BaseCallbackValidationError(
+                    OAuth2Error.INVALID_REQUEST_CODE,
+                    "No code param present in Authorisation response");
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/CallbackValidationError.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/CallbackValidationError.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.oauth;
+
+public interface CallbackValidationError {
+    String code();
+
+    String description();
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/CallbackValidator.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/CallbackValidator.java
@@ -1,0 +1,5 @@
+package uk.gov.di.orchestration.shared.oauth;
+
+public interface CallbackValidator {
+    CallbackValidationError handleError(String error, String description);
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -1,8 +1,11 @@
 package uk.gov.di.orchestration.shared.oauth;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
@@ -24,6 +27,7 @@ import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
 
 import java.io.IOException;
+import java.security.interfaces.RSAPublicKey;
 import java.time.temporal.ChronoUnit;
 
 import static java.lang.String.format;
@@ -159,5 +163,17 @@ public class OAuthService {
                     userInfoResponse.toErrorResponse().toString());
         }
         return userInfoResponse.toSuccessResponse().getUserInfo();
+    }
+
+    public AuthorizationRequest createAuthorisationRequest(
+            JWTClaimsSet claims, RSAPublicKey publicEncKey) {
+        var encryptedJar =
+                jwtService.signAndEncryptJWT(claims, clientConfig.signingKeyAlias(), publicEncKey);
+        return new AuthorizationRequest.Builder(
+                        new ResponseType(ResponseType.Value.CODE),
+                        new ClientID(clientConfig.clientId()))
+                .endpointURI(clientConfig.authorizationURI())
+                .requestObject(encryptedJar)
+                .build();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -128,9 +128,13 @@ public class OAuthService {
         }
     }
 
-    public UserInfo getUserInfo(UserInfoRequest userInfoRequest)
+    public UserInfo getUserInfo(TokenResponse tokenResponse)
             throws UnsuccessfulCredentialResponseException {
         LOG.info("Sending userinfo request");
+        var userInfoRequest =
+                new UserInfoRequest(
+                        clientConfig.userInfoURI(),
+                        tokenResponse.toSuccessResponse().getTokens().getBearerAccessToken());
         int count = 0;
         int maxTries = 2;
         UserInfoResponse userInfoResponse;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -26,6 +26,7 @@ import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 
@@ -48,16 +49,19 @@ public class OAuthService {
     private final NowHelper.NowClock clock;
     private final HTTPRequestSender httpRequestSender;
     private final StateStorageService stateStorageService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final Logger LOG = LogManager.getLogger(this.getClass());
 
     public OAuthService(
             OAuthConfiguration clientConfig,
             OrchJwtService jwtService,
             NowHelper.NowClock clock,
-            StateStorageService stateStorageService) {
+            StateStorageService stateStorageService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.httpRequestSender = null;
         this.stateStorageService = stateStorageService;
     }
@@ -67,12 +71,14 @@ public class OAuthService {
             OrchJwtService jwtService,
             NowHelper.NowClock clock,
             HTTPRequestSender httpRequestSender,
-            StateStorageService stateStorageService) {
+            StateStorageService stateStorageService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
         this.httpRequestSender = httpRequestSender;
         this.stateStorageService = stateStorageService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
     }
 
     public TokenResponse getToken(String authCode) {
@@ -202,5 +208,10 @@ public class OAuthService {
                 storedState.getValue(),
                 responseState.equals(storedState.getValue()));
         return responseState.equals(storedState.getValue());
+    }
+
+    public void storeState(String prefix, State state, String sessionId, String clientSessionId) {
+        stateStorageService.storeState(prefix + sessionId, state.getValue());
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -13,15 +13,20 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
 
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 public class OAuthService {
@@ -121,5 +126,34 @@ public class OAuthService {
             LOG.error("Error whilst parsing response", e);
             throw new RuntimeException(e);
         }
+    }
+
+    public UserInfo getUserInfo(UserInfoRequest userInfoRequest)
+            throws UnsuccessfulCredentialResponseException {
+        LOG.info("Sending userinfo request");
+        int count = 0;
+        int maxTries = 2;
+        UserInfoResponse userInfoResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying user info request");
+            count++;
+            userInfoResponse =
+                    sendHttpRequest(userInfoRequest.toHTTPRequest(), UserInfoResponse::parse);
+            if (!userInfoResponse.indicatesSuccess()) {
+                LOG.warn(
+                        format(
+                                "Unsuccessful %s response from userinfo endpoint on attempt %d: %s ",
+                                userInfoResponse.toHTTPResponse().getStatusCode(),
+                                count,
+                                userInfoResponse.toHTTPResponse().getBody()));
+            }
+        } while (!userInfoResponse.indicatesSuccess() && count < maxTries);
+
+        if (!userInfoResponse.indicatesSuccess()) {
+            LOG.error("Response from userinfo endpoint does not indicate success");
+            throw new UnsuccessfulCredentialResponseException(
+                    userInfoResponse.toErrorResponse().toString());
+        }
+        return userInfoResponse.toSuccessResponse().getUserInfo();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -16,15 +16,18 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
@@ -44,25 +47,32 @@ public class OAuthService {
     private final OrchJwtService jwtService;
     private final NowHelper.NowClock clock;
     private final HTTPRequestSender httpRequestSender;
+    private final StateStorageService stateStorageService;
     private final Logger LOG = LogManager.getLogger(this.getClass());
 
     public OAuthService(
-            OAuthConfiguration clientConfig, OrchJwtService jwtService, NowHelper.NowClock clock) {
+            OAuthConfiguration clientConfig,
+            OrchJwtService jwtService,
+            NowHelper.NowClock clock,
+            StateStorageService stateStorageService) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
         this.httpRequestSender = null;
+        this.stateStorageService = stateStorageService;
     }
 
     public OAuthService(
             OAuthConfiguration clientConfig,
             OrchJwtService jwtService,
             NowHelper.NowClock clock,
-            HTTPRequestSender httpRequestSender) {
+            HTTPRequestSender httpRequestSender,
+            StateStorageService stateStorageService) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
         this.httpRequestSender = httpRequestSender;
+        this.stateStorageService = stateStorageService;
     }
 
     public TokenResponse getToken(String authCode) {
@@ -175,5 +185,22 @@ public class OAuthService {
                 .endpointURI(clientConfig.authorizationURI())
                 .requestObject(encryptedJar)
                 .build();
+    }
+
+    public boolean isStateValid(String prefix, String sessionId, String responseState) {
+        var valueFromDynamo =
+                stateStorageService.getState(prefix + sessionId).map(StateItem::getState);
+        if (valueFromDynamo.isEmpty()) {
+            LOG.info("No state found in Dynamo");
+            return false;
+        }
+
+        State storedState = new State(valueFromDynamo.get());
+        LOG.info(
+                "Response state: {} and Stored state: {}. Are equal: {}",
+                responseState,
+                storedState.getValue(),
+                responseState.equals(storedState.getValue()));
+        return responseState.equals(storedState.getValue());
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -1,0 +1,125 @@
+package uk.gov.di.orchestration.shared.oauth;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
+
+import java.io.IOException;
+import java.time.temporal.ChronoUnit;
+
+import static java.util.Collections.singletonList;
+
+public class OAuthService {
+    private static final long PRIVATE_KEY_JWT_EXPIRY = 5L;
+
+    interface ResponseParser<T> {
+        T parse(HTTPResponse response) throws ParseException;
+    }
+
+    protected final OAuthConfiguration clientConfig;
+    private final OrchJwtService jwtService;
+    private final NowHelper.NowClock clock;
+    private final HTTPRequestSender httpRequestSender;
+    private final Logger LOG = LogManager.getLogger(this.getClass());
+
+    public OAuthService(
+            OAuthConfiguration clientConfig, OrchJwtService jwtService, NowHelper.NowClock clock) {
+        this.clientConfig = clientConfig;
+        this.jwtService = jwtService;
+        this.clock = clock;
+        this.httpRequestSender = null;
+    }
+
+    public OAuthService(
+            OAuthConfiguration clientConfig,
+            OrchJwtService jwtService,
+            NowHelper.NowClock clock,
+            HTTPRequestSender httpRequestSender) {
+        this.clientConfig = clientConfig;
+        this.jwtService = jwtService;
+        this.clock = clock;
+        this.httpRequestSender = httpRequestSender;
+    }
+
+    public TokenResponse getToken(String authCode) {
+        int count = 0;
+        int maxTries = 2;
+        TokenResponse tokenResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying token request");
+            count++;
+            // We must generate a new token request every time:
+            // private_key_jwt client auth JWTs are not reusable
+            var tokenRequest = createTokenRequest(authCode);
+            LOG.info("Sending Token request");
+            tokenResponse = sendHttpRequest(tokenRequest.toHTTPRequest(), TokenResponse::parse);
+            if (!tokenResponse.indicatesSuccess()) {
+                HTTPResponse response = tokenResponse.toHTTPResponse();
+                LOG.warn(
+                        "Unsuccessful {} response from token endpoint: {} on attempt {}: {} ",
+                        response.getStatusCode(),
+                        tokenRequest.getEndpointURI().toString(),
+                        count,
+                        response.getBody());
+            }
+        } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+        return tokenResponse;
+    }
+
+    private TokenRequest createTokenRequest(String authCode) {
+        var codeGrant =
+                new AuthorizationCodeGrant(
+                        new AuthorizationCode(authCode), clientConfig.redirectURI());
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(clientConfig.clientId()),
+                        singletonList(new Audience(clientConfig.privateKeyJwtAudience())),
+                        clock.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
+                        clock.now(),
+                        clock.now(),
+                        new JWTID());
+        var signedJWT =
+                jwtService.signJWT(claimsSet.toJWTClaimsSet(), clientConfig.signingKeyAlias());
+        return new TokenRequest.Builder(
+                        clientConfig.tokenURI(), new PrivateKeyJWT(signedJWT), codeGrant)
+                .customParameter("client_id", clientConfig.clientId())
+                .build();
+    }
+
+    private <T> T sendHttpRequest(HTTPRequest httpRequest, ResponseParser<T> parser) {
+        try {
+            HTTPResponse response;
+            if (httpRequestSender != null) {
+                response = httpRequest.send(httpRequestSender);
+            } else {
+                // Currently we only use the above for dependency injection, but in future we should
+                // create a custom HTTP client and remove this block!
+                response = httpRequest.send();
+            }
+
+            return parser.parse(response);
+        } catch (IOException e) {
+            LOG.error("Error whilst sending request", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error whilst parsing response", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -41,6 +41,7 @@ import static java.util.Collections.singletonList;
 
 public class OAuthService {
     private static final long PRIVATE_KEY_JWT_EXPIRY = 5L;
+    private static final Logger LOG = LogManager.getLogger(OAuthService.class);
 
     interface ResponseParser<T> {
         T parse(HTTPResponse response) throws ParseException;
@@ -53,7 +54,6 @@ public class OAuthService {
     private final StateStorageService stateStorageService;
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final CallbackValidator callbackValidator;
-    private final Logger LOG = LogManager.getLogger(this.getClass());
 
     public OAuthService(
             OAuthConfiguration clientConfig,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -200,7 +200,7 @@ public class OAuthService {
                 .build();
     }
 
-    public boolean isStateValid(String sessionId, String responseState) {
+    private boolean isStateValid(String sessionId, String responseState) {
         var valueFromDynamo =
                 stateStorageService
                         .getState(clientConfig.statePrefix() + sessionId)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -33,6 +33,8 @@ import uk.gov.di.orchestration.shared.services.StateStorageService;
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -50,6 +52,7 @@ public class OAuthService {
     private final HTTPRequestSender httpRequestSender;
     private final StateStorageService stateStorageService;
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
+    private final CallbackValidator callbackValidator;
     private final Logger LOG = LogManager.getLogger(this.getClass());
 
     public OAuthService(
@@ -57,11 +60,13 @@ public class OAuthService {
             OrchJwtService jwtService,
             NowHelper.NowClock clock,
             StateStorageService stateStorageService,
-            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
+            CallbackValidator callbackValidator) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
+        this.callbackValidator = callbackValidator;
         this.httpRequestSender = null;
         this.stateStorageService = stateStorageService;
     }
@@ -72,13 +77,15 @@ public class OAuthService {
             NowHelper.NowClock clock,
             HTTPRequestSender httpRequestSender,
             StateStorageService stateStorageService,
-            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
+            CallbackValidator callbackValidator) {
         this.clientConfig = clientConfig;
         this.jwtService = jwtService;
         this.clock = clock;
         this.httpRequestSender = httpRequestSender;
         this.stateStorageService = stateStorageService;
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
+        this.callbackValidator = callbackValidator;
     }
 
     public TokenResponse getToken(String authCode) {
@@ -215,5 +222,36 @@ public class OAuthService {
     public void storeState(State state, String sessionId, String clientSessionId) {
         stateStorageService.storeState(clientConfig.statePrefix() + sessionId, state.getValue());
         crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
+    }
+
+    public Optional<CallbackValidationError> validateCallback(
+            Map<String, String> queryParams, String sessionId) {
+        if (queryParams == null || queryParams.isEmpty()) {
+            LOG.warn("No Query parameters in  Authorisation response");
+            return Optional.of(BaseCallbackValidationError.NO_QUERY_PARAMS);
+        }
+
+        if (queryParams.containsKey("error")) {
+            LOG.warn("Error response found in Authorisation response");
+            return Optional.of(
+                    callbackValidator.handleError(
+                            queryParams.get("error"), queryParams.get("error_description")));
+        }
+
+        if (!queryParams.containsKey("state") || queryParams.get("state").isEmpty()) {
+            LOG.warn("No state param in Authorisation response");
+            return Optional.of(BaseCallbackValidationError.NO_STATE);
+        }
+
+        if (!isStateValid(sessionId, queryParams.get("state"))) {
+            return Optional.of(BaseCallbackValidationError.INVALID_STATE);
+        }
+
+        if (!queryParams.containsKey("code") || queryParams.get("code").isEmpty()) {
+            LOG.warn("No code param in Authorisation response");
+            return Optional.of(BaseCallbackValidationError.NO_CODE_IN_PARAMS);
+        }
+
+        return Optional.empty();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/oauth/OAuthService.java
@@ -193,9 +193,11 @@ public class OAuthService {
                 .build();
     }
 
-    public boolean isStateValid(String prefix, String sessionId, String responseState) {
+    public boolean isStateValid(String sessionId, String responseState) {
         var valueFromDynamo =
-                stateStorageService.getState(prefix + sessionId).map(StateItem::getState);
+                stateStorageService
+                        .getState(clientConfig.statePrefix() + sessionId)
+                        .map(StateItem::getState);
         if (valueFromDynamo.isEmpty()) {
             LOG.info("No state found in Dynamo");
             return false;
@@ -210,8 +212,8 @@ public class OAuthService {
         return responseState.equals(storedState.getValue());
     }
 
-    public void storeState(String prefix, State state, String sessionId, String clientSessionId) {
-        stateStorageService.storeState(prefix + sessionId, state.getValue());
+    public void storeState(State state, String sessionId, String clientSessionId) {
+        stateStorageService.storeState(clientConfig.statePrefix() + sessionId, state.getValue());
         crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -8,11 +8,14 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPRequest;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.sharedtest.helper.Constants;
@@ -28,6 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -220,6 +224,108 @@ public class OAuthServiceTest {
                     return fixedNowClock.nowPlus(5, ChronoUnit.SECONDS);
                 }
             };
+        }
+    }
+
+    @Nested
+    class UserinfoRequestTest {
+
+        @Test
+        void shouldCallUserInfoEndpointAndReturnWhenSuccessful()
+                throws IOException,
+                        UnsuccessfulCredentialResponseException,
+                        com.nimbusds.oauth2.sdk.ParseException {
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(getSuccessfulUserinfoResponse());
+            var userInfoRequest =
+                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
+
+            var userInfoResponse = oAuthService.getUserInfo(userInfoRequest);
+
+            assertEquals(
+                    getSuccessfulUserinfoResponse().getBodyAsJSONObject(),
+                    userInfoResponse.toJSONObject());
+            verify(mockHttpService, times(1)).send(any(ReadOnlyHTTPRequest.class));
+        }
+
+        @Test
+        void shouldRetryIfInitialUserInfoRequestFails()
+                throws IOException,
+                        UnsuccessfulCredentialResponseException,
+                        com.nimbusds.oauth2.sdk.ParseException {
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(getFailedUserInfoResponse())
+                    .thenReturn(getSuccessfulUserinfoResponse());
+            var userInfoRequest =
+                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
+
+            var userInfoResponse = oAuthService.getUserInfo(userInfoRequest);
+
+            assertEquals(
+                    getSuccessfulUserinfoResponse().getBodyAsJSONObject(),
+                    userInfoResponse.toJSONObject());
+            verify(mockHttpService, times(2)).send(any(ReadOnlyHTTPRequest.class));
+        }
+
+        @Test
+        void shouldThrowUnsuccessfulCredentialResponseExceptionIfTwoRequestsFail()
+                throws IOException {
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(getFailedUserInfoResponse())
+                    .thenReturn(getFailedUserInfoResponse());
+            var userInfoRequest =
+                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
+
+            assertThrows(
+                    UnsuccessfulCredentialResponseException.class,
+                    () -> oAuthService.getUserInfo(userInfoRequest));
+
+            verify(mockHttpService, times(2)).send(any(ReadOnlyHTTPRequest.class));
+        }
+
+        private HTTPResponse getSuccessfulUserinfoResponse() {
+            var userInfoResponse = new HTTPResponse(200);
+            userInfoResponse.setEntityContentType(APPLICATION_JSON);
+            userInfoResponse.setBody(
+                    """
+               {
+                   "sub": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                   "vot": "P2",
+                   "vtm": "https://oidc.example.com/trustmark",
+                   "https://vocab.example.gov.uk/v1/credentialJWT": [
+                       "<JWT-encoded VC 1>",
+                       "<JWT-encoded VC 2>"
+                   ],
+                   "https://vocab.example.gov.uk/v1/coreIdentity": {
+                       "name": [
+                           {}
+                       ],
+                       "birthDate": [
+                           {}
+                       ]
+                   },
+                   "phone_number_verified": true,
+                   "email_address_verified": true
+               }
+               """);
+            return userInfoResponse;
+        }
+
+        private HTTPResponse getFailedUserInfoResponse() {
+            var userInfoResponse = new HTTPResponse(401);
+            userInfoResponse.setEntityContentType(APPLICATION_JSON);
+            userInfoResponse.setBody(
+                    """
+                    {
+                        "error": "invalid_token",
+                        "error_description": "The access token expired or is invalid."
+                    }
+                    """);
+            userInfoResponse.setHeader(
+                    "WWW-Authenticate",
+                    "error=\"invalid_token\", error_description=\"The access token expired or is invalid.\"");
+
+            return userInfoResponse;
         }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPRequest;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,15 +19,18 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.helper.Constants;
 
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
@@ -34,9 +38,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -57,6 +64,7 @@ public class OAuthServiceTest {
                     Constants.TEST_PRIVATE_KEY_JWT_AUDIENCE);
 
     private final OrchJwtService jwtService = mock(OrchJwtService.class);
+    private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private final HTTPRequestSender mockHttpService = mock(HTTPRequestSender.class);
     private final RSAPublicKey publicKey = mock(RSAPublicKey.class);
     private OAuthService oAuthService;
@@ -64,7 +72,12 @@ public class OAuthServiceTest {
     @BeforeEach
     void setup() {
         oAuthService =
-                new OAuthService(TEST_OAUTH_CONFIG, jwtService, fixedNowClock, mockHttpService);
+                new OAuthService(
+                        TEST_OAUTH_CONFIG,
+                        jwtService,
+                        fixedNowClock,
+                        mockHttpService,
+                        stateStorageService);
     }
 
     @Nested
@@ -357,6 +370,55 @@ public class OAuthServiceTest {
                             eq(TEST_OAUTH_CONFIG.signingKeyAlias()),
                             any(RSAPublicKey.class)))
                     .thenReturn(EncryptedJWT.parse(TEST_SERIALIZED_JWE));
+        }
+    }
+
+    @Nested
+    class CallbackValidation {
+        public String statePrefix = "state::";
+
+        @Test
+        void shouldValidateStateInDynamoMatchesStateProvided() {
+            mockStatePresent();
+            assertTrue(
+                    oAuthService.isStateValid(
+                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+        }
+
+        @Test
+        void shouldReturnFalseForMissingState() {
+            mockStateMissing();
+            assertFalse(
+                    oAuthService.isStateValid(
+                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+        }
+
+        @Test
+        void shouldReturnFalseForMismatchState() {
+            mockStateMismatch();
+            assertFalse(
+                    oAuthService.isStateValid(
+                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+        }
+
+        private void mockStatePresent() {
+            when(stateStorageService.getState(anyString()))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(statePrefix + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+        }
+
+        private void mockStateMissing() {
+            when(stateStorageService.getState(anyString())).thenReturn(Optional.empty());
+        }
+
+        private void mockStateMismatch() {
+            when(stateStorageService.getState(anyString()))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(statePrefix + Constants.SESSION_ID)
+                                            .withState(new State().getValue())));
         }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -62,7 +63,8 @@ public class OAuthServiceTest {
                     Constants.TEST_USERINFO_URI,
                     Constants.TEST_CALLBACK_URI,
                     Constants.TEST_SIGNING_KEY_ALIAS,
-                    Constants.TEST_PRIVATE_KEY_JWT_AUDIENCE);
+                    Constants.TEST_PRIVATE_KEY_JWT_AUDIENCE,
+                    Constants.TEST_STATE_PREFIX);
 
     private final OrchJwtService jwtService = mock(OrchJwtService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
@@ -70,6 +72,8 @@ public class OAuthServiceTest {
             mock(CrossBrowserOrchestrationService.class);
     private final HTTPRequestSender mockHttpService = mock(HTTPRequestSender.class);
     private final RSAPublicKey publicKey = mock(RSAPublicKey.class);
+    CallbackValidator noOpCallbackValidator =
+            (error, description) -> BaseCallbackValidationError.INVALID_STATE;
     private OAuthService oAuthService;
 
     @BeforeEach
@@ -81,7 +85,8 @@ public class OAuthServiceTest {
                         fixedNowClock,
                         mockHttpService,
                         stateStorageService,
-                        crossBrowserOrchestrationService);
+                        crossBrowserOrchestrationService,
+                        noOpCallbackValidator);
     }
 
     @Nested
@@ -209,12 +214,12 @@ public class OAuthServiceTest {
         private HTTPResponse getSuccessfulTokenHttpResponse() {
             var tokenResponseContent =
                     """
-                    {
-                        "access_token": "740e5834-3a29-46b4-9a6f-16142fde533a",
-                        "token_type": "Bearer",
-                        "expires_in": 3600
-                    }
-                    """;
+                            {
+                                "access_token": "740e5834-3a29-46b4-9a6f-16142fde533a",
+                                "token_type": "Bearer",
+                                "expires_in": 3600
+                            }
+                            """;
             var tokenHTTPResponse = new HTTPResponse(200);
             tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
             tokenHTTPResponse.setBody(tokenResponseContent);
@@ -225,11 +230,11 @@ public class OAuthServiceTest {
         private HTTPResponse failedTokenResponse() {
             var tokenResponseContent =
                     """
-                    {
-                        "error": "invalid_grant",
-                        "error_description": "Client authentication failed"
-                    }
-                    """;
+                            {
+                                "error": "invalid_grant",
+                                "error_description": "Client authentication failed"
+                            }
+                            """;
 
             var tokenHTTPResponse = new HTTPResponse(401);
             tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
@@ -304,26 +309,26 @@ public class OAuthServiceTest {
             userInfoResponse.setEntityContentType(APPLICATION_JSON);
             userInfoResponse.setBody(
                     """
-               {
-                   "sub": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-                   "vot": "P2",
-                   "vtm": "https://oidc.example.com/trustmark",
-                   "https://vocab.example.gov.uk/v1/credentialJWT": [
-                       "<JWT-encoded VC 1>",
-                       "<JWT-encoded VC 2>"
-                   ],
-                   "https://vocab.example.gov.uk/v1/coreIdentity": {
-                       "name": [
-                           {}
-                       ],
-                       "birthDate": [
-                           {}
-                       ]
-                   },
-                   "phone_number_verified": true,
-                   "email_address_verified": true
-               }
-               """);
+                            {
+                                "sub": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                                "vot": "P2",
+                                "vtm": "https://oidc.example.com/trustmark",
+                                "https://vocab.example.gov.uk/v1/credentialJWT": [
+                                    "<JWT-encoded VC 1>",
+                                    "<JWT-encoded VC 2>"
+                                ],
+                                "https://vocab.example.gov.uk/v1/coreIdentity": {
+                                    "name": [
+                                        {}
+                                    ],
+                                    "birthDate": [
+                                        {}
+                                    ]
+                                },
+                                "phone_number_verified": true,
+                                "email_address_verified": true
+                            }
+                            """);
             return userInfoResponse;
         }
 
@@ -332,11 +337,11 @@ public class OAuthServiceTest {
             userInfoResponse.setEntityContentType(APPLICATION_JSON);
             userInfoResponse.setBody(
                     """
-                    {
-                        "error": "invalid_token",
-                        "error_description": "The access token expired or is invalid."
-                    }
-                    """);
+                            {
+                                "error": "invalid_token",
+                                "error_description": "The access token expired or is invalid."
+                            }
+                            """);
             userInfoResponse.setHeader(
                     "WWW-Authenticate",
                     "error=\"invalid_token\", error_description=\"The access token expired or is invalid.\"");
@@ -379,42 +384,36 @@ public class OAuthServiceTest {
 
     @Nested
     class StateStorage {
-        public String statePrefix = "state::";
 
         @Test
         void shouldValidateStateInDynamoMatchesStateProvided() {
             mockStatePresent();
-            assertTrue(
-                    oAuthService.isStateValid(
-                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+            assertTrue(oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
         }
 
         @Test
         void shouldReturnFalseForMissingState() {
             mockStateMissing();
             assertFalse(
-                    oAuthService.isStateValid(
-                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+                    oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
         }
 
         @Test
         void shouldReturnFalseForMismatchState() {
             mockStateMismatch();
             assertFalse(
-                    oAuthService.isStateValid(
-                            statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+                    oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
         }
 
         @Test
         void shouldStoreStateAgainstSessionAndClientSessionID() {
             oAuthService.storeState(
-                    statePrefix,
-                    Constants.STATE,
-                    Constants.SESSION_ID,
-                    Constants.CLIENT_SESSION_ID);
+                    Constants.STATE, Constants.SESSION_ID, Constants.CLIENT_SESSION_ID);
 
             verify(stateStorageService, times(1))
-                    .storeState(statePrefix + Constants.SESSION_ID, Constants.STATE.getValue());
+                    .storeState(
+                            Constants.TEST_STATE_PREFIX + Constants.SESSION_ID,
+                            Constants.STATE.getValue());
             verify(crossBrowserOrchestrationService, times(1))
                     .storeClientSessionIdAgainstState(Constants.CLIENT_SESSION_ID, Constants.STATE);
         }
@@ -423,7 +422,9 @@ public class OAuthServiceTest {
             when(stateStorageService.getState(anyString()))
                     .thenReturn(
                             Optional.of(
-                                    new StateItem(statePrefix + Constants.SESSION_ID)
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
                                             .withState(Constants.STATE.getValue())));
         }
 
@@ -435,8 +436,146 @@ public class OAuthServiceTest {
             when(stateStorageService.getState(anyString()))
                     .thenReturn(
                             Optional.of(
-                                    new StateItem(statePrefix + Constants.SESSION_ID)
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
                                             .withState(new State().getValue())));
+        }
+    }
+
+    @Nested
+    class CallbackErrorValidation {
+        @Test
+        void shouldReturnErrorWhenQueryParamsAreNull() {
+            var errorOpt = oAuthService.validateCallback(null, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_QUERY_PARAMS, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenQueryParamsAreEmpty() {
+            var errorOpt = oAuthService.validateCallback(Map.of(), Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_QUERY_PARAMS, errorOpt.get());
+        }
+
+        @Test
+        void shouldDelegateErrorValidationToTheProvidedValidator() {
+            var params =
+                    Map.of(
+                            "state",
+                            Constants.STATE.getValue(),
+                            "code",
+                            Constants.AUTHORIZATION_CODE.getValue(),
+                            "error",
+                            "custom_error",
+                            "error_description",
+                            "custom_description");
+
+            var response = oAuthService.validateCallback(params, Constants.SESSION_ID);
+            assertEquals(Optional.of(BaseCallbackValidationError.INVALID_STATE), response);
+        }
+
+        @Test
+        void shouldReturnErrorWhenStateNotPresentInQueryParams() {
+            // Query params needs to be not empty to reach the state check
+            var queryParams = Map.of("unused_param", "test");
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_STATE, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenStateIsEmptyInQueryParams() {
+            var queryParams = Map.of("state", "");
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_STATE, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenStateInDynamoIsEmpty() {
+            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
+                    .thenReturn(Optional.empty());
+
+            var queryParams = Map.of("state", Constants.STATE.getValue());
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.INVALID_STATE, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenStateInDynamoDoesNotMatchStateInQueryParams() {
+            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+
+            var queryParams = Map.of("state", new State().getValue());
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.INVALID_STATE, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenCodeIsNotPresentInQueryParams() {
+            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+            var queryParams = Map.of("state", Constants.STATE.getValue());
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_CODE_IN_PARAMS, errorOpt.get());
+        }
+
+        @Test
+        void shouldReturnErrorWhenCodeIsEmptyInQueryParams() {
+            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+            var queryParams = Map.of("state", Constants.STATE.getValue(), "code", "");
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+
+            assertTrue(errorOpt.isPresent());
+            assertEquals(BaseCallbackValidationError.NO_CODE_IN_PARAMS, errorOpt.get());
+        }
+
+        @Test
+        void shouldNotReturnErrorIfResponseIsValid() {
+            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+            var queryParams =
+                    Map.of(
+                            "state",
+                            Constants.STATE.getValue(),
+                            "code",
+                            Constants.AUTHORIZATION_CODE.getValue());
+
+            var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
+            assertTrue(errorOpt.isEmpty());
         }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -4,12 +4,13 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPRequest;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.oauth2.sdk.token.Tokens;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -237,10 +238,8 @@ public class OAuthServiceTest {
                         com.nimbusds.oauth2.sdk.ParseException {
             when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
                     .thenReturn(getSuccessfulUserinfoResponse());
-            var userInfoRequest =
-                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
 
-            var userInfoResponse = oAuthService.getUserInfo(userInfoRequest);
+            var userInfoResponse = oAuthService.getUserInfo(getTokenResponse());
 
             assertEquals(
                     getSuccessfulUserinfoResponse().getBodyAsJSONObject(),
@@ -256,10 +255,8 @@ public class OAuthServiceTest {
             when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
                     .thenReturn(getFailedUserInfoResponse())
                     .thenReturn(getSuccessfulUserinfoResponse());
-            var userInfoRequest =
-                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
 
-            var userInfoResponse = oAuthService.getUserInfo(userInfoRequest);
+            var userInfoResponse = oAuthService.getUserInfo(getTokenResponse());
 
             assertEquals(
                     getSuccessfulUserinfoResponse().getBodyAsJSONObject(),
@@ -273,12 +270,10 @@ public class OAuthServiceTest {
             when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
                     .thenReturn(getFailedUserInfoResponse())
                     .thenReturn(getFailedUserInfoResponse());
-            var userInfoRequest =
-                    new UserInfoRequest(TEST_OAUTH_CONFIG.userInfoURI(), new BearerAccessToken());
 
             assertThrows(
                     UnsuccessfulCredentialResponseException.class,
-                    () -> oAuthService.getUserInfo(userInfoRequest));
+                    () -> oAuthService.getUserInfo(getTokenResponse()));
 
             verify(mockHttpService, times(2)).send(any(ReadOnlyHTTPRequest.class));
         }
@@ -327,5 +322,9 @@ public class OAuthServiceTest {
 
             return userInfoResponse;
         }
+    }
+
+    private AccessTokenResponse getTokenResponse() {
+        return new AccessTokenResponse(new Tokens(new BearerAccessToken(), null), null);
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -1,0 +1,225 @@
+package uk.gov.di.orchestration.shared.oauth;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.sharedtest.helper.Constants;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+
+import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OAuthServiceTest {
+    private static final NowHelper.NowClock fixedNowClock =
+            new NowHelper.NowClock(Constants.FIXED_CLOCK);
+    private static final OAuthConfiguration TEST_OAUTH_CONFIG =
+            new OAuthConfiguration(
+                    Constants.TEST_CLIENT_ID,
+                    Constants.TEST_AUTHORIZE_URI,
+                    Constants.TEST_TOKEN_URI,
+                    Constants.TEST_USERINFO_URI,
+                    Constants.TEST_CALLBACK_URI,
+                    Constants.TEST_SIGNING_KEY_ALIAS,
+                    Constants.TEST_PRIVATE_KEY_JWT_AUDIENCE);
+
+    private final OrchJwtService jwtService = mock(OrchJwtService.class);
+    private final HTTPRequestSender mockHttpService = mock(HTTPRequestSender.class);
+    private OAuthService oAuthService;
+
+    @BeforeEach
+    void setup() {
+        oAuthService =
+                new OAuthService(TEST_OAUTH_CONFIG, jwtService, fixedNowClock, mockHttpService);
+    }
+
+    @Nested
+    class TokenRequestTests {
+        private static final String MOCK_SERIALIZED_SIGNED_JWT =
+                "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MjY2ODQ1ODQsImlzcyI6Im15IGNsaWVudCBpZCIsInN1YiI6Im15IGNsaWVudCBpZCIsImF1ZCI6Imh0dHBzOi8vbXl0ZW5hbnQuYXV0aDAuY29tLyIsImV4cCI6MTYyNjY4NDY0NCwianRpIjoiZTRkYzhlZDEtYjEwOC00OTAxLThiYmMtYzA3YTc5MTgxN2U3In0.TSn6qTq2ioriY85GtPiC-a1ZvXSX5hmPRQ36DG3KV8e4-lWgTYru24yqBdg960pyAHp3OtNYzEaO_38eu7n9OK8c3biE1A5342PbSsLNS6IuI1MQTwM9nSS-u9RGehakKCYDpgUrjQloFcP-x3i944nAFOb708x_aa54L6SsLkL_gg565T0DWa56jFY35PSvybTIaPOq0LAquLrSlhOeClBCFOwx6HfAfgaDtbgbhtLAFDwdXXEUgSvhEUpIeSmN6FOcTXiyqZhTb70C2vM6JfICm-CEneUdMe8TpSo7QdDGhVKXjf-WJwUnkzjpgvkzU3MfYJOQIbiT-g4ytAOfqg";
+
+        @Test
+        void shouldCallTokenEndpointAndReturnWhenSuccessful()
+                throws IOException, com.nimbusds.oauth2.sdk.ParseException {
+            mockSigningJwt();
+            var expectedTokenResponse = getSuccessfulTokenHttpResponse();
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(expectedTokenResponse);
+
+            var tokenResponse = oAuthService.getToken(Constants.AUTHORIZATION_CODE.toString());
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+            assertEquals(
+                    expectedTokenResponse.getBodyAsJSONObject(),
+                    tokenResponse.toHTTPResponse().getBodyAsJSONObject());
+        }
+
+        @Test
+        void shouldRetryWithNewTokenRequestIfInitialRequestFails()
+                throws IOException, com.nimbusds.oauth2.sdk.ParseException {
+            mockSigningJwt();
+            var expectedTokenResponse = getSuccessfulTokenHttpResponse();
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(failedTokenResponse())
+                    .thenReturn(expectedTokenResponse);
+
+            var tokenResponse = oAuthService.getToken(Constants.AUTHORIZATION_CODE.toString());
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+            verify(mockHttpService, times(2)).send(any(ReadOnlyHTTPRequest.class));
+            verify(jwtService, times(2))
+                    .signJWT(any(JWTClaimsSet.class), eq(TEST_OAUTH_CONFIG.signingKeyAlias()));
+            assertEquals(
+                    expectedTokenResponse.getBodyAsJSONObject(),
+                    tokenResponse.toHTTPResponse().getBodyAsJSONObject());
+        }
+
+        @Test
+        void shouldReturnAFailureIfTwoCallsToTheTokenEndpointFail()
+                throws IOException, com.nimbusds.oauth2.sdk.ParseException {
+            mockSigningJwt();
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(failedTokenResponse())
+                    .thenReturn(failedTokenResponse());
+
+            var tokenResponse = oAuthService.getToken(Constants.AUTHORIZATION_CODE.toString());
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+            verify(mockHttpService, times(2)).send(any(HTTPRequest.class));
+            assertEquals(
+                    failedTokenResponse().getBodyAsJSONObject(),
+                    tokenResponse.toHTTPResponse().getBodyAsJSONObject());
+        }
+
+        @Test
+        void eachTokenRequestShouldContainUniqueClientAssertionClaims() throws IOException {
+            mockSigningJwt();
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(failedTokenResponse())
+                    .thenReturn(getSuccessfulTokenHttpResponse());
+
+            oAuthService.getToken(Constants.AUTHORIZATION_CODE.toString());
+
+            var claimsSetArgumentCaptor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+
+            verify(mockHttpService, times(2)).send(any(HTTPRequest.class));
+            verify(jwtService, times(2))
+                    .signJWT(
+                            claimsSetArgumentCaptor.capture(),
+                            eq(TEST_OAUTH_CONFIG.signingKeyAlias()));
+
+            var firstClaimSet = claimsSetArgumentCaptor.getAllValues().get(0);
+            var secondClaimSet = claimsSetArgumentCaptor.getAllValues().get(1);
+            assertNotEquals(firstClaimSet, secondClaimSet);
+        }
+
+        @Test
+        void tokenRequestShouldContainPrivateKeyJwtClaims() throws IOException {
+            mockSigningJwt();
+            when(mockHttpService.send(any(ReadOnlyHTTPRequest.class)))
+                    .thenReturn(getSuccessfulTokenHttpResponse());
+
+            oAuthService.getToken(Constants.AUTHORIZATION_CODE.toString());
+
+            var claimsSetArgumentCaptor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+            var expectedClaims =
+                    new JWTClaimsSet.Builder()
+                            // Our Client ID is provided as the issuer
+                            .issuer(TEST_OAUTH_CONFIG.clientId())
+                            .audience(TEST_OAUTH_CONFIG.privateKeyJwtAudience())
+                            .expirationTime(fixedNowClock.nowPlus(5, ChronoUnit.MINUTES))
+                            .issueTime(fixedNowClock.now())
+                            .notBeforeTime(fixedNowClock.now())
+                            .build();
+
+            var verifier =
+                    getFixedTimeJwtVerifier(
+                            expectedClaims, Set.of("exp", "iat", "nbf", "jti", "iss"));
+            verify(jwtService)
+                    .signJWT(
+                            claimsSetArgumentCaptor.capture(),
+                            eq(TEST_OAUTH_CONFIG.signingKeyAlias()));
+
+            var privateKeyJwtClaimsSet = claimsSetArgumentCaptor.getAllValues().get(0);
+
+            assertDoesNotThrow(() -> verifier.verify(privateKeyJwtClaimsSet, null));
+        }
+
+        private void mockSigningJwt() {
+            try {
+                when(jwtService.signJWT(
+                                any(JWTClaimsSet.class), eq(Constants.TEST_SIGNING_KEY_ALIAS)))
+                        .thenReturn(SignedJWT.parse(MOCK_SERIALIZED_SIGNED_JWT));
+            } catch (ParseException e) {
+                throw new RuntimeException("Failed to parse JWT for test");
+            }
+        }
+
+        private HTTPResponse getSuccessfulTokenHttpResponse() {
+            var tokenResponseContent =
+                    """
+                    {
+                        "access_token": "740e5834-3a29-46b4-9a6f-16142fde533a",
+                        "token_type": "Bearer",
+                        "expires_in": 3600
+                    }
+                    """;
+            var tokenHTTPResponse = new HTTPResponse(200);
+            tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            tokenHTTPResponse.setBody(tokenResponseContent);
+
+            return tokenHTTPResponse;
+        }
+
+        private HTTPResponse failedTokenResponse() {
+            var tokenResponseContent =
+                    """
+                    {
+                        "error": "invalid_grant",
+                        "error_description": "Client authentication failed"
+                    }
+                    """;
+
+            var tokenHTTPResponse = new HTTPResponse(401);
+            tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            tokenHTTPResponse.setBody(tokenResponseContent);
+            return tokenHTTPResponse;
+        }
+
+        private DefaultJWTClaimsVerifier<SecurityContext> getFixedTimeJwtVerifier(
+                JWTClaimsSet expectedJwtClaimSet, Set<String> mandatoryClaims) {
+            return new DefaultJWTClaimsVerifier<>(expectedJwtClaimSet, mandatoryClaims) {
+                @Override
+                protected java.util.Date currentTime() {
+                    // Add 5 seconds so current time is ahead of iat and nbf
+                    return fixedNowClock.nowPlus(5, ChronoUnit.SECONDS);
+                }
+            };
+        }
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.orchestration.shared.entity.OAuthConfiguration;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.helper.Constants;
@@ -65,6 +66,8 @@ public class OAuthServiceTest {
 
     private final OrchJwtService jwtService = mock(OrchJwtService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private final HTTPRequestSender mockHttpService = mock(HTTPRequestSender.class);
     private final RSAPublicKey publicKey = mock(RSAPublicKey.class);
     private OAuthService oAuthService;
@@ -77,7 +80,8 @@ public class OAuthServiceTest {
                         jwtService,
                         fixedNowClock,
                         mockHttpService,
-                        stateStorageService);
+                        stateStorageService,
+                        crossBrowserOrchestrationService);
     }
 
     @Nested
@@ -374,7 +378,7 @@ public class OAuthServiceTest {
     }
 
     @Nested
-    class CallbackValidation {
+    class StateStorage {
         public String statePrefix = "state::";
 
         @Test
@@ -399,6 +403,20 @@ public class OAuthServiceTest {
             assertFalse(
                     oAuthService.isStateValid(
                             statePrefix, Constants.SESSION_ID, Constants.STATE.getValue()));
+        }
+
+        @Test
+        void shouldStoreStateAgainstSessionAndClientSessionID() {
+            oAuthService.storeState(
+                    statePrefix,
+                    Constants.STATE,
+                    Constants.SESSION_ID,
+                    Constants.CLIENT_SESSION_ID);
+
+            verify(stateStorageService, times(1))
+                    .storeState(statePrefix + Constants.SESSION_ID, Constants.STATE.getValue());
+            verify(crossBrowserOrchestrationService, times(1))
+                    .storeClientSessionIdAgainstState(Constants.CLIENT_SESSION_ID, Constants.STATE);
         }
 
         private void mockStatePresent() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -40,7 +40,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -380,30 +379,6 @@ public class OAuthServiceTest {
                             any(RSAPublicKey.class)))
                     .thenReturn(EncryptedJWT.parse(TEST_SERIALIZED_JWE));
         }
-    }
-
-    @Nested
-    class StateStorage {
-
-        @Test
-        void shouldValidateStateInDynamoMatchesStateProvided() {
-            mockStatePresent();
-            assertTrue(oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
-        }
-
-        @Test
-        void shouldReturnFalseForMissingState() {
-            mockStateMissing();
-            assertFalse(
-                    oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
-        }
-
-        @Test
-        void shouldReturnFalseForMismatchState() {
-            mockStateMismatch();
-            assertFalse(
-                    oAuthService.isStateValid(Constants.SESSION_ID, Constants.STATE.getValue()));
-        }
 
         @Test
         void shouldStoreStateAgainstSessionAndClientSessionID() {
@@ -416,30 +391,6 @@ public class OAuthServiceTest {
                             Constants.STATE.getValue());
             verify(crossBrowserOrchestrationService, times(1))
                     .storeClientSessionIdAgainstState(Constants.CLIENT_SESSION_ID, Constants.STATE);
-        }
-
-        private void mockStatePresent() {
-            when(stateStorageService.getState(anyString()))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(Constants.STATE.getValue())));
-        }
-
-        private void mockStateMissing() {
-            when(stateStorageService.getState(anyString())).thenReturn(Optional.empty());
-        }
-
-        private void mockStateMismatch() {
-            when(stateStorageService.getState(anyString()))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(new State().getValue())));
         }
     }
 
@@ -499,8 +450,7 @@ public class OAuthServiceTest {
 
         @Test
         void shouldReturnErrorWhenStateInDynamoIsEmpty() {
-            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
-                    .thenReturn(Optional.empty());
+            stateMissing();
 
             var queryParams = Map.of("state", Constants.STATE.getValue());
             var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
@@ -511,13 +461,7 @@ public class OAuthServiceTest {
 
         @Test
         void shouldReturnErrorWhenStateInDynamoDoesNotMatchStateInQueryParams() {
-            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(Constants.STATE.getValue())));
+            stateMismatch();
 
             var queryParams = Map.of("state", new State().getValue());
             var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
@@ -528,13 +472,8 @@ public class OAuthServiceTest {
 
         @Test
         void shouldReturnErrorWhenCodeIsNotPresentInQueryParams() {
-            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(Constants.STATE.getValue())));
+            statePresent();
+
             var queryParams = Map.of("state", Constants.STATE.getValue());
             var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
 
@@ -544,13 +483,8 @@ public class OAuthServiceTest {
 
         @Test
         void shouldReturnErrorWhenCodeIsEmptyInQueryParams() {
-            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(Constants.STATE.getValue())));
+            statePresent();
+
             var queryParams = Map.of("state", Constants.STATE.getValue(), "code", "");
             var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
 
@@ -560,13 +494,8 @@ public class OAuthServiceTest {
 
         @Test
         void shouldNotReturnErrorIfResponseIsValid() {
-            when(stateStorageService.getState(Constants.TEST_STATE_PREFIX + Constants.SESSION_ID))
-                    .thenReturn(
-                            Optional.of(
-                                    new StateItem(
-                                                    Constants.TEST_STATE_PREFIX
-                                                            + Constants.SESSION_ID)
-                                            .withState(Constants.STATE.getValue())));
+            statePresent();
+
             var queryParams =
                     Map.of(
                             "state",
@@ -576,6 +505,30 @@ public class OAuthServiceTest {
 
             var errorOpt = oAuthService.validateCallback(queryParams, Constants.SESSION_ID);
             assertTrue(errorOpt.isEmpty());
+        }
+
+        private void statePresent() {
+            when(stateStorageService.getState(anyString()))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(Constants.STATE.getValue())));
+        }
+
+        private void stateMissing() {
+            when(stateStorageService.getState(anyString())).thenReturn(Optional.empty());
+        }
+
+        private void stateMismatch() {
+            when(stateStorageService.getState(anyString()))
+                    .thenReturn(
+                            Optional.of(
+                                    new StateItem(
+                                                    Constants.TEST_STATE_PREFIX
+                                                            + Constants.SESSION_ID)
+                                            .withState(new State().getValue())));
         }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/oauth/OAuthServiceTest.java
@@ -1,10 +1,12 @@
 package uk.gov.di.orchestration.shared.oauth;
 
 import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
@@ -22,6 +24,7 @@ import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.sharedtest.helper.Constants;
 
 import java.io.IOException;
+import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -55,6 +58,7 @@ public class OAuthServiceTest {
 
     private final OrchJwtService jwtService = mock(OrchJwtService.class);
     private final HTTPRequestSender mockHttpService = mock(HTTPRequestSender.class);
+    private final RSAPublicKey publicKey = mock(RSAPublicKey.class);
     private OAuthService oAuthService;
 
     @BeforeEach
@@ -326,5 +330,33 @@ public class OAuthServiceTest {
 
     private AccessTokenResponse getTokenResponse() {
         return new AccessTokenResponse(new Tokens(new BearerAccessToken(), null), null);
+    }
+
+    @Nested
+    class AuthorisationRequest {
+        private static final String TEST_SERIALIZED_JWE =
+                "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ";
+
+        @Test
+        void shouldCreateAuthorisationRequestFromClaimsAndKeyInfo() throws ParseException {
+            mockSigningAndEncryption();
+            var claims = new JWTClaimsSet.Builder().claim("hello", "world").build();
+            var authenticationRequest = oAuthService.createAuthorisationRequest(claims, publicKey);
+
+            assertEquals(
+                    TEST_OAUTH_CONFIG.clientId(), authenticationRequest.getClientID().toString());
+            assertEquals(TEST_SERIALIZED_JWE, authenticationRequest.getRequestObject().serialize());
+            assertEquals(
+                    TEST_OAUTH_CONFIG.authorizationURI(), authenticationRequest.getEndpointURI());
+            assertEquals(ResponseType.CODE, authenticationRequest.getResponseType());
+        }
+
+        private void mockSigningAndEncryption() throws ParseException {
+            when(jwtService.signAndEncryptJWT(
+                            any(JWTClaimsSet.class),
+                            eq(TEST_OAUTH_CONFIG.signingKeyAlias()),
+                            any(RSAPublicKey.class)))
+                    .thenReturn(EncryptedJWT.parse(TEST_SERIALIZED_JWE));
+        }
     }
 }


### PR DESCRIPTION
### Wider context of change

We have many OAuth interfaces with different components of One Login such as Auth, IPV, DCMAW and soon to be SIS. Despite this, we have tended to duplicate a lot of the OAuth code especially around making the `/token` and `/userinfo` requests 

### What’s changed
- Adds a generic OAuth service, which is configurable via thin configuration record `OAuthConfiguration`
- Adds several public methods which aim to represent each part of the OAuth flow (making the `/authorize`, `/token` and `/userinfo` requests.
- Adds a couple of helper methods to validate  and store state
- Moves most of the callback validation into this class, with a specific interface providing our handling of the cases in which we're returned an OAuth error, in which case we delegate to our handleError method. This is to account for the fact that sometimes we need to handle specific OAuth error codes 

### Manual testing

- N/A - this is new code that is unit tested and is part of some preparatory refactoring of our existing OAuth interfaces

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->