### PR TITLE
AUT-4954: Removing the deprecated signing from IPV jwks lambda

### DIFF
--- a/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
@@ -12,16 +12,6 @@ Resources:
       Environment:
         Variables:
           IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:${IpvReverificationRequestSigningKeyAlias}"
-          IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS: !Sub
-            - arn:aws:kms:${AWS::Region}:${DataStoreAccountId}:alias/${env}-ipv_reverification_request_signing_key
-            - DataStoreAccountId:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  dataStoreAccountId,
-                ]
-              env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       LoggingConfig:
         LogGroup: !Ref MfaResetJarJwkFunctionLogGroup
       Policies:


### PR DESCRIPTION
## What

[AUT-4954] : Removed the deprecated signing from IPV jwks lambda

Kms key for IPV Mfa reset  jwks was migrated in PR https://github.com/govuk-one-login/authentication-api/pull/8741 , This PR removes the old deprecated KMS key 

## How to review


1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions)

[AUT-4954]: https://govukverify.atlassian.net/browse/AUT-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