### PR TITLE
AUT-5725: Add alarm for PasskeysDeleteFailedMetric

### DIFF
--- a/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
+++ b/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
@@ -238,3 +238,38 @@ Resources:
       DestinationArn: !Ref LoggingSubscriptionEndpointArn
       FilterPattern: ""
       LogGroupName: !Ref PasskeysDeleteProxyFunctionLogGroup
+
+  PasskeysDeleteFailedMetricCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Threshold: &LocalThresholdVar 10
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "${AlarmThreshold} or more number of passkey deletion attempts have failed in the ${Env}-passkeys-delete-proxy-lambda function. ${RunbookLink}"
+        - AlarmThreshold: *LocalThresholdVar
+          Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "passkeys-delete-proxy",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-passkeys-delete-failed-metric-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: PasskeyDeletionFailed
+      Dimensions:
+        - Name: FailureReason
+          Value: DataApiUnsuccessfulResponse
+        - Name: Environment
+          Value: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      Namespace: Authentication
+      Period: 3600
+      Statistic: Sum
+      TreatMissingData: notBreaching


### PR DESCRIPTION
## What

- The metric was added so that we could track non-5xx errors that don't get monitored by existing alarms; existing alarms we put on all lambdas as standard track 5xx errors
- We believe this may be due to users double clicking in home to delete a passkey, so on the second click the record is deleted, passing through a 404 error to home
- This creates an alarm to track this 4xx error

## How to review

1. Code Review, checking metric and its dimensions match what is produced in the scenario above in the `PasskeysDeleteProxyHandler`
2. Deploy to dev, use the AWS CLI to bump the count on the metric, see the alarm go into an alarm state in cloudwatch:
```
aws cloudwatch put-metric-data \
  --namespace "Authentication" \
  --metric-name "PasskeyDeletionFailed" \
  --dimensions "FailureReason=DataApiUnsuccessfulResponse,Environment=dev" \
  --value 10 \
  --unit None
```
3. Once this is deployed to production, I will bump the count to observe the alarm go off and see the slack integration 

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
