### PR TITLE
BAU: Handle unknown passkey transport values

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
@@ -63,7 +63,7 @@ public class AccountDataCredentialRepository implements CredentialRepository {
 
     Set<AuthenticatorTransport> transportStringsToSet(List<String> passkeyTransports) {
         return passkeyTransports.stream()
-                .map(s -> AuthenticatorTransport.valueOf(s.toUpperCase()))
+                .map(AuthenticatorTransport::of)
                 .collect(Collectors.toSet());
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -240,7 +240,7 @@ class AccountDataCredentialRepositoryTest {
                 "some-aaguid",
                 true,
                 5,
-                List.of("BLE", "internal"),
+                List.of("ble", "internal"),
                 true,
                 true,
                 true,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -143,7 +143,7 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                     passkeysResponse(
                             passkeyJson(FIRST_PASSKEY_ID),
                             passkeyJsonWithTransports(
-                                    SECOND_PASSKEY_ID, List.of("BLE", "INTERNAL"))));
+                                    SECOND_PASSKEY_ID, List.of("ble", "internal"))));
 
             var response =
                     makeRequest(


### PR DESCRIPTION
## What

- Replace AuthenticatorTransport.valueOf() with AuthenticatorTransport.of() in transportStringsToSet(). valueOf() throws IllegalArgumentException for any transport string not matching one of the five known constants (USB, NFC, BLE, HYBRID, INTERNAL). of() returns a matching constant for known values and wraps unknown values in a new instance without throwing:

```
  @JsonCreator
  public static AuthenticatorTransport of(@NonNull String id) {
    return Stream.of(values())
        .filter(v -> v.getId().equals(id))
        .findAny()
        .orElseGet(() -> new AuthenticatorTransport(id));
  }
```

- The WebAuthn spec defines AuthenticatorTransport as a hint for how clients might communicate with an authenticator. The spec uses DOMString rather than a closed enum specifically to allow new values without breaking implementations. The W3C WebAuthn Level 3 spec states in section 5.2.1 that Relying Parties ["SHOULD accept and store unknown values"](https://www.w3.org/TR/webauthn-3/#enum-transport:~:text=credential%20data.-,%5B%5Btransports%5D%5D,of%20AuthenticatorTransport%20but%20Relying%20Parties%20SHOULD%20accept%20and%20store%20unknown%20values.,-5.2.1.1.%20Easily), and in section 5.8.3 that client platforms ["MUST ignore unknown values"](https://www.w3.org/TR/webauthn-3/#enum-transport:~:text=%5B%5Btransports%5D%5D,%2C%20but%20client%20platforms%20MUST%20ignore%20unknown%20values.). This means unknown transports are silently skipped during authenticator discovery but do not prevent the credential from being used.

- The immediate cause was passkey records stored with transport value "cable" (an early pre-standard identifier for what became "hybrid" in the W3C spec). Some browsers and authenticators stored "cable" during registration before the standard settled on "hybrid". When a user with such a record attempted to sign in, startAssertion called getCredentialIdsForUsername, which called transportStringsToSet, which called valueOf("CABLE") and threw. The unhandled exception crashed the Lambda and returned a 500, completely blocking that user from signing in with their passkey.

- This triggered the production-start-passkey-assertion-error-rate alarm on 10/08/2026 at 18:58 (10% error rate threshold breached within a 1-minute window, caused by 5+ failures from repeated retries by affected users).

- Impact: users whose passkeys were registered with "cable" (or any other non-standard transport string) can now sign in successfully. The unknown transport value passes through to the allowCredentials response as a transport hint. The browser ignores hints it does not recognise and discovers the authenticator through its default mechanisms. The credential ID is still present in allowCredentials, so the assertion ceremony proceeds normally.

- No impact on users with standard transport values. of() returns the same constant instances as valueOf() for known values.

See: https://www.w3.org/TR/webauthn-3/#enum-transport
See: https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialdescriptor-transports
See: https://developers.yubico.com/java-webauthn-server/JavaDoc/webauthn-server-core/latest/com/yubico/webauthn/data/AuthenticatorTransport.html#of(java.lang.String)

## How to review

1. Code Review
2. Wipe your authenticators in your test environment
3. Register a passkey using the `generate_webauthn_script.py` script and running the output in dev tools console on sign in and create page, but change this line:
```
const transports = (response.getTransports ? response.getTransports() : (credential.getTransports ? credential.getTransports() : ["internal"]));

```
to: 
```
const transports = ["cable"];
```
4. Create a record in the authenticators table by copying the output of running the dev tools script
5. Log in, see you are taken to https://signin.dev.account.gov.uk/sign-in-passkey successfully. 


## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
6. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
