### PR TITLE
AUT-5572: Add further parameter validation to tflint.py

### DIFF
--- a/scripts/tflint.py
+++ b/scripts/tflint.py
@@ -14,6 +14,48 @@ from multiprocessing.pool import AsyncResult
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CONFIG_FILE = os.path.join(REPO_ROOT, ".tflint.hcl")
 
+# Valid tflint flags that can be passed through this wrapper.
+# Flags managed by the wrapper (--config, --chdir, --format, --filter, --init) are excluded.
+VALID_TFLINT_FLAGS = {
+    "-v",
+    "--version",
+    "--langserver",
+    "--ignore-module",
+    "--enable-rule",
+    "--disable-rule",
+    "--only",
+    "--enable-plugin",
+    "--var-file",
+    "--var",
+    "--call-module-type",
+    "--recursive",
+    "--force",
+    "--minimum-failure-severity",
+    "--color",
+    "--no-color",
+    "--fix",
+    "--no-parallel-runners",
+    "--max-workers",
+    "-h",
+    "--help",
+}
+
+
+def validate_tflint_args(args: list[str]) -> None:
+    """Validate that pass-through args are known tflint flags."""
+    for arg in args:
+        if not arg.startswith("-"):
+            continue
+        # Handle --flag=value style
+        flag = arg.split("=", 1)[0]
+        if flag not in VALID_TFLINT_FLAGS:
+            print(f"error: unknown tflint option: {flag}", file=sys.stderr)
+            print(
+                "hint: if this is a valid tflint flag, add it to VALID_TFLINT_FLAGS in this script.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
 
 def run_tflint(
     directory: pathlib.Path, files: list[str], args: list[str]
@@ -149,6 +191,8 @@ class ValidatePathAction(argparse.Action):
                 parser.error(f"Path {value} does not exist.")
             if not path.is_file():
                 parser.error(f"Path {value} is not a file.")
+            if path.suffix not in (".tf", ".hcl", ".tfvars"):
+                parser.error(f"Path {value} is not a Terraform file (.tf, .hcl).")
             pvalues.append(path)
         setattr(namespace, self.dest, pvalues)
 
@@ -165,4 +209,5 @@ if __name__ == "__main__":
         action=ValidatePathAction,
     )
     app_args, tflint_args = app_parser.parse_known_args()
+    validate_tflint_args(tflint_args)
     main(app_args, tflint_args)


### PR DESCRIPTION

## What

Add further parameter validation to tflint.py

## How to review

Stops the script being used for unintended purposes



1. Code Review
1. Check that all the pre-commit tasks run in github actions

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
