### PR TITLE
ATO-2792: Add redirect to SIS behind feature flag in dev

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -32,6 +32,7 @@ dependencies {
             libs.openTelemetryAwsSdk
 
     implementation project(path: ':ipv-api')
+    implementation project(path: ':sis-api')
 
     testImplementation libs.bundles.test,
             libs.awsLambdaTests,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -60,20 +60,24 @@ import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.Metrics;
 import uk.gov.di.orchestration.shared.services.OrchAccessTokenService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.OrchRefreshTokenService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenService;
+import uk.gov.di.orchestration.sis.service.SISAuthorisationService;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -125,6 +129,7 @@ public class AuthenticationCallbackHandler
     private final LogoutService logoutService;
     private final AuthFrontend authFrontend;
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
+    private final SISAuthorisationService sisAuthorisationService;
 
     public AuthenticationCallbackHandler() {
         this(ConfigurationService.getInstance());
@@ -149,7 +154,13 @@ public class AuthenticationCallbackHandler
         this.metrics = new Metrics(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
-
+        var tokenService =
+                new TokenService(
+                        configurationService,
+                        kmsConnectionService,
+                        orchAccessTokenService,
+                        orchRefreshTokenService,
+                        oidcApi);
         this.initiateIPVAuthorisationService =
                 new InitiateIPVAuthorisationService(
                         configurationService,
@@ -157,18 +168,22 @@ public class AuthenticationCallbackHandler
                         new IPVAuthorisationService(configurationService),
                         metrics,
                         new CrossBrowserOrchestrationService(configurationService),
-                        new TokenService(
-                                configurationService,
-                                kmsConnectionService,
-                                orchAccessTokenService,
-                                orchRefreshTokenService,
-                                oidcApi));
+                        tokenService);
         this.accountInterventionService =
                 new AccountInterventionService(configurationService, metrics, auditService);
         this.logoutService = new LogoutService(configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.crossBrowserOrchestrationService =
                 new CrossBrowserOrchestrationService(configurationService);
+        this.sisAuthorisationService =
+                new SISAuthorisationService(
+                        configurationService,
+                        tokenService,
+                        stateStorageService,
+                        crossBrowserOrchestrationService,
+                        new JwksCacheService(configurationService),
+                        new OrchJwtService(configurationService),
+                        new NowHelper.NowClock(Clock.systemUTC()));
     }
 
     public AuthenticationCallbackHandler(
@@ -188,7 +203,8 @@ public class AuthenticationCallbackHandler
             AccountInterventionService accountInterventionService,
             LogoutService logoutService,
             AuthFrontend authFrontend,
-            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
+            SISAuthorisationService sisAuthorisationService) {
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
@@ -206,6 +222,7 @@ public class AuthenticationCallbackHandler
         this.logoutService = logoutService;
         this.authFrontend = authFrontend;
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
+        this.sisAuthorisationService = sisAuthorisationService;
     }
 
     public APIGatewayProxyResponseEvent handleRequest(
@@ -502,19 +519,32 @@ public class AuthenticationCallbackHandler
                 }
 
                 if (identityRequired) {
-                    return initiateIPVAuthorisationService.sendRequestToIPV(
-                            input,
-                            authenticationRequest,
-                            userInfo,
-                            sessionId,
-                            client,
-                            clientId,
-                            clientSessionId,
-                            persistentSessionId,
-                            reproveIdentity,
-                            VectorOfTrust.getRequestedLevelsOfConfidence(
-                                    orchClientSession.getVtrList()),
-                            false);
+                    if (configurationService.isSisEnabled()) {
+                        // TODO send ORCH_SIS_AUTHORISATION_REQUESTED
+                        return sisAuthorisationService.sendRequest(
+                                authenticationRequest,
+                                userInfo,
+                                clientId,
+                                sessionId,
+                                clientSessionId,
+                                reproveIdentity,
+                                VectorOfTrust.getRequestedLevelsOfConfidence(
+                                        orchClientSession.getVtrList()));
+                    } else {
+                        return initiateIPVAuthorisationService.sendRequestToIPV(
+                                input,
+                                authenticationRequest,
+                                userInfo,
+                                sessionId,
+                                client,
+                                clientId,
+                                clientSessionId,
+                                persistentSessionId,
+                                reproveIdentity,
+                                VectorOfTrust.getRequestedLevelsOfConfidence(
+                                        orchClientSession.getVtrList()),
+                                false);
+                    }
                 }
 
                 URI clientRedirectURI = authenticationRequest.getRedirectionURI();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -183,6 +183,7 @@ public class AuthenticationCallbackHandler
                         crossBrowserOrchestrationService,
                         new JwksCacheService(configurationService),
                         new OrchJwtService(configurationService),
+                        auditService,
                         new NowHelper.NowClock(Clock.systemUTC()));
     }
 
