### PR TITLE
BAU: move noisy http method check out of main handler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -255,18 +255,10 @@ public class AuthorisationHandler
         attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
         LOG.info("Received authentication request");
 
+        useOnlyApprovedHttpMethod("GET", input.getHttpMethod());
+
         AuthenticationRequest authRequest;
         try {
-            if (!"GET".equals(input.getHttpMethod())) {
-                LOG.warn(
-                        String.format(
-                                "Authentication request sent with invalid HTTP method %s",
-                                input.getHttpMethod()));
-                throw new InvalidHttpMethodException(
-                        String.format(
-                                "Authentication request does not support %s requests",
-                                input.getHttpMethod()));
-            }
             Map<String, String> parameterMap = input.getQueryStringParameters();
             Map<String, List<String>> requestParameters =
                     parameterMap.entrySet().stream()
@@ -490,6 +482,15 @@ public class AuthorisationHandler
                 reauthRequested,
                 requestedVtr,
                 user);
+    }
+
+    private void useOnlyApprovedHttpMethod(String acceptedHttpMethod, String usedHttpMethod) {
+        if (!acceptedHttpMethod.equals(usedHttpMethod)) {
+            LOG.warn("Authentication request sent with invalid HTTP method {}", usedHttpMethod);
+            throw new InvalidHttpMethodException(
+                    String.format(
+                            "Authentication request does not support %s requests", usedHttpMethod));
+        }
     }
 
     private void sendAuthRequestParsedAuditEvent(


### PR DESCRIPTION
### Wider context of change

A small cleanup change to improve readability.

### What’s changed

One operation is extracted into a private method.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
