### PR TITLE
AUT-5606: migrate remove account to data api

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -75,13 +76,15 @@ public class RemoveAccountHandler
         this.structuredAuditService = new StructuredAuditService(configurationService);
         this.configurationService = configurationService;
         this.dynamoDeleteService = new DynamoDeleteService(configurationService);
+        var accountDataApiService = new AccountDataApiService(configurationService);
         this.accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         sqsClient,
                         structuredAuditService,
                         configurationService,
-                        dynamoDeleteService);
+                        dynamoDeleteService,
+                        accountDataApiService);
     }
 
     public RemoveAccountHandler() {
@@ -120,17 +123,30 @@ public class RemoveAccountHandler
 
             authoriseRequest(input, userProfile);
 
+            var token =
+                    Optional.ofNullable(input.getHeaders())
+                            .map(headers -> headers.get("X-ADAPI-AccessToken"))
+                            .filter(t -> !t.isEmpty());
+
             accountDeletionService.removeAccount(
                     Optional.of(input),
                     userProfile,
                     TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
-                    AccountDeletionReason.USER_INITIATED);
+                    AccountDeletionReason.USER_INITIATED,
+                    true,
+                    token);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (UserNotFoundException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ACCT_DOES_NOT_EXIST);
         } catch (JsonException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.REQUEST_MISSING_PARAMS);
