### PR TITLE
AUT-5733: Use common subject ID in IAD data export

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -87,6 +87,13 @@ Resources:
               !Ref Environment,
               inactiveAccountExportMaxInvocations,
             ]
+          INTERNAl_SECTOR_URI: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://identity.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://identity.${Environment}.account.gov.uk"
+            - "https://identity.account.gov.uk"
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy

--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -90,7 +90,7 @@ Resources:
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy
-        - !Ref DynamoUserReadAccessPolicy
+        - !Ref DynamoUserReadWriteAccessPolicy
         - !Ref DynamoCredentialReadAccessPolicy
         - !Ref CloudWatchLogsKmsAccessPolicy
         - !Ref InactiveAccountDataExportSelfInvokePolicy

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -74,6 +74,12 @@ Conditions:
               - !Ref SubEnvironment
               - none
 
+  IsNotProduction:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref Environment
+          - production
+
   AllowBulkTestUsers:
     Fn::Equals:
       - !FindInMap [

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -195,11 +195,11 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportMaxItemsPerSegment: "25"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev1-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "20"
+      inactiveAccountExportMaxInvocations: "40"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -236,11 +236,11 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportMaxItemsPerSegment: "25"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev2-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "20"
+      inactiveAccountExportMaxInvocations: "40"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -277,11 +277,11 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportMaxItemsPerSegment: "25"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev3-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "20"
+      inactiveAccountExportMaxInvocations: "40"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -318,11 +318,11 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportMaxItemsPerSegment: "25"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "dev-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "20"
+      inactiveAccountExportMaxInvocations: "40"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -10,10 +10,12 @@ import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -162,7 +164,11 @@ public class InactiveAccountDataExportHelper {
         }
 
         String email = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_EMAIL);
-        LOG.info("Generating salt for email '{}': salt was missing or empty", email);
+        String publicSubjectId =
+                getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID);
+        LOG.info(
+                "Generating salt for public subject ID '{}': salt was missing or empty",
+                publicSubjectId);
 
         byte[] newSalt = SaltHelper.generateNewSalt();
         dynamoDbClient.updateItem(
@@ -183,11 +189,30 @@ public class InactiveAccountDataExportHelper {
 
     public static InactiveAccountTrackerItem buildTrackerItem(
             Map<String, AttributeValue> userProfileItem,
-            Map<String, AttributeValue> userCredentialsItem) {
+            Map<String, AttributeValue> userCredentialsItem,
+            String internalSectorUri) {
         String subjectId = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_SUBJECT_ID);
         String publicSubjectId =
                 getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID);
+        if (subjectId == null) {
+            LOG.warn(
+                    "Skipping tracker item for public subject ID '{}': subject ID is null. Manual processing required.",
+                    publicSubjectId);
+            return null;
+        }
+
         String email = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_EMAIL);
+        byte[] salt = getSalt(userProfileItem);
+        if (salt.length == 0) {
+            LOG.warn(
+                    "Skipping tracker item for public subject ID '{}': salt is null or empty. Salt should've already been generated if not present.",
+                    publicSubjectId);
+            return null;
+        }
+
+        String commonSubjectId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        subjectId, URI.create(internalSectorUri), salt);
 
         LastActiveDate lastActiveDate =
                 calculateLastActiveDate(userProfileItem, userCredentialsItem);
