### PR TITLE
ATO-2769: log validation of exp and nbf with clock skew

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -190,12 +190,12 @@ public class AuthorisationHandler
         this.auditService = new AuditService(configurationService);
         this.queryParamsAuthorizeValidator =
                 new QueryParamsAuthorizeValidator(configurationService);
+        this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
         this.requestObjectAuthorizeValidator =
-                new RequestObjectAuthorizeValidator(configurationService);
+                new RequestObjectAuthorizeValidator(configurationService, this.nowClock);
         this.clientService = new DynamoClientService(configurationService);
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
-        this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
         this.authenticationAuthorisationService =
                 new AuthenticationAuthorizationService(
                         configurationService,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.oidc.validators;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.langtag.LangTagException;
 import com.nimbusds.langtag.LangTagUtils;
 import com.nimbusds.oauth2.sdk.ErrorObject;
@@ -18,6 +20,7 @@ import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -30,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.nimbusds.oauth2.sdk.ResponseType.CODE;
 import static java.util.Collections.emptyList;
@@ -43,19 +47,27 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
     private final OidcAPI oidcApi;
     private final ClientSignatureValidationService clientSignatureValidationService;
+    private final DefaultJWTClaimsVerifier<?> claimsVerifier;
 
     public RequestObjectAuthorizeValidator(
             ConfigurationService configurationService,
             DynamoClientService dynamoClientService,
             IPVCapacityService ipvCapacityService,
             OidcAPI oidcApi,
-            ClientSignatureValidationService clientSignatureValidationService) {
+            ClientSignatureValidationService clientSignatureValidationService,
+            NowHelper.NowClock clock) {
         super(configurationService, dynamoClientService, ipvCapacityService);
         this.clientSignatureValidationService = clientSignatureValidationService;
         this.oidcApi = oidcApi;
+
+        // Currently we do not use this to exact match the JWT claims
+        // or assert certain claims are present. This just validates the
+        // time based nbf and exp claims
+        this.claimsVerifier = defaultJWTClaimsVerifier(null, null, clock);
     }
 
-    public RequestObjectAuthorizeValidator(ConfigurationService configurationService) {
+    public RequestObjectAuthorizeValidator(
+            ConfigurationService configurationService, NowHelper.NowClock clock) {
         super(
                 configurationService,
                 new DynamoClientService(configurationService),
@@ -63,6 +75,11 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         this.oidcApi = new OidcAPI(configurationService);
         this.clientSignatureValidationService =
                 new ClientSignatureValidationService(configurationService);
+
+        // Currently we do not use this to exact match the JWT claims
+        // or assert certain claims are present. This just validates the
+        // time based nbf and exp claims
+        this.claimsVerifier = defaultJWTClaimsVerifier(null, null, clock);
     }
 
     @Override
@@ -88,21 +105,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         try {
             var jwtClaimsSet = authRequest.getRequestObject().getJWTClaimsSet();
 
-            var expiration = jwtClaimsSet.getExpirationTime();
-            if (Objects.isNull(expiration)) {
-                LOG.info("Request object JWT does not have an expiry date");
-            } else {
-                long now = System.currentTimeMillis();
-                if (expiration.getTime() < now) {
-                    long expiredBySeconds = (now - expiration.getTime()) / 1000;
-                    LOG.warn(
-                            "Request object JWT has expired. Expiry: {}, expired by {} seconds",
-                            expiration,
-                            expiredBySeconds);
-                } else {
-                    LOG.info("Request object JWT has a valid expiry date. Expiry: {}", expiration);
-                }
-            }
+            validateTimestampClaims(jwtClaimsSet);
 
             if (jwtClaimsSet.getStringClaim("redirect_uri") == null
                     || !client.getRedirectUrls()
@@ -365,5 +368,27 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
     private static Optional<AuthRequestError> errorResponse(
             URI uri, ErrorObject error, State state) {
         return Optional.of(new AuthRequestError(error, uri, state));
+    }
+
+    private void validateTimestampClaims(JWTClaimsSet jwtClaimsSet) {
+        try {
+            claimsVerifier.verify(jwtClaimsSet, null);
+        } catch (BadJWTException e) {
+            LOG.warn("Error validating time based claims in request object: {}", e.getMessage());
+            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
+        }
+    }
+
+    private DefaultJWTClaimsVerifier<?> defaultJWTClaimsVerifier(
+            JWTClaimsSet exactMatchClaims, Set<String> requiredClaims, NowHelper.NowClock clock) {
+        var cv =
+                new DefaultJWTClaimsVerifier<>(exactMatchClaims, requiredClaims) {
+                    @Override
+                    protected java.util.Date currentTime() {
+                        return clock.now();
+                    }
+                };
+        cv.setMaxClockSkew(30);
+        return cv;
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -37,6 +37,7 @@ import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -44,15 +45,21 @@ import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.security.KeyPair;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.time.Clock.fixed;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,6 +94,9 @@ class RequestObjectAuthorizeValidatorTest {
             "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@digital.cabinet-office.gov.uk";
     private RequestObjectAuthorizeValidator validator;
     private final OidcAPI oidcApi = mock(OidcAPI.class);
+    private static final String FIXED_TIMESTAMP = "2021-09-01T22:10:00.012Z";
+    private static final Clock fixedClock = fixed(Instant.parse(FIXED_TIMESTAMP), ZoneId.of("UTC"));
+    private static final NowHelper.NowClock fixedNowClock = new NowHelper.NowClock(fixedClock);
 
     @BeforeEach
     void setup() {
@@ -98,7 +108,8 @@ class RequestObjectAuthorizeValidatorTest {
                         dynamoClientService,
                         ipvCapacityService,
                         oidcApi,
-                        clientSignatureValidationService);
+                        clientSignatureValidationService,
+                        fixedNowClock);
         var clientRegistry =
                 generateClientRegistry(
                         ClientType.APP.getValue(),
@@ -1001,6 +1012,58 @@ class RequestObjectAuthorizeValidatorTest {
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
         assertEquals(STATE, requestObjectError.get().state());
+    }
+
+    @Nested
+    class TimestampValidation {
+        @Test
+        void shouldThrowAnErrorWhenRequestIsExpired() throws Exception {
+            var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder()
+                            .expirationTime(fixedNowClock.nowMinus(2, ChronoUnit.MINUTES))
+                            .build();
+            var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+
+            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
+            assertDoesNotThrow(() -> validator.validate(authRequest));
+        }
+
+        @Test
+        void shouldThrowAnErrorWhenRequestCurrentTimeIsBeforeNotBeforeClaim() throws Exception {
+            var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder()
+                            .notBeforeTime(fixedNowClock.nowPlus(2, ChronoUnit.MINUTES))
+                            .build();
+            var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
+            assertDoesNotThrow(() -> validator.validate(authRequest));
+        }
+
+        @Test
+        void shouldNotThrowWhenExpiryIsWithinClockSkew() throws Exception {
+            var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder()
+                            .expirationTime(fixedNowClock.nowPlus(30, ChronoUnit.SECONDS))
+                            .build();
+            var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
+
+            var requestObjectError = validator.validate(generateAuthRequest(signedJWT));
+
+            assertThat(requestObjectError, equalTo(Optional.empty()));
+        }
+
+        @Test
+        void shouldNotThrowWhenNotBeforeIsWithinClockSkew() throws Exception {
+            var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder()
+                            .notBeforeTime(fixedNowClock.nowMinus(30, ChronoUnit.SECONDS))
+                            .build();
+            var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
+
+            var requestObjectError = validator.validate(generateAuthRequest(signedJWT));
+
+            assertThat(requestObjectError, equalTo(Optional.empty()));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change

Some RPs choose to send authorise requests in the form of signed JWT Authorise requests (JARs). As these are JWTs, they come with some default timestamp based claims, such as `exp` and `nbf`. Because this new validation can be potentially breaking, we can 

### What’s changed

- Uses `DefaultJWTClaimsVerifier`  to validate the exp claim in RP provided JARs
- This also validates the `nbf` claim (see java docs [here](https://www.javadoc.io/doc/com.nimbusds/nimbus-jose-jwt/latest/com/nimbusds/jwt/proc/DefaultJWTClaimsVerifier.html) )
- Currently fails open, with a followup to return an exception here and have it return an error to the RP

### Manual testing

- N/A covered by unit tests 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
