### PR TITLE
BAU: Extract deploy workflow version info to a composite action

### DIFF
--- a/.github/actions/extract-version-info/action.yml
+++ b/.github/actions/extract-version-info/action.yml
@@ -1,0 +1,23 @@
+name: "Extract version info"
+description: "Extracts PR number and commit message to build a version string"
+
+outputs:
+  version:
+    description: "The version string (PR number + commit message or short SHA + message)"
+    value: ${{ steps.version_info.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract PR number and commit message
+      id: version_info
+      shell: bash
+      run: |
+        HEAD_MESSAGE=$(git log -1 --format=%s)
+        SHORT_SHA=$(git rev-parse --short HEAD)
+        if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
+          VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
+        else
+          VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
+        fi
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-api-account-data-sp.yml
+++ b/.github/workflows/deploy-api-account-data-sp.yml
@@ -107,17 +107,9 @@ jobs:
           sam validate --lint -t ad-template.yaml
           sam build --parallel -t ad-template.yaml
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0

--- a/.github/workflows/deploy-api-account-management-sp.yml
+++ b/.github/workflows/deploy-api-account-management-sp.yml
@@ -106,17 +106,9 @@ jobs:
           sam validate --lint -t am-template.yaml
           sam build --parallel -t am-template.yaml
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0

--- a/.github/workflows/deploy-api-auth-sp.yml
+++ b/.github/workflows/deploy-api-auth-sp.yml
@@ -103,17 +103,9 @@ jobs:
           sam validate --lint -t auth-template.yaml
           sam build --parallel -t auth-template.yaml
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0

--- a/.github/workflows/deploy-api-stubs-sp.yml
+++ b/.github/workflows/deploy-api-stubs-sp.yml
@@ -106,17 +106,9 @@ jobs:
           sam validate --lint -t stubs-template.yaml
           sam build --parallel -t stubs-template.yaml
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0

--- a/.github/workflows/deploy-api-utils-sp.yml
+++ b/.github/workflows/deploy-api-utils-sp.yml
@@ -106,17 +106,9 @@ jobs:
           sam validate --lint -t utils-template.yaml
           sam build --parallel -t utils-template.yaml
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0

--- a/.github/workflows/deploy-auth-api-combined-dev-sp.yml
+++ b/.github/workflows/deploy-auth-api-combined-dev-sp.yml
@@ -93,17 +93,9 @@ jobs:
           sam validate --lint -t $TEMPLATE_FILE
           sam build --parallel -t $TEMPLATE_FILE
 
-      - name: Extract PR number and commit message
+      - name: Extract version info
         id: version_info
-        run: |
-          HEAD_MESSAGE=$(git log -1 --format=%s)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "$HEAD_MESSAGE" =~ \(#([0-9]+)\) ]]; then
-            VERSION="#${BASH_REMATCH[1]} - ${HEAD_MESSAGE}"
-          else
-            VERSION="${SHORT_SHA}${HEAD_MESSAGE:+: $HEAD_MESSAGE}"
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/extract-version-info
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf # v4.1.0


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Adds a reusable composite action for extracting version info
- Updates dev and live action extraction steps to this new composite action

Composite action docs for further reading: https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Ensure the dev GitHub action job runs as expected

## Testing

Ran the dev action that was updated ([job log](https://github.com/govuk-one-login/authentication-api/actions/runs/31379159850/job/93425177429)) and checked that the "Extract version info" step worked as expected (it did) and referenced the new composite action (`extract-version-info`):

<img width="928" height="736" alt="Example job dev passing with changes" src="https://github.com/user-attachments/assets/e6862dcf-6f08-4b9a-950b-71560b5de9ad" />

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, deploy workflow change only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, deploy workflow change only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, deploy workflow change only**