### PR TITLE
BAU: Fix CC Gradle Home cache fallback on new PRs

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -54,7 +54,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/warm-configuration-cache.yml
+++ b/.github/workflows/warm-configuration-cache.yml
@@ -16,7 +16,7 @@ on:
       - "gradle/wrapper/gradle-wrapper.properties"
 
 jobs:
-  warm-style-checks:
+  style-checks:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -36,7 +36,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-style-checks-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-unit-tests:
+  run-unit-tests:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -56,7 +56,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-unit-tests-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-api:
+  run-integration-tests-api:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -76,7 +76,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-api-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-services:
+  run-integration-tests-services:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -96,7 +96,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-services-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-orchestration:
+  run-integration-tests-orchestration:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -116,7 +116,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-orchestration-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-utils:
+  run-integration-tests-utils:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -136,7 +136,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-utils-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-account-mgmt:
+  run-account-management-and-delivery-receipts-tests:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -158,7 +158,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-account-mgmt-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-integration-account-data:
+  run-account-data-api-integration-tests:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -178,7 +178,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-integration-account-data-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-sonar:
+  run-sonar-analysis:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -198,7 +198,7 @@ jobs:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-sonar-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
 
-  warm-sonar-on-merge:
+  run-code-analysis:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## What

- Renames warm-up workflow jobs to match pre-merge-checks job names
- Sets cache-read-only: true on the build job in pre-merge-checks

The first CI run on a new PR branch fails when configuration cache
entries are available from the warm-up but the Gradle Home cache
fallback provides an incomplete set of dependency jars. This happens
because the build job (which runs `build -x test`) saves a Gradle Home
entry on the PR branch that downstream jobs fall back to, and that
entry lacks test-runtime dependencies like JaCoCo. When the CC entry
is reused and Gradle skips dependency resolution, tasks reference jar
paths that do not exist on disk.

The fix prevents the build job from writing its Gradle Home to the
PR branch cache, and renames warm-up jobs so that downstream PR jobs
fall back to the warm-up's complete Gradle Home on main instead.

## How to review

1. Code Review