### PR TITLE
ATO-2821: remove migration feature flags

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -109,14 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  UseCloudfront:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   DeployMigratedRecords:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -6135,7 +6127,6 @@ Resources:
 
   OrchestrationOidcApiWafAssociation:
     Type: "AWS::WAFv2::WebACLAssociation"
-    Condition: UseCloudfront
     Properties:
       WebACLArn:
         Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-CloakingOriginWebACLArn"

--- a/template.yaml
+++ b/template.yaml
@@ -109,8 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  ProvisionNewApiClientRegistryApiKey:
-    !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -4633,7 +4631,7 @@ Resources:
 
   UpdateClientConfigFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiClientRegistryApiKey
+    Condition: IsNotProduction
     Properties:
       FunctionName: !Ref UpdateClientConfigFunction.Alias
       Action: lambda:InvokeFunction
@@ -4815,7 +4813,7 @@ Resources:
 
   ClientRegistrationFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiClientRegistryApiKey
+    Condition: IsNotProduction
     Properties:
       FunctionName: !Ref ClientRegistrationFunction.Alias
       Action: lambda:InvokeFunction
@@ -6104,7 +6102,7 @@ Resources:
       RetentionInDays: 30
 
   ClientRegistryApiKey:
-    Condition: ProvisionNewApiClientRegistryApiKey
+    Condition: IsNotProduction
     DependsOn:
       - OrchestrationOidcApiStage # Needs to wait for the stage created by the AWS::Serverless::Api
     Type: "AWS::ApiGateway::ApiKey"
@@ -6120,7 +6118,7 @@ Resources:
 
   ClientRegistryApiKeyUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    Condition: ProvisionNewApiClientRegistryApiKey
+    Condition: IsNotProduction
     Properties:
       UsagePlanName: !Sub ${Environment}-client-registry-api-key-usage-plan
       ApiStages:
@@ -6129,7 +6127,7 @@ Resources:
 
   ClientRegistryApiKeyUsagePlanKey:
     Type: AWS::ApiGateway::UsagePlanKey
-    Condition: ProvisionNewApiClientRegistryApiKey
+    Condition: IsNotProduction
     Properties:
       KeyId: !Ref ClientRegistryApiKey
       KeyType: API_KEY

--- a/template.yaml
+++ b/template.yaml
@@ -107,21 +107,6 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
 