@@ -520,7 +521,6 @@ public class AuthenticationCallbackHandler
 
                 if (identityRequired) {
                     if (configurationService.isSisEnabled()) {
-                        // TODO send ORCH_SIS_AUTHORISATION_REQUESTED
                         return sisAuthorisationService.sendRequest(
                                 authenticationRequest,
                                 userInfo,
@@ -529,7 +529,10 @@ public class AuthenticationCallbackHandler
                                 clientSessionId,
                                 reproveIdentity,
                                 VectorOfTrust.getRequestedLevelsOfConfidence(
-                                        orchClientSession.getVtrList()));
+                                        orchClientSession.getVtrList()),
+                                IpAddressHelper.extractIpAddress(input),
+                                persistentSessionId,
+                                client.getLandingPageUrl());
                     } else {
                         return initiateIPVAuthorisationService.sendRequestToIPV(
                                 input,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -97,6 +97,7 @@ import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchRefreshTokenService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
+import uk.gov.di.orchestration.sis.service.SISAuthorisationService;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -170,6 +171,8 @@ class AuthenticationCallbackHandlerTest {
     private static final LogoutService logoutService = mock(LogoutService.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final AuthFrontend authFrontend = mock(AuthFrontend.class);
+    private final SISAuthorisationService sisAuthorisationService =
+            mock(SISAuthorisationService.class);
     private static final String TEST_FRONTEND_BASE_URI = "http://example.com";
     private static final String TEST_FRONTEND_LOGIN_URI = "http://example.com/login";
     private static final String TEST_FRONTEND_ERROR_URI = "http://example.com/error";
@@ -303,7 +306,8 @@ class AuthenticationCallbackHandlerTest {
                         accountInterventionService,
                         logoutService,
                         authFrontend,
-                        CROSS_BROWSER_ORCHESTRATION_SERVICE);
+                        CROSS_BROWSER_ORCHESTRATION_SERVICE,
+                        sisAuthorisationService);
         orchSession.resetClientSessions();
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -311,6 +311,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getURLOrThrow("SIS_JWKS_URL");
     }
 
+    public boolean isSisEnabled() {
+        return getFlagOrFalse("SIS_ENABLED");
+    }
+
     public int getJwkCacheExpirationInSeconds() {
         return Integer.parseInt(
                 System.getenv().getOrDefault("JWK_CACHE_EXPIRATION_IN_SECONDS", "300"));

--- a/sis-api/src/main/java/uk/gov/di/orchestration/sis/domain/SISAuditableEvent.java
+++ b/sis-api/src/main/java/uk/gov/di/orchestration/sis/domain/SISAuditableEvent.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.sis.domain;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 
 public enum SISAuditableEvent implements AuditableEvent {
+    ORCH_SIS_AUTHORISATION_REQUESTED,
     ORCH_SIS_SUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
     ORCH_SIS_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
     ORCH_SIS_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,

--- a/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
+++ b/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
@@ -16,9 +16,11 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
@@ -38,6 +40,8 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem;
+import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.orchestration.sis.domain.SISAuditableEvent.ORCH_SIS_AUTHORISATION_REQUESTED;
 
 public class SISAuthorisationService {
     private static final String STATE_STORAGE_PREFIX = "sis-state:";
@@ -49,6 +53,7 @@ public class SISAuthorisationService {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final JwksCacheService jwksCacheService;
     private final OrchJwtService orchJwtService;
+    private final AuditService auditService;
     private final NowHelper.NowClock nowClock;
 
     public SISAuthorisationService(
@@ -58,6 +63,7 @@ public class SISAuthorisationService {
             CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             JwksCacheService jwksCacheService,
             OrchJwtService orchJwtService,
+            AuditService auditService,
             NowHelper.NowClock nowClock) {
         this.configurationService = configurationService;
         this.tokenService = tokenService;
@@ -65,6 +71,7 @@ public class SISAuthorisationService {
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.jwksCacheService = jwksCacheService;
         this.orchJwtService = orchJwtService;
+        this.auditService = auditService;
         this.nowClock = nowClock;
     }
 
@@ -75,7 +82,10 @@ public class SISAuthorisationService {
             String sessionId,
             String clientSessionId,
             Boolean reproveIdentity,
-            List<String> levelsOfConfidence) {
+            List<String> levelsOfConfidence,
+            String ipAddress,
+            String persistentSessionCookieId,
+            String landingPageUrl) {
         if (!configurationService.isIdentityEnabled()) {
             LOG.error("Identity is not enabled");
             throw new RuntimeException("Identity is not enabled");
@@ -109,7 +119,20 @@ public class SISAuthorisationService {
                         .build();
         stateStorageService.storeState(STATE_STORAGE_PREFIX + sessionId, state.getValue());
         crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
-        // TODO: Add audit events
+        var rpPairwiseId = userInfo.getClaim("rp_pairwise_id");
+
+        auditService.submitAuditEventNoPrefix(
+                ORCH_SIS_AUTHORISATION_REQUESTED,
+                rpClientID,
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(clientSessionId)
+                        .withSessionId(sessionId)
+                        .withUserId(internalCommonSubjectId.getValue())
+                        .withEmail(userInfo.getEmailAddress())
+                        .withIpAddress(ipAddress)
+                        .withPersistentSessionId(persistentSessionCookieId),
+                pair("clientLandingPageUrl", landingPageUrl),
+                pair("rpPairwiseId", rpPairwiseId));
         // TODO: Add cloudwatch metric for SISHandoff
         LOG.info(
                 "Successfully processed SIS authorisation request, redirect URI {}",

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.MockedStatic;
 import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
@@ -99,6 +100,7 @@ class SISAuthorisationServiceTest {
             mock(CrossBrowserOrchestrationService.class);
     private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
     private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
+    private final AuditService auditService = mock(AuditService.class);
     private SISAuthorisationService authorisationService;
 
     private RSAPublicKey publicEncKey;
@@ -136,6 +138,7 @@ class SISAuthorisationServiceTest {
                         crossBrowserOrchestrationService,
                         jwksCacheService,
                         orchJwtService,
+                        auditService,
                         new NowHelper.NowClock(Clock.fixed(NOW, ZoneOffset.UTC)));
     }
 
@@ -158,7 +161,10 @@ class SISAuthorisationServiceTest {
                                             SESSION_ID,
                                             CLIENT_SESSION_ID,
                                             false,
-                                            LEVELS_OF_CONFIDENCE),
+                                            LEVELS_OF_CONFIDENCE,
+                                            "123.123.123.123",
+                                            "test-psid",
+                                            "http://test-landing-page"),
                             "Expected to throw exception");
 
             assertThat(exception.getMessage(), equalTo("Identity is not enabled"));
@@ -229,7 +235,10 @@ class SISAuthorisationServiceTest {
                             SESSION_ID,
                             CLIENT_SESSION_ID,
                             false,
-                            LEVELS_OF_CONFIDENCE);
+                            LEVELS_OF_CONFIDENCE,
+                            "123.123.123.123",
+                            "test-psid",
+                            "http://test-landing-page");
             assertThat(response, hasStatus(302));
             String redirectLocation = response.getHeaders().get("Location");
             assertThat(redirectLocation, startsWith(SIS_AUTHORISATION_URI.toString()));

--- a/template.yaml
+++ b/template.yaml
@@ -168,6 +168,7 @@ Conditions:
         !Equals [production, !Ref Environment],
       ],
     ]
+  SisEnabled: !Equals [dev, !Ref Environment]
   #endregion
 
   # Comment to force re-deployment of template - this can be deleted once the staging API GW/CloudFront migration is complete.
@@ -184,6 +185,7 @@ Mappings:
       newauthAccountId: "975050272416"
       authEnvironment: authdev3
       serviceDomain: authdev3.dev.account.gov.uk
+      orchServiceDomain: dev.account.gov.uk
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:653994557586:key/17e5e566-4e99-43b4-ad59-e1ef924a582b
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:653994557586:authdev3-back-channel-logout-queue
       docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
@@ -220,6 +222,7 @@ Mappings:
       newauthAccountId: "058264536367"
       authEnvironment: build
       serviceDomain: build.account.gov.uk
+      orchServiceDomain: build.account.gov.uk
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:761723964695:build-back-channel-logout-queue
       docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
       docAppDomain: https://dcmaw-cri.build.stubs.account.gov.uk
@@ -3137,12 +3140,80 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
+          SIS_ENABLED: !If
+            - SisEnabled
+            - true
+            - false
+          SIS_AUDIENCE: !If
+            - IpvExists
+            - !Sub
+              - https://reuse-identity.${ServiceDomain}
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ]
+            - !Sub
+              - https://sisstub.oidc.${ServiceDomain}
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    orchServiceDomain,
+                  ]
+          SIS_AUTHORISATION_CALLBACK_URI: !Sub
+            - https://oidc.${ServiceDomain}/sis-callback
+            - ServiceDomain:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  serviceDomain,
+                ]
+          SIS_AUTHORISATION_CLIENT_ID: authOrchestrator
+          SIS_AUTHORISATION_URI: !If
+            - IpvExists
+            - !Sub
+              - https://reuse-identity.${ServiceDomain}/oauth2/authorize
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ]
+            - !Sub
+              - https://sisstub.oidc.${ServiceDomain}/authorize
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    orchServiceDomain,
+                  ]
+          SIS_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchSISTokenSigningKmsKeyAlias
+          SIS_JWKS_URL: !If
+            - IpvExists
+            - !Sub
+              - https://reuse-identity.${ServiceDomain}/.well-known/jwks.json
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    serviceDomain,
+                  ]
+            - !Sub
+              - https://sisstub.oidc.${ServiceDomain}/.well-known/jwks.json
+              - ServiceDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    orchServiceDomain,
+                  ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref AuthUserInfoTableReadWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref StorageTokenSigningKmsAccessPolicy
-        - !Ref IpvTokenSigningKmsAccessPolicy
+        - !Ref IdentityTokenSigningKmsAccessPolicy
         - !Ref OrchToAuthSigningKmsAccessPolicy
         - !Ref AuthPublicEncryptionKeyAccessPolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy


### PR DESCRIPTION
### Wider context of change

We should now have an SISCallbackHandler setup, and the sis-stub is now setup in dev. We can now redirect to the SIS stub in dev from the auth callback handler

### What’s changed

This PR adds a feature flag to redirect the user to SIS instead of IPV when they are on an identity journey. This is only enabled in dev at the moment and should be using the sis stub.

I've also added the final SIS auth requested audit event, and have emitted it in the createAuthRequest method.

### Manual testing

Have deployed to dev, saw that when performing an identity journey I got redirected to the SIS stub first instead of the IPV stub.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
