### PR TITLE
BAU: Support UTC offset timestamps in IAD last active date calculation

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -17,6 +17,8 @@ import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +28,13 @@ public class InactiveAccountDataExportHelper {
 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHelper.class);
     private static final long BASE_BACKOFF_MS = 100;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    .optionalStart()
+                    .appendOffsetId()
+                    .optionalEnd()
+                    .toFormatter();
 
     public record LastActiveDate(String timestamp, String source) {}
 
@@ -88,7 +97,8 @@ public class InactiveAccountDataExportHelper {
             }
 
             try {
-                LocalDateTime parsed = LocalDateTime.parse(candidate.timestamp());
+                LocalDateTime parsed =
+                        LocalDateTime.parse(candidate.timestamp(), DATE_TIME_FORMATTER);
                 if (mostRecent == null || parsed.isAfter(mostRecent)) {
                     mostRecent = parsed;
                     mostRecentSource = candidate.source();

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -441,6 +441,21 @@ class InactiveAccountDataExportHelperTest {
     }
 
     @Test
+    void calculateLastActiveDateShouldHandleTimestampWithUtcOffsetSuffix() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2026-08-13T15:22:10.000Z").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2025-05-19T20:48:40.000375").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+
+        assertEquals("2026-08-13T15:22:10", result.timestamp());
+        assertEquals("UserProfile.Created", result.source());
+    }
+
+    @Test
     void calculateLastActiveDateShouldHandleOnlyCredentialsItemProvided() {
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of(


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Support UTC offset timestamps in IAD last active date calculation (e.g., `2026-08-13T15:22:10.000Z`).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env, set an accounts timestamps to use UTC offset, run the `inactive-account-data-export-lambda`, check that there were no parsing failures.

## Testing

I have ran through the above steps and confirmed the timestamps previously failing on staging (and copied over to dev) are now supported.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils Lambda only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils Lambda only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, utils Lambda only**