@@ -198,7 +223,7 @@ public class InactiveAccountDataExportHelper {
 
         if (dateForDeletion == null) {
             LOG.warn(
-                    "Skipping tracker item for public subject ID '{}': could not determine dateForDeletion (lastActiveDate was null)",
+                    "Skipping tracker item for public subject ID '{}': could not determine dateForDeletion (lastActiveDate was null).",
                     publicSubjectId);
             return null;
         }
@@ -208,7 +233,7 @@ public class InactiveAccountDataExportHelper {
 
         return new InactiveAccountTrackerItem()
                 .withDateForDeletion(dateForDeletion)
-                .withCommonSubjectId(subjectId)
+                .withCommonSubjectId(commonSubjectId)
                 .withPublicSubjectId(publicSubjectId)
                 .withEmailAddress(email)
                 .withEmailAddressLastUpdated(profileUpdated)
@@ -266,4 +291,16 @@ public class InactiveAccountDataExportHelper {
         AttributeValue value = item.get(attributeName);
         return value != null ? value.s() : null;
     }
+
+    private static byte[] getSalt(Map<String, AttributeValue> item) {
+        AttributeValue value = item.get(UserProfile.ATTRIBUTE_SALT);
+
+        if (value == null || value.b() == null || value.b().asByteArray().length == 0) {
+            return new byte[0];
+        }
+
+        return value.b().asByteArray();
+    }
+
+    
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -2,12 +2,16 @@ package uk.gov.di.authentication.utils.helpers;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
 import java.time.LocalDateTime;
@@ -146,6 +150,35 @@ public class InactiveAccountDataExportHelper {
             return null;
         }
         return LocalDateTime.parse(lastActiveDate).toLocalDate().plusYears(5).toString();
+    }
+
+    public static void ensureSaltPresent(
+            Map<String, AttributeValue> userProfileItem,
+            DynamoDbClient dynamoDbClient,
+            String userProfileTableName) {
+        AttributeValue saltAttr = userProfileItem.get(UserProfile.ATTRIBUTE_SALT);
+        if (saltAttr != null && saltAttr.b() != null && saltAttr.b().asByteArray().length > 0) {
+            return;
+        }
+
+        String email = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_EMAIL);
+        LOG.info("Generating salt for email '{}': salt was missing or empty", email);
+
+        byte[] newSalt = SaltHelper.generateNewSalt();
+        dynamoDbClient.updateItem(
+                UpdateItemRequest.builder()
+                        .tableName(userProfileTableName)
+                        .key(Map.of(UserProfile.ATTRIBUTE_EMAIL, AttributeValue.fromS(email)))
+                        .updateExpression("SET #salt = :salt")
+                        .expressionAttributeNames(Map.of("#salt", UserProfile.ATTRIBUTE_SALT))
+                        .expressionAttributeValues(
+                                Map.of(
+                                        ":salt",
+                                        AttributeValue.fromB(SdkBytes.fromByteArray(newSalt))))
+                        .build());
+
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_SALT, AttributeValue.fromB(SdkBytes.fromByteArray(newSalt)));
     }
 
     public static InactiveAccountTrackerItem buildTrackerItem(

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -301,6 +301,4 @@ public class InactiveAccountDataExportHelper {
 
         return value.b().asByteArray();
     }
-
-    
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -37,6 +37,7 @@ import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHe
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildTrackerItem;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.ensureSaltPresent;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
 public class InactiveAccountDataExportHandler
@@ -403,8 +404,10 @@ public class InactiveAccountDataExportHandler
             if (email == null) {
                 continue;
             }
+            Map<String, AttributeValue> mutableProfileItem = new HashMap<>(profileItem);
+            ensureSaltPresent(mutableProfileItem, client, userProfileTableName);
             InactiveAccountTrackerItem trackerItem =
-                    buildTrackerItem(profileItem, credentialsByEmail.get(email.s()));
+                    buildTrackerItem(mutableProfileItem, credentialsByEmail.get(email.s()));
             if (trackerItem != null) {
                 batchWriteService.add(trackerItem);
             }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -70,6 +70,7 @@ public class InactiveAccountDataExportHandler
     private final long pauseBetweenInvocationsMs;
     private final String lambdaName;
     private final int maxInvocations;
+    private final String internalSectorUri;
 
     public InactiveAccountDataExportHandler(
             ConfigurationService configurationService,
@@ -92,6 +93,7 @@ public class InactiveAccountDataExportHandler
                 configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
         this.lambdaName = configurationService.getInactiveAccountExportLambdaName();
         this.maxInvocations = configurationService.getInactiveAccountExportMaxInvocations();
+        this.internalSectorUri = configurationService.getInternalSectorUri();
     }
 
     public InactiveAccountDataExportHandler() {
@@ -407,7 +409,10 @@ public class InactiveAccountDataExportHandler
             Map<String, AttributeValue> mutableProfileItem = new HashMap<>(profileItem);
             ensureSaltPresent(mutableProfileItem, client, userProfileTableName);
             InactiveAccountTrackerItem trackerItem =
-                    buildTrackerItem(mutableProfileItem, credentialsByEmail.get(email.s()));
+                    buildTrackerItem(
+                            mutableProfileItem,
+                            credentialsByEmail.get(email.s()),
+                            internalSectorUri);
             if (trackerItem != null) {
                 batchWriteService.add(trackerItem);
             }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -10,9 +10,11 @@ import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 import uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.LastActiveDate;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -216,17 +218,22 @@ class InactiveAccountDataExportHelperTest {
                         UserProfile.ATTRIBUTE_EMAIL,
                         AttributeValue.builder().s("test@example.com").build(),
                         UserProfile.ATTRIBUTE_UPDATED,
-                        AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
+                        AttributeValue.builder().s("2021-07-17T10:30:00.123456").build(),
+                        UserProfile.ATTRIBUTE_SALT,
+                        AttributeValue.builder()
+                                .b(SdkBytes.fromByteArray(new byte[] {1, 2, 3, 4, 5}))
+                                .build());
 
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of(
                         UserCredentials.ATTRIBUTE_EMAIL,
                         AttributeValue.builder().s("test@example.com").build());
 
-        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, userCredentialsItem);
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, userCredentialsItem, INTERNAL_SECTOR_URI);
 
         assertEquals("2026-07-17", result.getDateForDeletion());
