### PR TITLE
Bau: Add flattap

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
@@ -66,9 +66,9 @@ public class PasskeysCreateHandler
         LOG.info("PasskeysCreateHandler called");
 
         return parseRequest(input)
-                .flatMap(createContext -> validateAuthorizedSubjectId(createContext, input))
-                .flatMap(createContext -> validateScope(createContext, input))
-                .flatMap(this::validateRequest)
+                .flatTap(createContext -> validateAuthorizedSubjectId(createContext, input))
+                .flatTap(createContext -> validateScope(input))
+                .flatTap(this::validateRequest)
                 .flatMap(this::createPasskey)
                 .fold(
                         failure ->
@@ -110,26 +110,26 @@ public class PasskeysCreateHandler
         return Result.success(new PasskeysCreateContext(publicSubjectId, passkeysCreateRequest));
     }
 
-    private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateAuthorizedSubjectId(
+    private Result<PasskeysCreateFailureReason, Void> validateAuthorizedSubjectId(
             PasskeysCreateContext context, APIGatewayProxyRequestEvent input) {
         if (isSubjectIdAuthorized(context.publicSubjectId(), input.getRequestContext())) {
-            return Result.success(context);
+            return Result.emptySuccess();
         } else {
             LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
             return Result.failure(UNAUTHORIZED_REQUEST);
         }
     }
 
-    private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateScope(
-            PasskeysCreateContext context, APIGatewayProxyRequestEvent input) {
+    private Result<PasskeysCreateFailureReason, Void> validateScope(
+            APIGatewayProxyRequestEvent input) {
         if (isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, input.getRequestContext())) {
-            return Result.success(context);
+            return Result.emptySuccess();
         } else {
             return Result.failure(UNAUTHORIZED_REQUEST);
         }
     }
 
-    private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateRequest(
+    private Result<PasskeysCreateFailureReason, Void> validateRequest(
             PasskeysCreateContext context) {
         var passkeysCreateRequest = context.passkeysCreateRequest();
 
@@ -137,7 +137,7 @@ public class PasskeysCreateHandler
             return Result.failure(INVALID_AAGUID);
         }
 
-        return Result.success(context);
+        return Result.emptySuccess();
     }
 
     private Result<PasskeysCreateFailureReason, Void> createPasskey(PasskeysCreateContext context) {

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysCreateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
 import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
@@ -69,7 +70,11 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             -7);
-            when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
+            var requestAsObject =
+                    SerializationService.getInstance()
+                            .readValue(
+                                    passkeysCreateRequestBody, PasskeysCreateRequest.class, true);
+            when(passkeysService.createPasskey(requestAsObject, PUBLIC_SUBJECT_ID))
                     .thenReturn(Result.success(null));
             var request =
                     passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -20,8 +20,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -108,6 +111,7 @@ class PasskeysCreateHandlerTest {
             // Then
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_REQUEST_BODY));
+            verify(passkeysService, never()).createPasskey(any(), anyString());
         }
 
         @Test
@@ -135,6 +139,7 @@ class PasskeysCreateHandlerTest {
             // Then
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_REQUEST_BODY));
+            verify(passkeysService, never()).createPasskey(any(), anyString());
         }
 
         @Test
@@ -162,6 +167,7 @@ class PasskeysCreateHandlerTest {
             // Then
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.MISSING_SUBJECT_ID));
+            verify(passkeysService, never()).createPasskey(any(), anyString());
         }
 
         @Test
@@ -247,6 +253,7 @@ class PasskeysCreateHandlerTest {
             // Then
             assertThat(result, hasStatus(422));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AAGUID));
+            verify(passkeysService, never()).createPasskey(any(), anyString());
         }
 
         @Test
@@ -274,6 +281,7 @@ class PasskeysCreateHandlerTest {
             // Then
             assertThat(result, hasStatus(422));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AAGUID));
+            verify(passkeysService, never()).createPasskey(any(), anyString());
         }
     }
 
@@ -308,6 +316,7 @@ class PasskeysCreateHandlerTest {
         // Then
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        verify(passkeysService, never()).createPasskey(any(), anyString());
     }
 
     @Test
