### PR TITLE
AUT-5747: Add feature flag to gate IAD export tracker writes 

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -94,6 +94,12 @@ Resources:
               - !Sub "https://identity.${SubEnvironment}.${Environment}.account.gov.uk"
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
+          INACTIVE_ACCOUNT_EXPORT_TRACKER_WRITE_ENABLED:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              inactiveAccountExportTrackerWriteEnabled,
+            ]
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -200,6 +200,7 @@ Mappings:
       inactiveAccountExportTableName: "authdev1-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "40"
+      inactiveAccountExportTrackerWriteEnabled: "true"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -241,6 +242,7 @@ Mappings:
       inactiveAccountExportTableName: "authdev2-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "40"
+      inactiveAccountExportTrackerWriteEnabled: "true"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -282,6 +284,7 @@ Mappings:
       inactiveAccountExportTableName: "authdev3-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "40"
+      inactiveAccountExportTrackerWriteEnabled: "true"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -323,6 +326,7 @@ Mappings:
       inactiveAccountExportTableName: "dev-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "40"
+      inactiveAccountExportTrackerWriteEnabled: "true"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
@@ -364,6 +368,7 @@ Mappings:
       inactiveAccountExportTableName: "build-stub-inactive-account-tracker"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
@@ -407,6 +412,7 @@ Mappings:
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "25"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
@@ -450,6 +456,7 @@ Mappings:
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
@@ -493,6 +500,7 @@ Mappings:
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
       inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -272,6 +272,12 @@ public class ConfigurationService
                 System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_MAX_INVOCATIONS", "0"));
     }
 