-        assertEquals("subject-123", result.getCommonSubjectId());
+        assertTrue(result.getCommonSubjectId().startsWith("urn:fdc:gov.uk:2022:"));
         assertEquals("public-456", result.getPublicSubjectId());
         assertEquals("test@example.com", result.getEmailAddress());
         assertEquals("2021-07-17T10:30:00.123456", result.getEmailAddressLastUpdated());
@@ -246,9 +253,14 @@ class InactiveAccountDataExportHelperTest {
         Map<String, AttributeValue> userProfileItem =
                 Map.of(
                         UserProfile.ATTRIBUTE_SUBJECT_ID,
-                        AttributeValue.builder().s("subject-789").build());
+                        AttributeValue.builder().s("subject-789").build(),
+                        UserProfile.ATTRIBUTE_SALT,
+                        AttributeValue.builder()
+                                .b(SdkBytes.fromByteArray(new byte[] {1, 2, 3}))
+                                .build());
 
-        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, INTERNAL_SECTOR_URI);
 
         assertNull(result);
     }
@@ -262,12 +274,85 @@ class InactiveAccountDataExportHelperTest {
                         UserProfile.ATTRIBUTE_EMAIL,
                         AttributeValue.builder().s("user@gov.uk").build(),
                         UserProfile.ATTRIBUTE_UPDATED,
-                        AttributeValue.builder().s("2020-01-01T00:00:00.000000").build());
+                        AttributeValue.builder().s("2020-01-01T00:00:00.000000").build(),
+                        UserProfile.ATTRIBUTE_SALT,
+                        AttributeValue.builder()
+                                .b(SdkBytes.fromByteArray(new byte[] {10, 20, 30}))
+                                .build());
 
-        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, INTERNAL_SECTOR_URI);
 
         assertEquals("UserProfile.Updated", result.getUserLastActiveSourceId());
-        assertEquals("my-subject-id", result.getCommonSubjectId());
+        assertTrue(result.getCommonSubjectId().startsWith("urn:fdc:gov.uk:2022:"));
+    }
+
+    @Test
+    void buildTrackerItemShouldReturnNullWhenSaltIsMissing() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_SUBJECT_ID,
+                        AttributeValue.builder().s("subject-no-salt").build(),
+                        UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID,
+                        AttributeValue.builder().s("public-no-salt").build(),
+                        UserProfile.ATTRIBUTE_EMAIL,
+                        AttributeValue.builder().s("nosalt@example.com").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
+
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, INTERNAL_SECTOR_URI);
+
+        assertNull(result);
+    }
+
+    @Test
+    void buildTrackerItemShouldReturnNullWhenSaltIsEmpty() {
+        Map<String, AttributeValue> userProfileItem = new HashMap<>();
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_SUBJECT_ID,
+                AttributeValue.builder().s("subject-empty-salt").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID,
+                AttributeValue.builder().s("public-empty-salt").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_EMAIL,
+                AttributeValue.builder().s("emptysalt@example.com").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_UPDATED,
+                AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_SALT,
+                AttributeValue.builder().b(SdkBytes.fromByteArray(new byte[] {})).build());
+
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, INTERNAL_SECTOR_URI);
+
+        assertNull(result);
+    }
+
+    @Test
+    void buildTrackerItemShouldReturnNullWhenSubjectIdIsNull() {
+        Map<String, AttributeValue> userProfileItem = new HashMap<>();
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID,
+                AttributeValue.builder().s("public-no-subject").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_EMAIL,
+                AttributeValue.builder().s("nosubject@example.com").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_UPDATED,
+                AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
+        userProfileItem.put(
+                UserProfile.ATTRIBUTE_SALT,
+                AttributeValue.builder()
+                        .b(SdkBytes.fromByteArray(new byte[] {1, 2, 3, 4, 5}))
+                        .build());
+
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, INTERNAL_SECTOR_URI);
+
+        assertNull(result);
     }
 
     @Test
