### PR TITLE
AUT-5724: Add max re-invocation limit to IAD data export Lambda

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -81,6 +81,12 @@ Resources:
               !Ref Environment,
               inactiveAccountExportBatchWriteMaxRetries,
             ]
+          INACTIVE_ACCOUNT_EXPORT_MAX_INVOCATIONS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              inactiveAccountExportMaxInvocations,
+            ]
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -193,6 +193,7 @@ Mappings:
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev1-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "20"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -233,6 +234,7 @@ Mappings:
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev2-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "20"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -273,6 +275,7 @@ Mappings:
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev3-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "20"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -313,6 +316,7 @@ Mappings:
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "dev-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "20"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
@@ -353,6 +357,7 @@ Mappings:
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableName: "build-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "0"
 
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
@@ -395,6 +400,7 @@ Mappings:
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:539729775994:key/5191526d-1c85-4316-baf7-9fbe373880cf
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "0"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
@@ -437,6 +443,7 @@ Mappings:
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:666500506359:key/1ab2a72b-63e0-49b6-b88a-5160a7d27985
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "0"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
@@ -479,6 +486,7 @@ Mappings:
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:026991849909:key/5489c67b-2c14-4b76-b6a3-a25148b14311
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
+      inactiveAccountExportMaxInvocations: "0"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -267,6 +267,11 @@ public class ConfigurationService
                         .getOrDefault("INACTIVE_ACCOUNT_EXPORT_BATCH_WRITE_MAX_RETRIES", "0"));
     }
 
+    public int getInactiveAccountExportMaxInvocations() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_MAX_INVOCATIONS", "0"));
+    }
+
     public String getTicfCRILambdaIdentifier() {
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -224,6 +224,11 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getInactiveAccountExportMaxInvocationsShouldDefault() {
+        assertEquals(0, configurationService.getInactiveAccountExportMaxInvocations());
+    }
+
+    @Test
     void getTicfCRILambdaNameShouldDefault() {
         assertEquals("", configurationService.getTicfCRILambdaIdentifier());
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
@@ -7,4 +7,5 @@ import java.util.Map;
 public record InactiveAccountDataExportRequest(
         @Expose Map<Integer, Map<String, String>> segmentKeys,
         @Expose Long processedCount,
-        @Expose Long writtenCount) {}
+        @Expose Long writtenCount,
+        @Expose Long invocationCount) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -110,6 +110,10 @@ public class InactiveAccountDataExportHandler
                 request != null && request.processedCount() != null ? request.processedCount() : 0L;
         long writtenCount =
                 request != null && request.writtenCount() != null ? request.writtenCount() : 0L;
+        long invocationCount =
+                request != null && request.invocationCount() != null
+                        ? request.invocationCount()
+                        : 0L;
 
         Map<Integer, Map<String, AttributeValue>> activeSegments =
                 resolveActiveSegments(request, totalSegments);
@@ -178,7 +182,7 @@ public class InactiveAccountDataExportHandler
                     remainingSegmentKeys.size());
 
             if (!remainingSegmentKeys.isEmpty()) {
-                selfInvoke(remainingSegmentKeys, processedCount, writtenCount);
+                selfInvoke(remainingSegmentKeys, processedCount, writtenCount, invocationCount);
             }
 
             return new InactiveAccountDataExportResponse(processedCount, writtenCount);