+    public boolean isInactiveAccountExportTrackerWriteEnabled() {
+        return System.getenv()
+                .getOrDefault("INACTIVE_ACCOUNT_EXPORT_TRACKER_WRITE_ENABLED", FEATURE_SWITCH_OFF)
+                .equals(FEATURE_SWITCH_ON);
+    }
+
     public String getTicfCRILambdaIdentifier() {
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -229,6 +229,11 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void isInactiveAccountExportTrackerWriteEnabledShouldDefaultToFalse() {
+        assertFalse(configurationService.isInactiveAccountExportTrackerWriteEnabled());
+    }
+
+    @Test
     void getTicfCRILambdaNameShouldDefault() {
         assertEquals("", configurationService.getTicfCRILambdaIdentifier());
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
@@ -28,6 +28,7 @@ public class InactiveAccountDataExportBatchWriteService {
     private final DynamoDbClient client;
     private final String tableName;
     private final int maxRetries;
+    private final boolean dryRun;
     private final List<InactiveAccountTrackerItem> buffer = new ArrayList<>();
     private long totalWritten;
     private long totalFailed;
@@ -35,9 +36,15 @@ public class InactiveAccountDataExportBatchWriteService {
 
     public InactiveAccountDataExportBatchWriteService(
             DynamoDbClient client, String tableName, int maxRetries) {
+        this(client, tableName, maxRetries, false);
+    }
+
+    public InactiveAccountDataExportBatchWriteService(
+            DynamoDbClient client, String tableName, int maxRetries, boolean dryRun) {
         this.client = client;
         this.tableName = tableName;
         this.maxRetries = maxRetries;
+        this.dryRun = dryRun;
     }
 
     public void add(InactiveAccountTrackerItem item) {
@@ -67,7 +74,18 @@ public class InactiveAccountDataExportBatchWriteService {
 
     private void flush() {
         List<WriteRequest> writeRequests = toWriteRequests(buffer);
+        int itemCount = buffer.size();
         buffer.clear();
+
+        if (dryRun) {
+            totalWritten += itemCount;
+            totalBatchesFlushed++;
+            LOG.info(
+                    "Dry-run mode enabled: {} items would have been written to tracker table (batch {})",
+                    itemCount,
+                    totalBatchesFlushed);
+            return;
+        }
 
         int retryCount = 0;
 

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -71,6 +71,7 @@ public class InactiveAccountDataExportHandler
     private final String lambdaName;
     private final int maxInvocations;
     private final String internalSectorUri;
+    private final boolean trackerWriteEnabled;
 
     public InactiveAccountDataExportHandler(
             ConfigurationService configurationService,
@@ -94,6 +95,8 @@ public class InactiveAccountDataExportHandler
         this.lambdaName = configurationService.getInactiveAccountExportLambdaName();
         this.maxInvocations = configurationService.getInactiveAccountExportMaxInvocations();
         this.internalSectorUri = configurationService.getInternalSectorUri();
+        this.trackerWriteEnabled =
+                configurationService.isInactiveAccountExportTrackerWriteEnabled();
     }
 
     public InactiveAccountDataExportHandler() {
@@ -110,6 +113,8 @@ public class InactiveAccountDataExportHandler
             throw new IllegalStateException(
                     "INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT must be greater than 0");
         }
+
+        LOG.info("Tracker write enabled: {}", trackerWriteEnabled);
 
         long processedCount =
                 request != null && request.processedCount() != null ? request.processedCount() : 0L;
@@ -295,7 +300,7 @@ public class InactiveAccountDataExportHandler
         List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
         InactiveAccountDataExportBatchWriteService batchWriteService =
                 new InactiveAccountDataExportBatchWriteService(
-                        client, exportTableName, batchWriteMaxRetries);
+                        client, exportTableName, batchWriteMaxRetries, !trackerWriteEnabled);
 
         do {
             if (itemsScanned >= maxItemsPerSegment) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
@@ -39,6 +39,11 @@ class InactiveAccountDataExportBatchWriteServiceTest {
         return new InactiveAccountDataExportBatchWriteService(client, TABLE_NAME, MAX_RETRIES);
     }
 
+    private InactiveAccountDataExportBatchWriteService createDryRunService() {
+        return new InactiveAccountDataExportBatchWriteService(
+                client, TABLE_NAME, MAX_RETRIES, true);
+    }
+
     @Test
     void shouldFlushAutomaticallyAtBatchSize() {
         var service = createService();
@@ -195,5 +200,69 @@ class InactiveAccountDataExportBatchWriteServiceTest {
                 .withCommonSubjectId("subject-" + index)
                 .withPublicSubjectId("public-subject-" + index)
                 .withEmailAddress("user" + index + "@example.com");
+    }
+
+    @Test
+    void shouldNotCallDynamoDbWhenDryRunEnabled() {
+        var service = createDryRunService();
+
+        for (int i = 0; i < BATCH_WRITE_ITEM_MAX_SIZE; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+    }
+
+    @Test
+    void shouldTrackWrittenCountInDryRunMode() {
+        var service = createDryRunService();
+
+        for (int i = 0; i < BATCH_WRITE_ITEM_MAX_SIZE; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        assertEquals(BATCH_WRITE_ITEM_MAX_SIZE, service.getTotalWritten());
+        assertEquals(1, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldFlushRemainingInDryRunMode() {
+        var service = createDryRunService();
+        int itemCount = 10;
+
+        for (int i = 0; i < itemCount; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(itemCount, service.getTotalWritten());
+        assertEquals(1, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldTrackMultipleBatchesInDryRunMode() {
+        var service = createDryRunService();
+        int totalItems = BATCH_WRITE_ITEM_MAX_SIZE * 3;
+
+        for (int i = 0; i < totalItems; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(totalItems, service.getTotalWritten());
+        assertEquals(3, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldReportZeroFailedInDryRunMode() {
+        var service = createDryRunService();
+
+        for (int i = 0; i < BATCH_WRITE_ITEM_MAX_SIZE + 5; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        assertEquals(0, service.getTotalFailed());
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -72,6 +72,7 @@ class InactiveAccountDataExportHandlerTest {
         when(configurationService.getInactiveAccountExportMaxInvocations()).thenReturn(1000);
         when(configurationService.getInternalSectorUri())
                 .thenReturn("https://identity.test.account.gov.uk");
+        when(configurationService.isInactiveAccountExportTrackerWriteEnabled()).thenReturn(true);
         when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
                 .thenReturn(BatchWriteItemResponse.builder().build());
     }
@@ -703,6 +704,40 @@ class InactiveAccountDataExportHandlerTest {
 
         assertEquals(itemCount, response.processedCount());
         assertEquals(itemCount, response.writtenCount());
+    }
+
+    void shouldNotWriteToTrackerTableWhenWriteDisabled() {
+        when(configurationService.isInactiveAccountExportTrackerWriteEnabled()).thenReturn(false);
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.processedCount());
+        assertEquals(itemCount, response.writtenCount());
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+    }
+
+    @Test
+    void shouldStillScanAndProcessWhenWriteDisabled() {
+        when(configurationService.isInactiveAccountExportTrackerWriteEnabled()).thenReturn(false);
+        int itemCount = 10;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.processedCount());
+        verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
     }
 
     private Map<String, AttributeValue> createItem(int index) {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

It would be beneficial to run the IAD export Lambda without writing any items to the tracker table. This PR adds a feature flag to control writing those tracker items.

Note that if an account is missing a salt on its UserProfile item, the operation to write the generated salt will still be performed.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the utils module to a dev environment, ensure new FF set to false, make a test request to the `*-inactive-account-data-export-lambda` Lambda to scan the dev tables, review the logs and check that the dry run logs were present, then set FF to true and check that writes are still performed.
    - I have followed these steps - see "Testing" section below

## Testing

1. Deployed the utils module to authdev1
1. Set the new FF to false
1. Made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev tables
1. Once the scans had completed, reviewed the Lambda logs and observed "dry run" logs
1. Set the new FF to true
1. Made another test request
1. Observed items being written to the table

<img width="813" height="77" alt="example log" src="https://github.com/user-attachments/assets/d94a885d-4a64-41be-acf0-a61a2ffe4251" />

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
5. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils lambda change**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils lambda change**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, utils lambda change**