### PR TITLE
ATO-2821: Remove alternate domain records

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -127,13 +127,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  DeployAlternateDomainRecord:
-    !Or [
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   DeployMigratedRecords:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -216,7 +209,6 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.dev.account.gov.uk"
-      oidcAlternateDomainName: "oidc-orch.dev.account.gov.uk"
       serviceNameForKeyRotationStack: "orch"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -252,7 +244,6 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.build.account.gov.uk"
-      oidcAlternateDomainName: "oidc-orch.build.account.gov.uk"
       serviceNameForKeyRotationStack: "orch"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -290,7 +281,6 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.staging.account.gov.uk"
-      oidcAlternateDomainName: "oidc-orch.staging.account.gov.uk"
       serviceNameForKeyRotationStack: "orch"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -326,7 +316,6 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.integration.account.gov.uk"
-      oidcAlternateDomainName: "oidc-orch.integration.account.gov.uk"
       serviceNameForKeyRotationStack: "orch"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -362,7 +351,6 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.account.gov.uk"
-      oidcAlternateDomainName: "oidc-orch.account.gov.uk"
       serviceNameForKeyRotationStack: "orch"
 
 Globals:
@@ -6241,25 +6229,6 @@ Resources:
           - SwapLiveTrafficToCloudfront
           - Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
           - "{{resolve:ssm:/deploy/api-migration/old-cloudfront-distribution-domain}}"
-        HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
-        EvaluateTargetHealth: false
-
-  #region AlternateDomainRecordSet
-  OrchestrationOidcAlternateCloudFrontRecordSet:
-    Type: AWS::Route53::RecordSet
-    Condition: DeployAlternateDomainRecord
-    Properties:
-      Name:
-        !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          oidcAlternateDomainName,
-        ]
-      Type: A
-      HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc-orch/hosted-zone-id}}"
-      AliasTarget:
-        DNSName:
-          Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
         HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
         EvaluateTargetHealth: false
 


### PR DESCRIPTION
### Wider context of change

Now that we've completed the migration, we can start to remove some of the alternate domain resources we setup to allow us to test the live infrastructure before cutting over.

### What’s changed

- Removes the `DeployAlternateDomainRecord` feature flag and the alternate domain Cloudfront record set. This removes the A record from the `oidc-orch` hosted zone, which is a pre-req to cleaning up the old hosted zone.

### Manual testing

- N/A - this just removes unused resources left over from the migration

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
