### PR TITLE
AUT-5688: Update IAD export config to expected values

### DIFF
--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -490,16 +490,16 @@ Mappings:
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
       frontendApiFMSTagValue: "authenticationfrontend"
-      inactiveAccountExportParallelism: "200"
-      inactiveAccountExportTotalSegments: "200"
-      inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportParallelism: "5"
+      inactiveAccountExportTotalSegments: "125"
+      inactiveAccountExportMaxRetries: "7"
+      inactiveAccountExportMaxItemsPerSegment: "2000"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableAccountId: "026991849909"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:026991849909:key/5489c67b-2c14-4b76-b6a3-a25148b14311
       inactiveAccountExportTableName: "inactive_account_tracker_store"
-      inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportBatchWriteMaxRetries: "7"
+      inactiveAccountExportMaxInvocations: "150"
       inactiveAccountExportTrackerWriteEnabled: "false"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -446,16 +446,16 @@ Mappings:
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
       frontendApiFMSTagValue: "authenticationfrontend"
-      inactiveAccountExportParallelism: "200"
-      inactiveAccountExportTotalSegments: "200"
-      inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportParallelism: "5"
+      inactiveAccountExportTotalSegments: "125"
+      inactiveAccountExportMaxRetries: "7"
+      inactiveAccountExportMaxItemsPerSegment: "2000"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableAccountId: "666500506359"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:666500506359:key/1ab2a72b-63e0-49b6-b88a-5160a7d27985
       inactiveAccountExportTableName: "inactive_account_tracker_store"
-      inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "0"
+      inactiveAccountExportBatchWriteMaxRetries: "7"
+      inactiveAccountExportMaxInvocations: "150"
       inactiveAccountExportTrackerWriteEnabled: "false"
 
     production:

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -402,16 +402,16 @@ Mappings:
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
       frontendApiFMSTagValue: "authenticationfrontend"
-      inactiveAccountExportParallelism: "20"
-      inactiveAccountExportTotalSegments: "150"
-      inactiveAccountExportMaxRetries: "3"
-      inactiveAccountExportMaxItemsPerSegment: "2500"
+      inactiveAccountExportParallelism: "5"
+      inactiveAccountExportTotalSegments: "125"
+      inactiveAccountExportMaxRetries: "7"
+      inactiveAccountExportMaxItemsPerSegment: "2000"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableAccountId: "539729775994"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:539729775994:key/5191526d-1c85-4316-baf7-9fbe373880cf
       inactiveAccountExportTableName: "inactive_account_tracker_store"
-      inactiveAccountExportBatchWriteMaxRetries: "3"
-      inactiveAccountExportMaxInvocations: "25"
+      inactiveAccountExportBatchWriteMaxRetries: "7"
+      inactiveAccountExportMaxInvocations: "40"
       inactiveAccountExportTrackerWriteEnabled: "true"
 
     integration:

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
@@ -80,10 +80,6 @@ public class InactiveAccountDataExportBatchWriteService {
         if (dryRun) {
             totalWritten += itemCount;
             totalBatchesFlushed++;
-            LOG.info(
-                    "Dry-run mode enabled: {} items would have been written to tracker table (batch {})",
-                    itemCount,
-                    totalBatchesFlushed);
             return;
         }
 
@@ -106,11 +102,17 @@ public class InactiveAccountDataExportBatchWriteService {
             if (!writeRequests.isEmpty()) {
                 retryCount++;
                 if (retryCount > maxRetries) {
-                    LOG.error(
-                            "Failed to write {} items after {} retries",
-                            writeRequests.size(),
-                            maxRetries);
                     totalFailed += writeRequests.size();
+                    LOG.error(
+                            "Failed to write {} items to table '{}' after {} retries. "
+                                    + "totalWrittenSoFar={}, totalFailedSoFar={}, batchesFlushedSoFar={}",
+                            writeRequests.size(),
+                            tableName,
+                            maxRetries,
+                            totalWritten,
+                            totalFailed,
+                            totalBatchesFlushed);
+
                     break;
                 }
                 LOG.warn(


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Remove "dry-run" log - not very useful and produces a lot of events
- Reduce staging config to account for hot partitions on `user-credentials` table
- Set expected integration and production config

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils change only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils change only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A, utils change only**