-  #region API Migration Feature Flags
-  # Please keep separate from the other ones
-  SwapOriginToApiGateway:
-    !And [
-      !Condition CreateApiGwCustomDomain,
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
-  #endregion
-
   # Comment to force re-deployment of template - this can be deleted once the staging API GW/CloudFront migration is complete.
 
 Mappings:
@@ -6137,14 +6122,8 @@ Resources:
       Type: A
       HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
       AliasTarget:
-        DNSName: !If
-          - SwapOriginToApiGateway
-          - !GetAtt OrchestrationOidcApiCustomDomain.RegionalDomainName
-          - "{{resolve:ssm:/deploy/api-migration/old-api-gateway-regional-domain-name}}"
-        HostedZoneId: !If
-          - SwapOriginToApiGateway
-          - !GetAtt OrchestrationOidcApiCustomDomain.RegionalHostedZoneId
-          - "{{resolve:ssm:/deploy/api-migration/old-api-gateway-regional-hosted-zone-id}}"
+        DNSName: !GetAtt OrchestrationOidcApiCustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt OrchestrationOidcApiCustomDomain.RegionalHostedZoneId
         EvaluateTargetHealth: false
 
   OrchestrationOidcCloudFrontRecordSet:

--- a/template.yaml
+++ b/template.yaml
@@ -109,17 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  CreateApiGwCustomDomain:
-    !And [
-      !Condition SwapLiveTrafficToCloudfront,
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
   SwapOriginToApiGateway:
     !And [
       !Condition CreateApiGwCustomDomain,
@@ -6117,7 +6106,6 @@ Resources:
 
   OrchestrationOidcApiCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
-    Condition: CreateApiGwCustomDomain
     Properties:
       DomainName:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
@@ -6127,7 +6115,6 @@ Resources:
 
   OrchestrationOidcApiBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
-    Condition: CreateApiGwCustomDomain
     Properties:
       DomainName:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]

--- a/template.yaml
+++ b/template.yaml
@@ -109,14 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  DeployMigratedRecords:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   SwapLiveTrafficToCloudfront:
     !And [
       !Condition DeployMigratedRecords,
@@ -6157,7 +6149,6 @@ Resources:
 
   OrchestrationOidcOriginRecordSet:
     Type: AWS::Route53::RecordSet
-    Condition: DeployMigratedRecords
     Properties:
       Name: !Sub
         - "origin.${oidcDomain}"
@@ -6182,7 +6173,6 @@ Resources:
 
   OrchestrationOidcCloudFrontRecordSet:
     Type: AWS::Route53::RecordSet
-    Condition: DeployMigratedRecords
     Properties:
       Name:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]

--- a/template.yaml
+++ b/template.yaml
@@ -109,14 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  ProvisionNewApiGateway:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront:
@@ -1638,7 +1630,6 @@ Resources:
 
   OpenIdConfigurationFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref OpenIdConfigurationFunction.Alias
       Action: lambda:InvokeFunction
@@ -1796,7 +1787,6 @@ Resources:
 
   TrustmarkFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref TrustmarkFunction.Alias
       Action: lambda:InvokeFunction
@@ -2203,7 +2193,6 @@ Resources:
 
   DocAppCallbackFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref DocAppCallbackFunction.Alias
       Action: lambda:InvokeFunction
@@ -2386,7 +2375,6 @@ Resources:
 
   TokenFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref TokenFunction.Alias
       Action: lambda:InvokeFunction
@@ -2589,7 +2577,6 @@ Resources:
 
   LogoutFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref LogoutFunction.Alias
       Action: lambda:InvokeFunction
@@ -3174,7 +3161,6 @@ Resources:
 
   AuthenticationCallbackFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref AuthenticationCallbackFunction.Alias
       Action: lambda:InvokeFunction
@@ -3393,7 +3379,6 @@ Resources:
 
   JwksFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref JwksFunction.Alias
       Action: lambda:InvokeFunction
@@ -3545,7 +3530,6 @@ Resources:
 
   IpvJwksFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref IpvJwksFunction.Alias
       Action: lambda:InvokeFunction
@@ -3679,7 +3663,6 @@ Resources:
 
   SISJwksFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref SISJwksFunction.Alias
       Action: lambda:InvokeFunction
@@ -3812,7 +3795,6 @@ Resources:
 
   AuthJwksFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref AuthJwksFunction.Alias
       Action: lambda:InvokeFunction
@@ -4081,7 +4063,6 @@ Resources:
 
   AuthorisationFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref AuthorisationFunction.Alias
       Action: lambda:InvokeFunction
@@ -4276,7 +4257,6 @@ Resources:
 
   UserInfoFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref UserInfoFunction.Alias
       Action: lambda:InvokeFunction
@@ -4468,7 +4448,6 @@ Resources:
 
   AuthCodeFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref AuthCodeFunction.Alias
       Action: lambda:InvokeFunction
@@ -5286,7 +5265,6 @@ Resources:
 
   IpvCallbackFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref IpvCallbackFunction.Alias
       Action: lambda:InvokeFunction
@@ -5924,7 +5902,6 @@ Resources:
 
   StorageTokenJwkFunctionOrchestrationApiPermission:
     Type: AWS::Lambda::Permission
-    Condition: ProvisionNewApiGateway
     Properties:
       FunctionName: !Ref StorageTokenJwkFunction.Alias
       Action: lambda:InvokeFunction
@@ -6088,7 +6065,6 @@ Resources:
     #region API Gateway
 
   OrchestrationOidcApi:
-    Condition: ProvisionNewApiGateway
     Type: AWS::Serverless::Api
     # checkov:skip=CKV_AWS_120: We absolutely do not want caching enabled for the API as it returns OIDC userinfo and access tokens
     Properties:
@@ -6121,7 +6097,6 @@ Resources:
         FMSRegionalPolicy: "false"
 
   OidcApiAccessLogGroup:
-    Condition: ProvisionNewApiGateway
     Type: AWS::Logs::LogGroup
     Properties:
       KmsKeyId: !GetAtt MainKmsKey.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -109,17 +109,6 @@ Conditions:
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
-  SwapLiveTrafficToCloudfront:
-    !And [
-      !Condition DeployMigratedRecords,
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
   CreateApiGwCustomDomain:
     !And [
       !Condition SwapLiveTrafficToCloudfront,
@@ -6179,10 +6168,8 @@ Resources:
       Type: A
       HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
       AliasTarget:
-        DNSName: !If
-          - SwapLiveTrafficToCloudfront
-          - Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
-          - "{{resolve:ssm:/deploy/api-migration/old-cloudfront-distribution-domain}}"
+        DNSName:
+          Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
         HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
         EvaluateTargetHealth: false
 


### PR DESCRIPTION
### Wider context of change

Now that we've completed our migration, we can clean up the feature flags that represented the intermediate steps of the migration. This should not change anything from the currently deployed infrastructure, as the final state here should just be the the `true` side of all these flags

### What’s changed

- Cleans up all the migration related feature flags

### Manual testing
- Deploy to dev, changeset looked sensible, none of CF/API gateway resources looked affected

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
