### PR TITLE
AUT-5688: Update staging IAD data export config

### DIFF
--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -397,16 +397,16 @@ Mappings:
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
       frontendApiFMSTagValue: "authenticationfrontend"
-      inactiveAccountExportParallelism: "200"
-      inactiveAccountExportTotalSegments: "200"
+      inactiveAccountExportParallelism: "20"
+      inactiveAccountExportTotalSegments: "150"
       inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportMaxItemsPerSegment: "2500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableAccountId: "539729775994"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:539729775994:key/5191526d-1c85-4316-baf7-9fbe373880cf
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportMaxInvocations: "25"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Adopting a "low and slow" approach. More details on how this test config was derived in this comment: https://govukverify.atlassian.net/browse/AUT-5688?focusedCommentId=335929

Metrics such as the peak DB RCU/WCU values and Lambda durations etc will be reviewed following the staging run.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils change only, staging only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils change only, staging only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, utils change only, staging only**