@@ -207,7 +211,8 @@ public class InactiveAccountDataExportHandler
     private void selfInvoke(
             Map<Integer, Map<String, String>> remainingSegmentKeys,
             long processedCount,
-            long writtenCount) {
+            long writtenCount,
+            long invocationCount) {
         if (lambdaName == null || lambdaName.isEmpty()) {
             throw new RuntimeException(
                     "INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME not set, cannot self-invoke");
@@ -215,9 +220,11 @@ public class InactiveAccountDataExportHandler
 
         LambdaPauseHelper.pauseBetweenInvocations(pauseBetweenInvocationsMs);
 
+        long nextInvocationCount = invocationCount + 1;
+
         var continuationRequest =
                 new InactiveAccountDataExportRequest(
-                        remainingSegmentKeys, processedCount, writtenCount, null);
+                        remainingSegmentKeys, processedCount, writtenCount, nextInvocationCount);
 
         String payload;
         try {
@@ -227,9 +234,10 @@ public class InactiveAccountDataExportHandler
         }
 
         LOG.info(
-                "Self-invoking with {} remaining segments, processedCount={}",
+                "Self-invoking with {} remaining segments, processedCount={}, invocationCount={}",
                 remainingSegmentKeys.size(),
-                processedCount);
+                processedCount,
+                nextInvocationCount);
 
         try {
             lambdaInvokerService.invokeAsyncWithPayload(payload, lambdaName);

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -68,6 +68,7 @@ public class InactiveAccountDataExportHandler
     private final int maxItemsPerSegment;
     private final long pauseBetweenInvocationsMs;
     private final String lambdaName;
+    private final int maxInvocations;
 
     public InactiveAccountDataExportHandler(
             ConfigurationService configurationService,
@@ -89,6 +90,7 @@ public class InactiveAccountDataExportHandler
         this.pauseBetweenInvocationsMs =
                 configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
         this.lambdaName = configurationService.getInactiveAccountExportLambdaName();
+        this.maxInvocations = configurationService.getInactiveAccountExportMaxInvocations();
     }
 
     public InactiveAccountDataExportHandler() {
@@ -114,6 +116,18 @@ public class InactiveAccountDataExportHandler
                 request != null && request.invocationCount() != null
                         ? request.invocationCount()
                         : 0L;
+
+        if (invocationCount >= maxInvocations) {
+            LOG.warn(
+                    "INACTIVE_ACCOUNT_DATA_EXPORT_MAX_INVOCATIONS_EXCEEDED: invocationCount={} "
+                            + "has reached or exceeded maxInvocations={}, halting self-invocation "
+                            + "chain. processedCount={}, writtenCount={}",
+                    invocationCount,
+                    maxInvocations,
+                    processedCount,
+                    writtenCount);
+            return new InactiveAccountDataExportResponse(processedCount, writtenCount);
+        }
 
         Map<Integer, Map<String, AttributeValue>> activeSegments =
                 resolveActiveSegments(request, totalSegments);

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -217,7 +217,7 @@ public class InactiveAccountDataExportHandler
 
         var continuationRequest =
                 new InactiveAccountDataExportRequest(
-                        remainingSegmentKeys, processedCount, writtenCount);
+                        remainingSegmentKeys, processedCount, writtenCount, null);
 
         String payload;
         try {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -95,7 +95,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -111,7 +111,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -127,7 +127,7 @@ class InactiveAccountDataExportHandlerTest {
                                 .build());
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         assertThrows(DynamoDbException.class, () -> handler.handleRequest(request, context));
     }
@@ -139,7 +139,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -195,7 +195,7 @@ class InactiveAccountDataExportHandlerTest {
                         });
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -250,7 +250,7 @@ class InactiveAccountDataExportHandlerTest {
                         });
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -264,7 +264,7 @@ class InactiveAccountDataExportHandlerTest {
         mockScanWithPagination(0, 1);
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -279,7 +279,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -294,7 +294,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -311,7 +311,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -329,7 +329,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -402,7 +402,7 @@ class InactiveAccountDataExportHandlerTest {
         Map<Integer, Map<String, String>> segmentKeys = new HashMap<>();
         segmentKeys.put(1, Map.of("Email", "user5@example.com"));
 
-        var request = new InactiveAccountDataExportRequest(segmentKeys, 100L, 0L);
+        var request = new InactiveAccountDataExportRequest(segmentKeys, 100L, 0L, null);
         var response = handler.handleRequest(request, context);
 
         assertEquals(105, response.processedCount());
@@ -417,7 +417,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, 500L, 0L);
+        var request = new InactiveAccountDataExportRequest(null, 500L, 0L, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -431,13 +431,14 @@ class InactiveAccountDataExportHandlerTest {
 
         var request =
                 new InactiveAccountDataExportRequest(
-                        Map.of(0, Map.of("Email", "user5@example.com")), 100L, 0L);
+                        Map.of(0, Map.of("Email", "user5@example.com")), 100L, 0L, 2L);
 
         String json = gson.toJson(request);
         var deserialised = gson.fromJson(json, InactiveAccountDataExportRequest.class);
 
         assertEquals(request.processedCount(), deserialised.processedCount());
         assertEquals(request.writtenCount(), deserialised.writtenCount());
+        assertEquals(request.invocationCount(), deserialised.invocationCount());
         assertEquals(
                 request.segmentKeys().get(0).get("Email"),
                 deserialised.segmentKeys().get(0).get("Email"));
@@ -452,6 +453,7 @@ class InactiveAccountDataExportHandlerTest {
         assertNull(deserialised.segmentKeys());
         assertNull(deserialised.processedCount());
         assertNull(deserialised.writtenCount());
+        assertNull(deserialised.invocationCount());
     }
 
     @Test
@@ -463,7 +465,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         handler.handleRequest(request, context);
 
@@ -479,7 +481,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         handler.handleRequest(request, context);
 
@@ -495,7 +497,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, 100L, 0L);
+        var request = new InactiveAccountDataExportRequest(null, 100L, 0L, null);
 
         handler.handleRequest(request, context);
 
@@ -549,7 +551,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         handler.handleRequest(request, context);
 
@@ -581,7 +583,7 @@ class InactiveAccountDataExportHandlerTest {
                 .invokeAsyncWithPayload(any(), any());
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         assertThrows(RuntimeException.class, () -> handler.handleRequest(request, context));
     }
@@ -596,7 +598,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, null, null);
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         assertThrows(RuntimeException.class, () -> handler.handleRequest(request, context));
     }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -68,6 +69,7 @@ class InactiveAccountDataExportHandlerTest {
         when(configurationService.getInactiveAccountExportTableName())
                 .thenReturn("test-tracker-table");
         when(configurationService.getInactiveAccountExportBatchWriteMaxRetries()).thenReturn(3);
+        when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(1000);
         when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
                 .thenReturn(BatchWriteItemResponse.builder().build());
     }