@@ -519,5 +604,34 @@ class InactiveAccountDataExportHelperTest {
 
             assertFalse(determineHasSetupMfa(profileItem, credentialsItem));
         }
+    }
+
+    @Test
+    void buildTrackerItemShouldExtractHostFromUriWhenCalculatingPairwiseIdentifier() {
+        String subjectId = "test-subject-id";
+        byte[] salt = new byte[] {1, 2, 3, 4, 5};
+        String sectorUriWithProtocol = "https://identity.dev.account.gov.uk";
+        String sectorHost = "identity.dev.account.gov.uk";
+
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_SUBJECT_ID,
+                        AttributeValue.builder().s(subjectId).build(),
+                        UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID,
+                        AttributeValue.builder().s("public-123").build(),
+                        UserProfile.ATTRIBUTE_EMAIL,
+                        AttributeValue.builder().s("test@example.com").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2021-07-17T10:30:00.123456").build(),
+                        UserProfile.ATTRIBUTE_SALT,
+                        AttributeValue.builder().b(SdkBytes.fromByteArray(salt)).build());
+
+        InactiveAccountTrackerItem result =
+                buildTrackerItem(userProfileItem, null, sectorUriWithProtocol);
+
+        String expectedPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(subjectId, sectorHost, salt);
+
+        assertEquals(expectedPairwiseId, result.getCommonSubjectId());
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -2,9 +2,12 @@ package uk.gov.di.authentication.utils.helpers;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
@@ -18,17 +21,25 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildTrackerItem;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateDateForDeletion;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateLastActiveDate;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.determineHasSetupMfa;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.ensureSaltPresent;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
 class InactiveAccountDataExportHelperTest {
 
     private static final String TABLE_NAME = "test-user-credentials";
+    private static final String USER_PROFILE_TABLE_NAME = "test-user-profile";
+    private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
+    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
 
     @Test
     void buildCredentialKeysShouldExtractEmailKeysFromProfileItems() {
@@ -142,6 +153,56 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void countMissingCredentialsShouldReturnZeroForZeroInputs() {
         assertEquals(0, countMissingCredentials(0, 0));
+    }
+
+    @Nested
+    class EnsureSaltPresentTest {
+
+        @Test
+        void shouldReturnWithoutCallingDynamoWhenSaltAlreadyExists() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_EMAIL,
+                            AttributeValue.builder().s("test@example.com").build(),
+                            UserProfile.ATTRIBUTE_SALT,
+                            AttributeValue.builder()
+                                    .b(SdkBytes.fromByteArray(new byte[] {1, 2, 3}))
+                                    .build());
+
+            ensureSaltPresent(profileItem, dynamoDbClient, USER_PROFILE_TABLE_NAME);
+
+            verify(dynamoDbClient, never()).updateItem(any(UpdateItemRequest.class));
+        }
+
+        @Test
+        void shouldGenerateAndPersistSaltWhenMissing() {
+            Map<String, AttributeValue> profileItem = new HashMap<>();
+            profileItem.put(
+                    UserProfile.ATTRIBUTE_EMAIL,
+                    AttributeValue.builder().s("nosalt@example.com").build());
+
+            ensureSaltPresent(profileItem, dynamoDbClient, USER_PROFILE_TABLE_NAME);
+
+            verify(dynamoDbClient).updateItem(any(UpdateItemRequest.class));
+            assertNotNull(profileItem.get(UserProfile.ATTRIBUTE_SALT));
+            assertTrue(profileItem.get(UserProfile.ATTRIBUTE_SALT).b().asByteArray().length > 0);
+        }
+
+        @Test
+        void shouldGenerateAndPersistSaltWhenEmpty() {
+            Map<String, AttributeValue> profileItem = new HashMap<>();
+            profileItem.put(
+                    UserProfile.ATTRIBUTE_EMAIL,
+                    AttributeValue.builder().s("emptysalt@example.com").build());
+            profileItem.put(
+                    UserProfile.ATTRIBUTE_SALT,
+                    AttributeValue.builder().b(SdkBytes.fromByteArray(new byte[] {})).build());
+
+            ensureSaltPresent(profileItem, dynamoDbClient, USER_PROFILE_TABLE_NAME);
+
+            verify(dynamoDbClient).updateItem(any(UpdateItemRequest.class));
+            assertTrue(profileItem.get(UserProfile.ATTRIBUTE_SALT).b().asByteArray().length > 0);
+        }
     }
 
     @Test

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -679,6 +679,30 @@ class InactiveAccountDataExportHandlerTest {
         verify(lambdaInvokerService, never()).invokeAsyncWithPayload(any(), any());
     }
 
