### PR TITLE
ATO-2818: Swap to devplatform stack CF template

### DIFF
--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #Ensure we are in the same dir as the script
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
-#CLOUDFRONT_DISTRIBUTION_STACK_VERSION="v3.0.0" # We will need this when we move back to the dev-platform managed version
+CLOUDFRONT_DISTRIBUTION_STACK_VERSION="v3.0.0"
 CERTIFICATE_STACK_VERSION="v1.1.4"
 CLOUDFRONT_MONITORING_STACK_VERSION="v2.1.0"
 
@@ -174,23 +174,7 @@ function provision_cloudfront_distribution() {
   tmp_params_file="$(mktemp)"
   jq "map(if .ParameterKey == \"PreviousOriginCloakingHeader\" then .ParameterValue = \"${PREVIOUS_ORIGIN_CLOAKING_SECRET}\" else . end)" "${params_file}" > "${tmp_params_file}"
 
-  # We can uncomment this once we migrate back to the dev platform cloudfront template
-  # TAGS_FILE="${tmp_tags_file}" PARAMETERS_FILE="${tmp_params_file}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-oidc-cloudfront" "cloudfront-distribution" "${CLOUDFRONT_DISTRIBUTION_STACK_VERSION}"
-
-  pushd "$(pwd)/manual-stacks/cloudfront-distribution"
-  sam build
-  sam deploy \
-    --stack-name "${ENVIRONMENT}-oidc-cloudfront" \
-    --resolve-s3 true \
-    --s3-prefix "${ENVIRONMENT}-oidc-cloudfront" \
-    --region "eu-west-2" \
-    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-    --confirm-changeset \
-    --no-fail-on-empty-changeset \
-    --parameter-overrides $(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "${tmp_params_file}") \
-    --tags $(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "${tmp_tags_file}")
-  popd
-
+  TAGS_FILE="${tmp_tags_file}" PARAMETERS_FILE="${tmp_params_file}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-oidc-cloudfront" "cloudfront-distribution" "${CLOUDFRONT_DISTRIBUTION_STACK_VERSION}"
   # Remove temp params file
   rm -f "${tmp_params_file}"
 


### PR DESCRIPTION
Swaps the template to use the dev platform template instead of the custom one defined in this repo

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
