### PR TITLE
AUT-5264: Add checkov CloudFormation scanning for migrated API templates

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -77,3 +77,70 @@ jobs:
         with:
           sarif_file: results.sarif
           category: orch-sam
+
+  scan-api-sam:
+    strategy:
+      matrix:
+        template:
+          - {
+              source_dir: "ci/cloudformation/auth",
+              file: "auth-template.yaml",
+              category: "auth-sam",
+            }
+          - {
+              source_dir: "ci/cloudformation/account-management",
+              file: "am-template.yaml",
+              category: "am-sam",
+            }
+          - {
+              source_dir: "ci/cloudformation/account-data",
+              file: "ad-template.yaml",
+              category: "ad-sam",
+            }
+          - {
+              source_dir: "ci/cloudformation/utils",
+              file: "utils-template.yaml",
+              category: "utils-sam",
+            }
+          - {
+              source_dir: "ci/cloudformation/stubs",
+              file: "stubs-template.yaml",
+              category: "stubs-sam",
+            }
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rain
+        uses: ./.github/actions/install-rain
+        with:
+          version: "v1.23.0"
+          arch: "linux-amd64"
+          sha256: "2fdfe059566acf15ad23e014a7856e88f6af61710854208a93526eec80f4078f"
+
+      - name: Merge templates
+        run: "./scripts/merge-templates.sh"
+        env:
+          TEMPLATE_SOURCE_DIR: ${{ matrix.template.source_dir }}
+          TEMPLATE_FILE: ${{ matrix.template.file }}
+
+      - name: Checkov GitHub Action
+        uses: bridgecrewio/checkov-action@dfb51aed1b783289b0d3f255028e7a88d5e8caa1 # v12.3105.0
+        with:
+          file: ${{ matrix.template.file }}
+          framework: cloudformation
+          quiet: true
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+          external_checks_dirs: checkov-policies
+
+      - name: Upload SARIF file
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.25.12v3
+        with:
+          sarif_file: results.sarif
+          category: ${{ matrix.template.category }}

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -134,6 +134,7 @@ jobs:
           file: ${{ matrix.template.file }}
           framework: cloudformation
           quiet: true
+          soft_fail: true
           output_format: cli,sarif
           output_file_path: console,results.sarif
           external_checks_dirs: checkov-policies

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "ci/terraform/**"
       - "template.yaml"
+      - "ci/cloudformation/**"
       - "checkov-policies/**"
   pull_request:
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - "ci/terraform/**"
       - "template.yaml"
+      - "ci/cloudformation/**"
       - "checkov-policies/**"
       - ".github/workflows/checkov.yml"
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The checkov workflow was only scanning TF modules and the orchestration template, but not the CF/SAM templates for API components that have been migrated to SAM.
  
This adds a new `scan-api-sam` job that:

1. Installs Rain and runs `merge-templates.sh` to generate the merged templates from `ci/cloudformation/`
1. Runs checkov against the merged output templates:
    - `auth-template.yaml`
    - `am-template.yaml`
    - `ad-template.yaml`
    - `utils-template.yaml`
    - `stubs-template.yaml`
  
This uses the same configuration as `scan-orch` (CF framework, custom checkov-policies, SARIF upload) and updates the paths trigger to run on `ci/cloudformation/**` changes.

Note on checkov "1 configuration not found" warning for test-services ([example run](https://github.com/govuk-one-login/authentication-api/pull/8718/checks?check_run_id=93452495116)): It looks like this is a pre-existing issue and that this module was previously removed from the TF scan matrix but GitHub still expects its SARIF category. Not including a fix on this PR.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Check the five new `scan-api-sam` jobs run on this PR and the job logs are as expected (e.g., scan failures or passes).

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, GitHub action/workflow changes only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, GitHub action/workflow changes only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, GitHub action/workflow changes only**
