### PR TITLE
BAU: Set Gradle Home cache read-only on PRs

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -92,7 +92,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -137,7 +137,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -244,7 +244,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -335,7 +335,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -426,7 +426,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -517,7 +517,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -610,7 +610,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -727,7 +727,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -789,7 +789,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          cache-read-only: true
       - name: Restore Build Cache
         if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## What

- Sets cache-read-only: true on all setup-gradle steps in pre-merge-checks

cache-read-only: false was introduced in the original CC PR to prove
that CC reuse worked within a single PR's successive runs. This is no
longer needed; the warm-up workflow now provides complete Gradle Home
entries on main with matching job names for each pre-merge-checks job.

With cache-read-only: false, early-finishing jobs (build, style-checks)
write incomplete Gradle Home entries to the PR branch scope, which later
jobs fall back to instead of the warm-up's complete entries on main.
Combined with a CC hit (skipping dependency resolution), this causes
compilation failures on the first run of new PRs.

## How to review

1. Code Review