@@ -338,6 +347,7 @@ class PasskeysCreateHandlerTest {
         // Then
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        verify(passkeysService, never()).createPasskey(any(), anyString());
     }
 
     private String buildPasskeysCreateRequestBody(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
@@ -50,6 +50,8 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
 
     Result<F, S> tapFailure(Consumer<F> action);
 
+    Result<F, S> flatTap(Function<S, Result<F, ?>> action);
+
     record Failure<F, S>(F value) implements Result<F, S> {
         @Override
         public boolean isFailure() {
@@ -99,6 +101,11 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
         @Override
         public Result<F, S> tapFailure(Consumer<F> action) {
             action.accept(this.value());
+            return this;
+        }
+
+        @Override
+        public Result<F, S> flatTap(Function<S, Result<F, ?>> action) {
             return this;
         }
     }
@@ -152,6 +159,15 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
 
         @Override
         public Result<F, S> tapFailure(Consumer<F> action) {
+            return this;
+        }
+
+        @Override
+        public Result<F, S> flatTap(Function<S, Result<F, ?>> action) {
+            Result<F, ?> result = action.apply(value);
+            if (result.isFailure()) {
+                return new Failure<>(result.getFailure());
+            }
             return this;
         }
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
@@ -321,4 +321,123 @@ class ResultTest {
             assertEquals(expected, logsEmitted.get(0));
         }
     }
+
+    @Nested
+    class FlatTapTests {
+        private ArrayList<String> logsEmitted;
+
+        private Result<String, Boolean> addToLogsReturningSuccess(String logMessage) {
+            return Result.success(logsEmitted.add(logMessage));
+        }
+
+        private Result<String, Boolean> addToLogsReturningFailure(
+                String logMessage, String failureMessage) {
+            logsEmitted.add(logMessage);
+            return Result.failure(failureMessage);
+        }
+
+        @BeforeEach
+        void setup() {
+            logsEmitted = new ArrayList<>();
+        }
+
+        @Test
+        void flatTapShouldExecuteActionAndReturnOriginalSuccessWhenActionSucceeds() {
+            var successValue = 42;
+            var originalSuccess = Result.<String, Integer>success(successValue);
+
+            var result =
+                    originalSuccess.flatTap(
+                            i -> addToLogsReturningSuccess(String.format("Processing %d", i)));
+
+            assertEquals(1, logsEmitted.size());
+            assertEquals("Processing 42", logsEmitted.get(0));
+            assertEquals(originalSuccess, result);
+            assertTrue(result.isSuccess());
+            assertEquals(successValue, result.getSuccess());
+        }
+
+        @Test
+        void flatTapShouldPropagateFailureWhenActionFails() {
+            var successValue = 42;
+            var originalSuccess = Result.<String, Integer>success(successValue);
+            var actionFailureMessage = "action failed";
+
+            var result =
+                    originalSuccess.flatTap(
+                            i ->
+                                    addToLogsReturningFailure(
+                                            String.format("Processing %d", i),
+                                            actionFailureMessage));
+
+            assertEquals(1, logsEmitted.size());
+            assertEquals("Processing 42", logsEmitted.get(0));
+            assertTrue(result.isFailure());
+            assertEquals(actionFailureMessage, result.getFailure());
+        }
+
+        @Test
+        void flatTapShouldNotExecuteActionOnFailureAndReturnOriginalFailure() {
+            var failureValue = "original failure";
+            var originalFailure = Result.<String, Integer>failure(failureValue);
+
+            var result =
+                    originalFailure.flatTap(
+                            i -> addToLogsReturningSuccess(String.format("Processing %d", i)));
+
+            assertEquals(0, logsEmitted.size());
+            assertEquals(originalFailure, result);
+            assertTrue(result.isFailure());
+            assertEquals(failureValue, result.getFailure());
+        }
+
+        @Test
+        void flatTapShouldReturnOriginalSuccessNotActionSuccessValue() {
+            var successValue = "original";
+            var originalSuccess = Result.<String, String>success(successValue);
+
+            var result =
+                    originalSuccess.flatTap(
+                            s -> Result.success("different success value that should be ignored"));
+
+            assertTrue(result.isSuccess());
+            assertEquals(successValue, result.getSuccess());
+        }
+
+        @Test
+        void flatTapShouldChainMultipleActionsCorrectly() {
+            var successValue = 10;
+            var originalSuccess = Result.<String, Integer>success(successValue);
+
+            var result =
+                    originalSuccess
+                            .flatTap(s -> addToLogsReturningSuccess("first action"))
+                            .flatTap(s -> addToLogsReturningSuccess("second action"));
+
+            assertEquals(2, logsEmitted.size());
+            assertEquals("first action", logsEmitted.get(0));
+            assertEquals("second action", logsEmitted.get(1));
+            assertEquals(originalSuccess, result);
+        }
+
+        @Test
+        void flatTapShouldShortCircuitOnFirstFailureInChain() {
+            var successValue = 10;
+            var originalSuccess = Result.<String, Integer>success(successValue);
+
+            var failureMessageForFirstAction = "first failed";
+            var result =
+                    originalSuccess
+                            .flatTap(
+                                    i ->
+                                            addToLogsReturningFailure(
+                                                    "first action", failureMessageForFirstAction))
+                            .flatTap(s -> addToLogsReturningSuccess("second action"));
+
+            assertEquals(1, logsEmitted.size());
+            assertEquals("first action", logsEmitted.get(0));
+            assertTrue(result.isFailure());
+            assertEquals(failureMessageForFirstAction, result.getFailure());
+        }
+    }
 }


### PR DESCRIPTION
Adds a new method `flatTap` on the result type. 

This allows for further chaining of results. Like the tap method, the intention of flatTap is to perform some action but return the original result it was chained on to. But in this case we pass in a function which returns a result rather than void.

When performed on a success result:
* If the result of the function passed into flatTap is a success, return the original success result
* If it's a failure, return the new failure

When performed on a failure result:
* Do not do anything and return the original failure

In this PR, we also use this in one case to demonstrate.