+    @Test
+    void shouldGenerateSaltAndWriteItemsWhenSaltIsMissing() {
+        int itemCount = 3;
+        List<ScanResponse> pages =
+                List.of(
+                        ScanResponse.builder()
+                                .items(createItemsWithoutSalt(itemCount))
+                                .count(itemCount)
+                                .scannedCount(itemCount)
+                                .build());
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(client.scan(any(ScanRequest.class)))
+                .thenAnswer(invocation -> pages.get(callCount.getAndIncrement()));
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.processedCount());
+        assertEquals(itemCount, response.writtenCount());
+    }
+
     private Map<String, AttributeValue> createItem(int index) {
         var profile =
                 new UserProfile()
@@ -691,6 +715,25 @@ class InactiveAccountDataExportHandlerTest {
                         .withTermsAndConditions(
                                 new TermsAndConditions("1.5", "2024-01-15T09:30:00Z"));
         return USER_PROFILE_SCHEMA.itemToMap(profile, true);
+    }
+
+    private List<Map<String, AttributeValue>> createItemsWithoutSalt(int count) {
+        List<Map<String, AttributeValue>> items = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            var profile =
+                    new UserProfile()
+                            .withEmail("nosalt" + i + "@example.com")
+                            .withCreated("2024-01-15T09:01:02.345678")
+                            .withUpdated("2024-06-20T10:03:04.567890")
+                            .withPublicSubjectID("public-nosalt-" + i)
+                            .withSubjectID("subject-nosalt-" + i)
+                            .withTermsAndConditions(
+                                    new TermsAndConditions("1.5", "2024-01-15T09:30:00Z"));
+            items.add(USER_PROFILE_SCHEMA.itemToMap(profile, true));
+        }
+
+        return items;
     }
 
     private Map<String, AttributeValue> createCredentialItem(String email) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -70,6 +70,8 @@ class InactiveAccountDataExportHandlerTest {
                 .thenReturn("test-tracker-table");
         when(configurationService.getInactiveAccountExportBatchWriteMaxRetries()).thenReturn(3);
         when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(1000);
+        when(configurationService.getInternalSectorUri())
+                .thenReturn("https://identity.test.account.gov.uk");
         when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
                 .thenReturn(BatchWriteItemResponse.builder().build());
     }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The "common subject ID" value in the tracker item was previously being set to the users "subject ID", this was incorrect, the "common subject ID" should be used here.

This change follows the project convention of calculating the "common subject ID" using the `getSubjectWithSectorIdentifier` helper method.

Generates and persists salt on the UserProfile item if missing or empty.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the utils module to a dev environment, clear the `*-stub-inactive-account-tracker` DynamoDB table for that dev environment, then make a test request to the `*-inactive-account-data-export-lambda` Lambda to scan the dev tables. Then review the dev tracker table items, pick two items, calculate the ICS ID (e.g., using `scripts/export-ics.sh` or another method) from the users subject ID and salt and that dev envs sector URI and check it matches what was written to the dev tracker table item.
    - I have followed these steps - see "Testing" section below

## Testing

1. Deployed the utils module to authdev1
1. Cleared the `authdev1-stub-inactive-account-tracker` DynamoDB table
1. Made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev tables
1. Once the scans had completed, reviewed the authdev1 tracker table items and picked two items:
    a. For each item, calculated the common subject ID (using the users subject ID and salt and authdev1 sector URI (`identity.authdev1.dev.account.gov.uk`)) and checked it matches what was written to the corresponding authdev1 tracker table item.
1. Confirmed the common subject IDs in the dev table all had prefixes `urn:fdc:gov.uk:2022:`

Also confirmed that an account missing a salt on its UserProfile item has one generated and persisted.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils lambda change**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils lambda change**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, utils lambda change**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- PR which introduced the bug: https://github.com/govuk-one-login/authentication-api/pull/8631 ([commit](https://github.com/govuk-one-login/authentication-api/commit/7c94231f1f22a58b4302072f996d53f7d0e155f9))