+        } catch (RuntimeException e) {
+            if (e instanceof InvalidPrincipalException) {
+                throw e;
+            }
+            LOG.error("Error deleting account", e);
+            return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -10,6 +10,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -17,6 +18,7 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -36,6 +38,7 @@ public class AccountDeletionService {
     private final StructuredAuditService structuredAuditService;
     private final ConfigurationService configurationService;
     private final DynamoDeleteService dynamoDeleteService;
+    private final AccountDataApiService accountDataApiService;
     private final Json objectMapper = SerializationService.getInstance();
 
     public AccountDeletionService(
@@ -43,12 +46,29 @@ public class AccountDeletionService {
             AwsSqsClient sqsClient,
             StructuredAuditService structuredAuditService,
             ConfigurationService configurationService,
-            DynamoDeleteService dynamoDeleteService) {
+            DynamoDeleteService dynamoDeleteService,
+            AccountDataApiService accountDataApiService) {
         this.authenticationService = authenticationService;
         this.sqsClient = sqsClient;
         this.structuredAuditService = structuredAuditService;
         this.configurationService = configurationService;
         this.dynamoDeleteService = dynamoDeleteService;
+        this.accountDataApiService = accountDataApiService;
+    }
+
+    public AccountDeletionService(
+            AuthenticationService authenticationService,
+            AwsSqsClient sqsClient,
+            StructuredAuditService structuredAuditService,
+            ConfigurationService configurationService,
+            DynamoDeleteService dynamoDeleteService) {
+        this(
+                authenticationService,
+                sqsClient,
+                structuredAuditService,
+                configurationService,
+                dynamoDeleteService,
+                null);
     }
 
     public void removeAccount(
@@ -57,7 +77,7 @@ public class AccountDeletionService {
             String txmaAuditEncoded,
             AccountDeletionReason reason)
             throws Json.JsonException {
-        removeAccount(input, userProfile, txmaAuditEncoded, reason, true);
+        removeAccount(input, userProfile, txmaAuditEncoded, reason, true, Optional.empty());
     }
 
     public void removeAccount(
@@ -67,6 +87,17 @@ public class AccountDeletionService {
             AccountDeletionReason reason,
             boolean sendNotification)
             throws Json.JsonException {
+        removeAccount(
+                input, userProfile, txmaAuditEncoded, reason, sendNotification, Optional.empty());
+    }
+
+    public void removeAccount(
+            Optional<APIGatewayProxyRequestEvent> input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            boolean sendNotification,
+            Optional<String> accountDataApiToken) {
         LOG.info("Calculating internal common subject identifier");
         var internalCommonSubjectIdentifier =
                 ClientSubjectHelper.getSubjectWithSectorIdentifier(
@@ -77,10 +108,15 @@ public class AccountDeletionService {
         var email = userProfile.getEmail();
 
         LOG.info("Deleting user account");
-        dynamoDeleteService.deleteAccount(
-                email,
-                internalCommonSubjectIdentifier.getValue(),
-                userProfile.getPublicSubjectID());
+        if (accountDataApiToken.isPresent() && accountDataApiService != null) {
+            deleteAccountViaDataApi(userProfile.getPublicSubjectID(), accountDataApiToken.get());
+        } else {
+            dynamoDeleteService.deleteAccount(
+                    email,
+                    internalCommonSubjectIdentifier.getValue(),
+                    userProfile.getPublicSubjectID());
+            LOG.info("User account deleted via DynamoDB directly, not via ADAPI");
+        }
 
         if (sendNotification) {
             try {
@@ -149,6 +185,30 @@ public class AccountDeletionService {
             structuredAuditService.submitAuditEvent(auditEvent);
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
+        }
+    }
+
+    private void deleteAccountViaDataApi(String publicSubjectId, String token) {
+        try {
+            var response = accountDataApiService.deleteAccount(publicSubjectId, token);
+            int statusCode = response.statusCode();
+            if (statusCode == 204) {
+                LOG.info("Successfully deleted account via Data API");
+            } else if (statusCode == 404) {
+                LOG.error("Account not found in Data API for publicSubjectId: {}", publicSubjectId);
+                throw new RuntimeException(
+                        "Account not found in Data API for publicSubjectId: " + publicSubjectId);
+            } else {
+                LOG.error(
+                        "Data API returned error status {} when deleting account for publicSubjectId: {}",
+                        statusCode,
+                        publicSubjectId);
+                throw new RuntimeException(
+                        "Data API returned error status " + statusCode + " when deleting account");
+            }
+        } catch (UnsuccessfulAccountDataApiResponseException e) {
+            LOG.error("Failed to call Data API to delete account: {}", e.getMessage());
+            throw new RuntimeException("Failed to delete account via Data API", e);
         }
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -94,7 +94,35 @@ class RemoveAccountHandlerTest {
                         Optional.of(event),
                         userProfile,
                         TXMA_ENCODED_HEADER_VALUE,
-                        AccountDeletionReason.USER_INITIATED);
+                        AccountDeletionReason.USER_INITIATED,
+                        true,
+                        Optional.empty());
+    }
+
+    @Test
+    void shouldPassAdapiTokenWhenHeaderIsPresent() {
+        var userProfile =
+                new UserProfile()
+                        .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
+                        .withSubjectID(INTERNAL_SUBJECT.getValue());
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+
+        var event = generateApiGatewayEvent(expectedCommonSubject);
+        var headers = new HashMap<>(event.getHeaders());
+        headers.put("X-ADAPI-AccessToken", "some-access-token");
+        event.setHeaders(headers);
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+        verify(accountDeletionService)
+                .removeAccount(
+                        Optional.of(event),
+                        userProfile,
+                        TXMA_ENCODED_HEADER_VALUE,
+                        AccountDeletionReason.USER_INITIATED,
+                        true,
+                        Optional.of("some-access-token"));
     }
 
     @Test
@@ -116,7 +144,9 @@ class RemoveAccountHandlerTest {
                         Optional.of(event),
                         userProfile,
                         StructuredAuditService.UNKNOWN,
-                        AccountDeletionReason.USER_INITIATED);
+                        AccountDeletionReason.USER_INITIATED,
+                        true,
+                        Optional.empty());
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -4,10 +4,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -15,15 +17,18 @@ import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,11 +42,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class AccountDeletionServiceTest {
+    public static final String TEST_EMAIL = "test@example.com";
+    public static final String TEST_ADAPI_TOKEN = "test-token";
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final StructuredAuditService structuredAuditService =
@@ -103,7 +111,7 @@ class AccountDeletionServiceTest {
     @Test
     void removeAccountCallsDeleteAccount() throws Json.JsonException {
         // given
-        var expectedEmail = "test@example.com";
+        var expectedEmail = TEST_EMAIL;
         when(userProfile.getEmail()).thenReturn(expectedEmail);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
         when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
@@ -122,7 +130,7 @@ class AccountDeletionServiceTest {
     void removeAccountThrowsIfDeleteAccountFails() {
         // given
         var expectedException = new RuntimeException();
-        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
         doThrow(expectedException).when(dynamoDeleteService).deleteAccount(any(), any(), any());
 
@@ -140,7 +148,7 @@ class AccountDeletionServiceTest {
     @Test
     void removeAccountSendsNotificationEmail() throws Json.JsonException {
         // given
-        var expectedEmail = "test@example.com";
+        var expectedEmail = TEST_EMAIL;
         when(userProfile.getEmail()).thenReturn(expectedEmail);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
 
@@ -164,7 +172,7 @@ class AccountDeletionServiceTest {
     @Test
     void removeAccountSucceedsIfEmailNotificationFails() {
         // given
-        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
         doThrow(new RuntimeException()).when(sqsClient).send(any());
 
@@ -184,9 +192,8 @@ class AccountDeletionServiceTest {
     @EnumSource()
     @ParameterizedTest
     void removeAccountAudits(AccountDeletionReason reason) throws Json.JsonException {
-        var expectedEmail = "test@example.com";
         var expectedPhoneNumber = "+44123456789";
-        when(userProfile.getEmail()).thenReturn(expectedEmail);
+        when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(userProfile.getPhoneNumber()).thenReturn(expectedPhoneNumber);
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
@@ -221,7 +228,7 @@ class AccountDeletionServiceTest {
 
     @Test
     void removeAccountAuditsWithNullLegacySubjectId() throws Json.JsonException {
-        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(userProfile.getPhoneNumber()).thenReturn("+44123456789");
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
@@ -257,7 +264,7 @@ class AccountDeletionServiceTest {
     @Test
     void removeAccountSucceedsIfAuditingFails() {
         // given
-        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
         doThrow(new RuntimeException()).when(structuredAuditService).submitAuditEvent(any());
         // then
@@ -271,5 +278,113 @@ class AccountDeletionServiceTest {
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining("Failed to audit account deletion")));
+    }
+
+    @Nested
+    class DataApiPath {
+        private final AccountDataApiService accountDataApiService =
+                mock(AccountDataApiService.class);
+        private final AccountDeletionService underTestWithDataApi =
+                new AccountDeletionService(
+                        authenticationService,
+                        sqsClient,
+                        structuredAuditService,
+                        configurationService,
+                        dynamoDeleteService,
+                        accountDataApiService);
+
+        @Test
+        void removeAccountCallsDataApiAndSendsNotificationWhenTokenIsPresent()
+                throws Json.JsonException, UnsuccessfulAccountDataApiResponseException {
+            var mockResponse = mock(HttpResponse.class);
+            when(mockResponse.statusCode()).thenReturn(204);
+            when(accountDataApiService.deleteAccount(any(), any())).thenReturn(mockResponse);
+            when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
+            when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+            when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+
+            underTestWithDataApi.removeAccount(
+                    Optional.of(input),
+                    userProfile,
+                    StructuredAuditService.UNKNOWN,
+                    AccountDeletionReason.USER_INITIATED,
+                    true,
+                    Optional.of(TEST_ADAPI_TOKEN));
+
+            verify(accountDataApiService)
+                    .deleteAccount(eq(TEST_PUBLIC_SUBJECT_ID), eq(TEST_ADAPI_TOKEN));
+            verify(dynamoDeleteService, never()).deleteAccount(any(), any(), any());
+
+            var captor = ArgumentCaptor.forClass(String.class);
+            verify(sqsClient).send(captor.capture());
+            var notifyRequest =
+                    SerializationService.getInstance().readValue(captor.getValue(), HashMap.class);
+            assertEquals(TEST_EMAIL, notifyRequest.get("destination"));
+            assertEquals("DELETE_ACCOUNT", notifyRequest.get("notificationType"));
+        }
+
+        @Test
+        void removeAccountFallsBackToDynamoWhenTokenIsEmpty() throws Json.JsonException {
+            when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
+            when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+            when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+
+            underTestWithDataApi.removeAccount(
+                    Optional.of(input),
+                    userProfile,
+                    StructuredAuditService.UNKNOWN,
+                    AccountDeletionReason.USER_INITIATED,
+                    true,
+                    Optional.empty());
+
+            verify(dynamoDeleteService)
+                    .deleteAccount(eq(TEST_EMAIL), any(), eq(TEST_PUBLIC_SUBJECT_ID));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {404, 500})
+        void removeAccountThrowsWhenDataApiReturnsError(int statusCode)
+                throws UnsuccessfulAccountDataApiResponseException {
+            var mockResponse = mock(HttpResponse.class);
+            when(mockResponse.statusCode()).thenReturn(statusCode);
+            when(accountDataApiService.deleteAccount(any(), any())).thenReturn(mockResponse);
+            when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
+            when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+            when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+
+            assertThrows(
+                    RuntimeException.class,
+                    () ->
+                            underTestWithDataApi.removeAccount(
+                                    Optional.of(input),
+                                    userProfile,
+                                    StructuredAuditService.UNKNOWN,
+                                    AccountDeletionReason.USER_INITIATED,
+                                    true,
+                                    Optional.of(TEST_ADAPI_TOKEN)));
+        }
+
+        @Test
+        void removeAccountThrowsWhenDataApiCallFails()
+                throws UnsuccessfulAccountDataApiResponseException {
+            when(accountDataApiService.deleteAccount(any(), any()))
+                    .thenThrow(
+                            new UnsuccessfulAccountDataApiResponseException(
+                                    "Connection failed", new RuntimeException()));
+            when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
+            when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+            when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+
+            assertThrows(
+                    RuntimeException.class,
+                    () ->
+                            underTestWithDataApi.removeAccount(
+                                    Optional.of(input),
+                                    userProfile,
+                                    StructuredAuditService.UNKNOWN,
+                                    AccountDeletionReason.USER_INITIATED,
+                                    true,
+                                    Optional.of(TEST_ADAPI_TOKEN)));
+        }
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
@@ -1,13 +1,23 @@
 package uk.gov.di.accountmanagement.api;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.accountmanagement.entity.NotificationType;
+import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.RemoveAccountRequest;
 import uk.gov.di.accountmanagement.lambda.RemoveAccountHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
@@ -17,12 +27,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_DELETE_ACCOUNT;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
+import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -123,6 +139,95 @@ public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertNoNotificationsReceived(notificationsQueue);
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+
+    @Nested
+    class ViaDataApi {
+        private static final String TOKEN = "test-adapi-access-token";
+        private WireMockServer accountDataApiWireMockServer;
+
+        @BeforeEach
+        void setUp() {
+            accountDataApiWireMockServer =
+                    new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+            accountDataApiWireMockServer.start();
+
+            handler =
+                    new RemoveAccountHandler(
+                            supportPasskeysAndTxmaEnabledConfigurationService(
+                                    "http://localhost:" + accountDataApiWireMockServer.port()));
+
+            txmaAuditQueue.clear();
+            notificationsQueue.clear();
+        }
+
+        @AfterEach
+        void tearDown() {
+            if (accountDataApiWireMockServer != null) {
+                accountDataApiWireMockServer.stop();
+            }
+        }
+
+        @Test
+        void shouldDeleteAccountViaDataApiAndReturn204WhenTokenIsPresent() {
+            var internalCommonSubjectId = setupUserAndRetrieveInternalCommonSubId();
+            var publicSubjectId = userStore.getPublicSubjectIdForEmail(EMAIL);
+
+            accountDataApiWireMockServer.stubFor(
+                    delete(urlPathMatching("/accounts/" + publicSubjectId))
+                            .withHeader("Authorization", WireMock.equalTo("Bearer " + TOKEN))
+                            .willReturn(aResponse().withStatus(204)));
+
+            var response =
+                    makeRequest(
+                            Optional.of(new RemoveAccountRequest(EMAIL)),
+                            Map.of("X-ADAPI-AccessToken", TOKEN),
+                            Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            Map.of("principalId", internalCommonSubjectId));
+
+            assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
+
+            accountDataApiWireMockServer.verify(
+                    1,
+                    deleteRequestedFor(urlPathMatching("/accounts/" + publicSubjectId))
+                            .withHeader("Authorization", WireMock.equalTo("Bearer " + TOKEN)));
+
+            assertTxmaAuditEventsSubmittedWithMatchingNames(
+                    txmaAuditQueue, List.of(AUTH_DELETE_ACCOUNT));
+
+            assertNotificationsReceived(
+                    notificationsQueue,
+                    List.of(
+                            new NotifyRequest(
+                                    EMAIL,
+                                    NotificationType.DELETE_ACCOUNT,
+                                    LocaleHelper.SupportedLanguage.EN)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {404, 500})
+        void shouldReturn500WhenDataApiReturnsError(int dataApiStatusCode) {
+            var internalCommonSubjectId = setupUserAndRetrieveInternalCommonSubId();
+            var publicSubjectId = userStore.getPublicSubjectIdForEmail(EMAIL);
+
+            accountDataApiWireMockServer.stubFor(
+                    delete(urlPathMatching("/accounts/" + publicSubjectId))
+                            .withHeader("Authorization", WireMock.equalTo("Bearer " + TOKEN))
+                            .willReturn(aResponse().withStatus(dataApiStatusCode)));
+
+            var response =
+                    makeRequest(
+                            Optional.of(new RemoveAccountRequest(EMAIL)),
+                            Map.of("X-ADAPI-AccessToken", TOKEN),
+                            Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            Map.of("principalId", internalCommonSubjectId));
+
+            assertThat(response, hasStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+
+            assertTrue(userStore.userExists(EMAIL));
+        }
     }
 
     private String setupUserAndRetrieveInternalCommonSubId() {

--- a/ci/cloudformation/account-management/function/delete-account.yaml
+++ b/ci/cloudformation/account-management/function/delete-account.yaml
@@ -32,6 +32,20 @@ Resources:
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
       LoggingConfig:
         LogGroup: !Ref DeleteAccountFunctionLogGroup
       Policies:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -15,7 +15,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
-import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.httpResponseCodeException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.interruptedException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.ioException;
@@ -25,6 +24,9 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 public class AccountDataApiService {
     private static final Logger LOG = LogManager.getLogger(AccountDataApiService.class);
     private static final int MAX_TRIES = 2;
+    public static final String BEARER = "Bearer ";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String ACCOUNTS_PATH_SEGMENT = "/accounts/";
     private final HttpClient httpClient;
     private final ConfigurationService configurationService;
     private final SerializationService serializationService = SerializationService.getInstance();
@@ -66,10 +68,10 @@ public class AccountDataApiService {
                 HttpRequest.newBuilder(
                                 buildURI(
                                         configurationService.getAccountDataURI(),
-                                        "/accounts/"
+                                        ACCOUNTS_PATH_SEGMENT
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys"))
-                        .header("Authorization", "Bearer " + token)
+                        .header(AUTHORIZATION, BEARER + token)
                         .GET()
                         .timeout(
                                 Duration.ofMillis(
@@ -85,11 +87,27 @@ public class AccountDataApiService {
                 HttpRequest.newBuilder(
                                 buildURI(
                                         configurationService.getAccountDataURI(),
-                                        "/accounts/"
+                                        ACCOUNTS_PATH_SEGMENT
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys/"
                                                 + passkeyId))
-                        .header("Authorization", "Bearer " + token)
+                        .header(AUTHORIZATION, BEARER + token)
+                        .DELETE()
+                        .timeout(
+                                Duration.ofMillis(
+                                        configurationService.getAccountDataApiCallTimeout()))
+                        .build();
+        return sendRequest(request);
+    }
+
+    public HttpResponse<String> deleteAccount(String publicSubjectId, String token)
+            throws UnsuccessfulAccountDataApiResponseException {
+        var request =
+                HttpRequest.newBuilder(
+                                buildURI(
+                                        configurationService.getAccountDataURI(),
+                                        ACCOUNTS_PATH_SEGMENT + publicSubjectId))
+                        .header(AUTHORIZATION, BEARER + token)
                         .DELETE()
                         .timeout(
                                 Duration.ofMillis(
@@ -107,7 +125,7 @@ public class AccountDataApiService {
                 count++;
                 return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             } catch (HttpTimeoutException e) {
-                LOG.warn(format("Timeout on attempt %d when calling Account Data API", count));
+                LOG.warn("Timeout on attempt {} when calling Account Data API", count);
                 if (count >= MAX_TRIES) {
                     throw timeoutException(configurationService.getAccountDataApiCallTimeout(), e);
                 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AccountDataApiServiceTest {
+    public static final String TEST_PUBLIC_SUBJECT_ID = "testPublicSubjectId";
     private AutoCloseable closeable;
 
     @Mock private HttpClient httpClient;
@@ -67,7 +68,7 @@ class AccountDataApiServiceTest {
             when(httpClient.send(any(), any())).thenReturn(null);
 
             // Act
-            service.retrievePasskeysAsJson("testPublicSubjectId", TOKEN);
+            service.retrievePasskeysAsJson(TEST_PUBLIC_SUBJECT_ID, TOKEN);
 
             // Assert
             verify(httpClient).send(httpRequestCaptor.capture(), any());
@@ -75,7 +76,9 @@ class AccountDataApiServiceTest {
                     httpRequestCaptor.getValue().uri(),
                     equalTo(
                             URI.create(
-                                    "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys")));
+                                    String.format(
+                                            "https://example.com/accounts/%s/authenticators/passkeys",
+                                            TEST_PUBLIC_SUBJECT_ID))));
             assertThat(httpRequestCaptor.getValue().method(), equalTo("GET"));
             assertThat(
                     httpRequestCaptor.getValue().headers().firstValue("Authorization").orElse(""),
@@ -94,7 +97,7 @@ class AccountDataApiServiceTest {
             when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
             // Act
-            var resp = service.retrievePasskeysAsJson("testPublicSubjectId", TOKEN);
+            var resp = service.retrievePasskeysAsJson(TEST_PUBLIC_SUBJECT_ID, TOKEN);
 
             // Assert
             assertThat(resp.statusCode(), equalTo(200));
@@ -148,7 +151,7 @@ class AccountDataApiServiceTest {
             when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
             // Act
-            var result = service.retrievePasskeys("testPublicSubjectId", TOKEN);
+            var result = service.retrievePasskeys(TEST_PUBLIC_SUBJECT_ID, TOKEN);
 
             // Assert
             assertThat(result.passkeys().size(), equalTo(2));
@@ -173,7 +176,7 @@ class AccountDataApiServiceTest {
 
             assertThrows(
                     UnsuccessfulAccountDataApiResponseException.class,
-                    () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
+                    () -> service.retrievePasskeys(TEST_PUBLIC_SUBJECT_ID, TOKEN));
         }
     }
 
@@ -189,7 +192,7 @@ class AccountDataApiServiceTest {
             when(httpClient.send(any(), any())).thenReturn(null);
 
             // Act
-            service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
+            service.deletePasskey(TEST_PUBLIC_SUBJECT_ID, "testPasskeyId", TOKEN);
 
             // Assert
             verify(httpClient).send(httpRequestCaptor.capture(), any());
@@ -197,7 +200,9 @@ class AccountDataApiServiceTest {
                     httpRequestCaptor.getValue().uri(),
                     equalTo(
                             URI.create(
-                                    "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys/testPasskeyId")));
+                                    String.format(
+                                            "https://example.com/accounts/%s/authenticators/passkeys/testPasskeyId",
+                                            TEST_PUBLIC_SUBJECT_ID))));
             assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
             assertThat(
                     httpRequestCaptor.getValue().headers().firstValue("Authorization").orElse(""),
@@ -216,11 +221,56 @@ class AccountDataApiServiceTest {
             when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
             // Act
-            var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
+            var resp = service.deletePasskey(TEST_PUBLIC_SUBJECT_ID, "testPasskeyId", TOKEN);
 
             // Assert
             assertThat(resp.statusCode(), equalTo(200));
             assertThat(resp.body(), equalTo("{'deleted': true}"));
+        }
+    }
+
+    @Nested
+    class DeleteAccount {
+        @Test
+        void shouldBuildCorrectRequestUri()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+            when(httpClient.send(any(), any())).thenReturn(null);
+
+            // Act
+            service.deleteAccount(TEST_PUBLIC_SUBJECT_ID, TOKEN);
+
+            // Assert
+            verify(httpClient).send(httpRequestCaptor.capture(), any());
+            assertThat(
+                    httpRequestCaptor.getValue().uri(),
+                    equalTo(URI.create("https://example.com/accounts/" + TEST_PUBLIC_SUBJECT_ID)));
+            assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
+            assertThat(
+                    httpRequestCaptor.getValue().headers().firstValue("Authorization").orElse(""),
+                    equalTo("Bearer " + TOKEN));
+        }
+
+        @Test
+        void shouldReturnVerbatimHttpResponse()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(204);
+            when(mockHttpResponse.body()).thenReturn("");
+            when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
+
+            // Act
+            var resp = service.deleteAccount(TEST_PUBLIC_SUBJECT_ID, TOKEN);
+
+            // Assert
+            assertThat(resp.statusCode(), equalTo(204));
+            assertThat(resp.body(), equalTo(""));
         }
     }
 
@@ -339,15 +389,17 @@ class AccountDataApiServiceTest {
 
     enum PasskeysMethod {
         RETRIEVE_PASSKEYS,
-        DELETE_PASSKEY;
+        DELETE_PASSKEY,
+        DELETE_ACCOUNT;
 
         void call(AccountDataApiService service)
                 throws UnsuccessfulAccountDataApiResponseException {
             switch (this) {
                 case RETRIEVE_PASSKEYS -> service.retrievePasskeysAsJson(
-                        "testPublicSubjectId", TOKEN);
+                        TEST_PUBLIC_SUBJECT_ID, TOKEN);
                 case DELETE_PASSKEY -> service.deletePasskey(
-                        "testPublicSubjectId", "testPasskeyId", TOKEN);
+                        TEST_PUBLIC_SUBJECT_ID, "testPasskeyId", TOKEN);
+                case DELETE_ACCOUNT -> service.deleteAccount(TEST_PUBLIC_SUBJECT_ID, TOKEN);
             }
         }
     }


### PR DESCRIPTION
## What

Move the remove `{env}-delete-account-lambda` to call ADAPI to delete an account rather than interacting with DynamoDB directly. The manual delete and bulk user delete lambdas will follow. Until then, the ADAPI request is only made _if_ a token is present. After we've migrated those lambdas over as well, we will require the presence of a token.

## How to review

1. Code Review
2. Calculate your ICS using the authentication-api `export-ics.sh` script
3. Create the ADAPI token using the following shell commands:

```
export AUTH_TO_ACCOUNT_DATA_SIGNING_KEY="alias/authdev2-auth-to-account-data-signing-key"
export AUTH_TO_ACCOUNT_DATA_API_AUDIENCE="https://account.authdev2.dev.account.gov.uk"
export AUTH_ISSUER_CLAIM="https://signin.authdev2.dev.account.gov.uk"
export AMC_CLIENT_ID="auth"

aws sso login --profile di-authentication-development-AdministratorAccessPermission && eval "$(aws configure export-credentials --profile di-authentication-development-AdministratorAccessPermission --format env)"

python3 ./account-data-api/scripts/generate_account_data_token.py \
    --public-subject-id="<your public subject ID>" \
    --scope "account-delete" \
    --profile di-authentication-development-AdministratorAccessPermission
```
4. Make a request in the {env}-delete-account-lambda test area using the following request template:
```
  {
    "resource": "/delete-account",
    "path": "/delete-account",
    "httpMethod": "POST",
    "headers": {
      "X-ADAPI-AccessToken": "<token retrieved from step 3"
    },
    "requestContext": {
      "requestId": "test-123",
      "authorizer": {
        "principalId": "<ICS calculated in step 2>"
      },
      "identity": {
        "sourceIp": "127.0.0.1"
      }
    },
    "body": "{\"email\": \"<your email>\"}",
    "isBase64Encoded": false
  }
```
5. See the "Successfully deleted account via Data API" message in the lambda logs


## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
