### PR TITLE
BAU: Update orch auth code threshold on the alarm

### DIFF
--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -146,7 +146,7 @@ Resources:
           EnvironmentConfiguration,
           !Ref Environment,
           lambdaLogAlarmThreshold,
-          DefaultValue: 5,
+          DefaultValue: 20,
         ]
 
   OrchAuthCodeFunctionErrorRateCloudwatchAlarm:


### PR DESCRIPTION
## What

[#8687](https://github.com/govuk-one-login/authentication-api/pull/8696) and [#8737](https://github.com/govuk-one-login/authentication-api/pull/8737) both tried to bump the orch auth code Lambda alarm threshold, but only updated the notification description.

This PR increases the actual alarm threshold to match the value used in the description.

The alert is currently triggering after enhanced code protection was enabled. Failures will be investigated under AUT-5723, TSD are unable to take action in the meantime so reducing alarm noise by raising the threshold.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

[#8687](https://github.com/govuk-one-login/authentication-api/pull/8696)
[#8737](https://github.com/govuk-one-login/authentication-api/pull/8737)