@@ -501,7 +503,7 @@ class InactiveAccountDataExportHandlerTest {
 
         handler.handleRequest(request, context);
 
-        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        var payloadCaptor = ArgumentCaptor.forClass(String.class);
         verify(lambdaInvokerService)
                 .invokeAsyncWithPayload(
                         payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
@@ -529,7 +531,7 @@ class InactiveAccountDataExportHandlerTest {
 
         handler.handleRequest(request, context);
 
-        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        var payloadCaptor = ArgumentCaptor.forClass(String.class);
         verify(lambdaInvokerService)
                 .invokeAsyncWithPayload(
                         payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
@@ -581,7 +583,7 @@ class InactiveAccountDataExportHandlerTest {
 
         handler.handleRequest(request, context);
 
-        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        var payloadCaptor = ArgumentCaptor.forClass(String.class);
         verify(lambdaInvokerService)
                 .invokeAsyncWithPayload(
                         payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
@@ -627,6 +629,54 @@ class InactiveAccountDataExportHandlerTest {
         var request = new InactiveAccountDataExportRequest(null, null, null, null);
 
         assertThrows(RuntimeException.class, () -> handler.handleRequest(request, context));
+    }
+
+    @Test
+    void shouldReturnEarlyOnFirstInvocationWhenMaxInvocationsIsZero() {
+        when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(0);
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertNotNull(response);
+        verify(client, never()).scan(any(ScanRequest.class));
+        verify(lambdaInvokerService, never()).invokeAsyncWithPayload(any(), any());
+    }
+
+    @Test
+    void shouldAllowInvocationOneBelowMaxInvocationsLimit() {
+        when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(3);
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, 100L, 0L, 2L);
+
+        handler.handleRequest(request, context);
+
+        verify(lambdaInvokerService)
+                .invokeAsyncWithPayload(any(), eq("test-inactive-account-data-export-lambda"));
+    }
+
+    @Test
+    void shouldReturnEarlyWhenMaxInvocationsExceeded() {
+        when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(3);
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, 100L, 0L, 3L);
+
+        var response = handler.handleRequest(request, context);
+
+        assertNotNull(response);
+        assertEquals(100L, response.processedCount());
+        assertEquals(0L, response.writtenCount());
+        verify(client, never()).scan(any(ScanRequest.class));
+        verify(lambdaInvokerService, never()).invokeAsyncWithPayload(any(), any());
     }
 
     private Map<String, AttributeValue> createItem(int index) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -497,7 +497,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, 100L, 0L, null);
+        var request = new InactiveAccountDataExportRequest(null, 100L, 0L, 3L);
 
         handler.handleRequest(request, context);
 
@@ -513,6 +513,32 @@ class InactiveAccountDataExportHandlerTest {
         assertNotNull(continuation.segmentKeys());
         assertEquals(105, continuation.processedCount());
         assertEquals(5, continuation.writtenCount());
+        assertEquals(4L, continuation.invocationCount());
+    }
+
+    @Test
+    void shouldSelfInvokeWithInvocationCountOneWhenFirstInvocationHasNoCount() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
+
+        handler.handleRequest(request, context);
+
+        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(lambdaInvokerService)
+                .invokeAsyncWithPayload(
+                        payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
+
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        var continuation =
+                gson.fromJson(payloadCaptor.getValue(), InactiveAccountDataExportRequest.class);
+
+        assertEquals(1L, continuation.invocationCount());
     }
 
     @Test


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Adds a max re-invocation limit to IAD data export Lambda as a safeguard to halt the self-invocation chain.

Details of how the re-invocation works can be found in:
- The original PR description: https://github.com/govuk-one-login/authentication-api/pull/8624
- The ADR for this IAD data export Lambda: https://github.com/govuk-one-login/authentication-api/blob/main/docs/adr/0006-inactive-account-deletion-data-export.md

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the utils module to a dev environment, update the new limit env var through the console to a low value, then make a test request to the *-inactive-account-data-export-lambda Lambda to scan the dev tables - the run should be aborted a few re-invocations in due to the limit.
    - I have followed these steps - see "Testing" section below

## Testing

Deployed the `utils` module to authdev1, set the new limit env var to `3` and made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev table with an empty payload (`{}`).

Observed the scan happening over multiple Lambda invocations, self-invocation chain halted after the expected 3 invocations, observed the following warn log (expected):

<img width="1318" height="68" alt="warn log when limit exceeded" src="https://github.com/user-attachments/assets/91fcf106-a2e2-4e95-bc5d-3088cda37db2" />

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils lambda only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils lambda only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required) **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Implement self re-invocation for inactive account data export lambda: https://github.com/govuk-one-login/authentication-api/pull/8624