### PR TITLE
AUT-5609: Create initial IAD queue processor

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -171,14 +171,21 @@ public class AuthorizeHandler
             return Result.failure(new UnauthorizedException());
         }
 
-        var amcClientId = configurationService.getAMCClientId();
-        var homeClientId = configurationService.getHomeClientId();
         var clientId = (String) claimsSet.getClaim(CLIENT_ID_CLAIM);
-        if (!amcClientId.equals(clientId) && !homeClientId.equals(clientId)) {
+        if (!isAllowedClientId(clientId)) {
             LOG.warn("Access Token client_id is invalid");
             return Result.failure(new UnauthorizedException());
         }
         return Result.success(claimsSet);
+    }
+
+    private boolean isAllowedClientId(String clientId) {
+        var allowedClientIds =
+                List.of(
+                        configurationService.getAMCClientId(),
+                        configurationService.getHomeClientId(),
+                        configurationService.getInactiveAccountDeletionClientId());
+        return allowedClientIds.contains(clientId);
     }
 
     private IamPolicyResponseV1 getAllowExecuteApiPolicyForSubject(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
@@ -50,6 +50,10 @@ public class ConfigurationService implements DynamoConfiguration {
         return System.getenv().getOrDefault("HOME_CLIENT_ID", "");
     }
 
+    public String getInactiveAccountDeletionClientId() {
+        return System.getenv().getOrDefault("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
     public String getAuthToAccountDataApiAudience() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "");
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -59,6 +59,7 @@ class AuthorizeHandlerTest {
     private static final String AUDIENCE = "https://account-data.example.com";
     private static final String CLIENT_ID = "some-client-id";
     private static final String HOME_CLIENT_ID = "home-client-id";
+    private static final String INACTIVE_ACCOUNT_DELETION_CLIENT_ID = "inactive-account-deletion";
 
     private static ECKey ecSigningKey;
     private APIGatewayCustomAuthorizerEvent event;
@@ -78,6 +79,8 @@ class AuthorizeHandlerTest {
         when(configurationService.getAuthToAccountDataApiAudience()).thenReturn(AUDIENCE);
         when(configurationService.getAMCClientId()).thenReturn(CLIENT_ID);
         when(configurationService.getHomeClientId()).thenReturn(HOME_CLIENT_ID);
+        when(configurationService.getInactiveAccountDeletionClientId())
+                .thenReturn(INACTIVE_ACCOUNT_DELETION_CLIENT_ID);
     }
 
     @AfterEach
@@ -129,6 +132,46 @@ class AuthorizeHandlerTest {
                             }
                             """
                             .formatted(SUBJECT, scope, METHOD_ARN);
+
+            assertEquals(
+                    JsonParser.parseString(expectedPolicyDocument),
+                    JsonParser.parseString(new Gson().toJson(result)));
+        }
+
+        @Test
+        void authorizeHandlerShouldAllowInactiveAccountDeletionClientId() throws JOSEException {
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow,
+                            ecSigningKey,
+                            AccountDataScope.ACCOUNT_DELETE.getValue(),
+                            INACTIVE_ACCOUNT_DELETION_CLIENT_ID);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            var result = handler.handleRequest(event, context);
+
+            var expectedPolicyDocument =
+                    """
+                            {
+                                "principalId": "%s",
+                                "context": {"scope": "%s"},
+                                "policyDocument": {
+                                    "version": "2012-10-17",
+                                    "statement": [{
+                                        "action": "execute-api:Invoke",
+                                        "effect": "Allow",
+                                        "resource": ["%s"]
+                                    }]
+                                }
+                            }
+                            """
+                            .formatted(
+                                    SUBJECT,
+                                    AccountDataScope.ACCOUNT_DELETE.getValue(),
+                                    METHOD_ARN);
 
             assertEquals(
                     JsonParser.parseString(expectedPolicyDocument),
@@ -373,6 +416,8 @@ class AuthorizeHandlerTest {
         void authorizeHandlerShouldRejectInvalidClientId() throws JOSEException {
             when(configurationService.getAMCClientId()).thenReturn("expected-client-id");
             when(configurationService.getHomeClientId()).thenReturn("expected-home-client-id");
+            when(configurationService.getInactiveAccountDeletionClientId())
+                    .thenReturn("expected-iad-client-id");
 
             var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
@@ -68,6 +68,12 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getInactiveAccountDeletionClientIdShouldDefaultToEmptyString() {
+        environment.set("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", null);
+        assertEquals("", configurationService.getInactiveAccountDeletionClientId());
+    }
+
+    @Test
     void getAuthToAccountDataApiAudienceShouldDefaultToEmptyString() {
         environment.set("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", null);
         assertEquals("", configurationService.getAuthToAccountDataApiAudience());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/InactiveAccountDeletionMessage.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/InactiveAccountDeletionMessage.java
@@ -1,0 +1,7 @@
+package uk.gov.di.accountmanagement.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public record InactiveAccountDeletionMessage(
+        @Expose @SerializedName("publicSubjectId") String publicSubjectId) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -1,0 +1,86 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.accountmanagement.entity.InactiveAccountDeletionMessage;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.util.ArrayList;
+
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceId;
+
+public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
+
+    private static final Logger LOG = LogManager.getLogger(InactiveAccountDeletionHandler.class);
+
+    private final Json objectMapper = SerializationService.getInstance();
+    private final ConfigurationService configurationService;
+
+    public InactiveAccountDeletionHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public InactiveAccountDeletionHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public SQSBatchResponse handleRequest(SQSEvent event, Context context) {
+        return segmentedFunctionCall(
+                "account-management-api::" + getClass().getSimpleName(),
+                () -> processMessages(event));
+    }
+
+    public SQSBatchResponse processMessages(SQSEvent event) {
+        attachTraceId();
+
+        var failures = new ArrayList<SQSBatchResponse.BatchItemFailure>();
+
+        if (event == null || event.getRecords() == null) {
+            LOG.warn("Received null event or null records");
+            return new SQSBatchResponse(failures);
+        }
+
+        LOG.info("Processing inactive account deletion batch, size: {}", event.getRecords().size());
+
+        for (SQSMessage msg : event.getRecords()) {
+            try {
+                var message = parseMessage(msg);
+                LOG.info(
+                        "Processing inactive account deletion for publicSubjectId: {}",
+                        message.publicSubjectId());
+                throw new UnsupportedOperationException("Deletion not yet implemented");
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to process inactive account deletion message with id: {}",
+                        msg.getMessageId(),
+                        e);
+                failures.add(new SQSBatchResponse.BatchItemFailure(msg.getMessageId()));
+            }
+        }
+
+        LOG.info(
+                "Completed batch processing. Failures: {}/{}",
+                failures.size(),
+                event.getRecords().size());
+        return new SQSBatchResponse(failures);
+    }
+
+    private InactiveAccountDeletionMessage parseMessage(SQSMessage msg) throws JsonException {
+        var message = objectMapper.readValue(msg.getBody(), InactiveAccountDeletionMessage.class);
+        if (message.publicSubjectId() == null || message.publicSubjectId().isBlank()) {
+            throw new IllegalArgumentException(
+                    "publicSubjectId is missing or blank in message: " + msg.getMessageId());
+        }
+        return message;
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -8,8 +8,11 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.InactiveAccountDeletionMessage;
+import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
@@ -23,14 +26,26 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDeletionHandler.class);
 
     private final Json objectMapper = SerializationService.getInstance();
-    private final ConfigurationService configurationService;
+    private final InactiveAccountDeletionTokenService tokenService;
+    private final AccountDeletionService accountDeletionService;
 
     public InactiveAccountDeletionHandler() {
         this(ConfigurationService.getInstance());
     }
 
     public InactiveAccountDeletionHandler(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
+        this.tokenService = new InactiveAccountDeletionTokenService(configurationService);
+        var accountDataApiService = new AccountDataApiService(configurationService);
+        this.accountDeletionService =
+                new AccountDeletionService(
+                        null, null, null, configurationService, null, accountDataApiService);
+    }
+
+    public InactiveAccountDeletionHandler(
+            InactiveAccountDeletionTokenService tokenService,
+            AccountDeletionService accountDeletionService) {
+        this.tokenService = tokenService;
+        this.accountDeletionService = accountDeletionService;
     }
 
     @Override
@@ -58,7 +73,8 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                 LOG.info(
                         "Processing inactive account deletion for publicSubjectId: {}",
                         message.publicSubjectId());
-                throw new UnsupportedOperationException("Deletion not yet implemented");
+
+                deleteAccount(message.publicSubjectId());
             } catch (Exception e) {
                 LOG.error(
                         "Failed to process inactive account deletion message with id: {}",
@@ -73,6 +89,17 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                 failures.size(),
                 event.getRecords().size());
         return new SQSBatchResponse(failures);
+    }
+
+    private void deleteAccount(String publicSubjectId) {
+        var tokenResult = tokenService.createAccountDataApiAccessToken(publicSubjectId);
+        if (tokenResult.isFailure()) {
+            throw new RuntimeException(
+                    "Failed to mint account-delete token for publicSubjectId: " + publicSubjectId);
+        }
+        var token = tokenResult.getSuccess().getValue();
+
+        accountDeletionService.deleteAccountViaDataApi(publicSubjectId, token);
     }
 
     private InactiveAccountDeletionMessage parseMessage(SQSMessage msg) throws JsonException {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -188,7 +188,7 @@ public class AccountDeletionService {
         }
     }
 
-    private void deleteAccountViaDataApi(String publicSubjectId, String token) {
+    public void deleteAccountViaDataApi(String publicSubjectId, String token) {
         try {
             var response = accountDataApiService.deleteAccount(publicSubjectId, token);
             int statusCode = response.statusCode();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/InactiveAccountDeletionTokenService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/InactiveAccountDeletionTokenService.java
@@ -1,0 +1,64 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class InactiveAccountDeletionTokenService {
+
+    private static final Logger LOG =
+            LogManager.getLogger(InactiveAccountDeletionTokenService.class);
+
+    private static final long ACCESS_TOKEN_LIFETIME_MINUTES = 5L;
+
+    private final ConfigurationService configurationService;
+    private final AccessTokenConstructorService accessTokenConstructorService;
+    private final NowHelper.NowClock nowClock;
+
+    public InactiveAccountDeletionTokenService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.accessTokenConstructorService =
+                new AccessTokenConstructorService(configurationService);
+        this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
+    }
+
+    public InactiveAccountDeletionTokenService(
+            ConfigurationService configurationService,
+            AccessTokenConstructorService accessTokenConstructorService,
+            NowHelper.NowClock nowClock) {
+        this.configurationService = configurationService;
+        this.accessTokenConstructorService = accessTokenConstructorService;
+        this.nowClock = nowClock;
+    }
+
+    public Result<JwtFailureReason, BearerAccessToken> createAccountDataApiAccessToken(
+            String publicSubjectId) {
+        return accessTokenConstructorService
+                .createSignedAccessToken(
+                        publicSubjectId,
+                        List.of(AccountDataScope.ACCOUNT_DELETE),
+                        nowClock.now(),
+                        nowClock.nowPlus(ACCESS_TOKEN_LIFETIME_MINUTES, ChronoUnit.MINUTES),
+                        configurationService.getAuthToAccountDataApiAudience(),
+                        configurationService.getAuthIssuerClaim(),
+                        configurationService.getInactiveAccountDeletionClientId(),
+                        configurationService.getAuthToAccountDataSigningKey())
+                .mapFailure(
+                        failure -> {
+                            LOG.error(
+                                    "Error creating account-delete access token for inactive account deletion. Error: {}",
+                                    failure);
+                            return failure;
+                        });
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/InactiveAccountDeletionMessageTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/InactiveAccountDeletionMessageTest.java
@@ -1,0 +1,40 @@
+package uk.gov.di.accountmanagement.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class InactiveAccountDeletionMessageTest {
+
+    private final Json objectMapper = SerializationService.getInstance();
+
+    @Test
+    void shouldDeserializeValidMessage() throws Json.JsonException {
+        String json = "{\"publicSubjectId\": \"urn:fdc:gov.uk:2022:abc123\"}";
+
+        var message = objectMapper.readValue(json, InactiveAccountDeletionMessage.class);
+
+        assertEquals("urn:fdc:gov.uk:2022:abc123", message.publicSubjectId());
+    }
+
+    @Test
+    void shouldDeserializeMessageWithNullPublicSubjectId() throws Json.JsonException {
+        String json = "{}";
+
+        var message = objectMapper.readValue(json, InactiveAccountDeletionMessage.class);
+
+        assertNull(message.publicSubjectId());
+    }
+
+    @Test
+    void shouldIgnoreUnknownFields() throws Json.JsonException {
+        String json = "{\"publicSubjectId\": \"sub-123\", \"extraField\": \"should-be-ignored\"}";
+
+        var message = objectMapper.readValue(json, InactiveAccountDeletionMessage.class);
+
+        assertEquals("sub-123", message.publicSubjectId());
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -4,9 +4,13 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
 
 import java.util.List;
 
@@ -15,27 +19,72 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class InactiveAccountDeletionHandlerTest {
 
+    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String TOKEN_VALUE = "test-bearer-token";
+
     private final Context context = mock(Context.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final InactiveAccountDeletionTokenService tokenService =
+            mock(InactiveAccountDeletionTokenService.class);
+    private final AccountDeletionService accountDeletionService =
+            mock(AccountDeletionService.class);
     private InactiveAccountDeletionHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new InactiveAccountDeletionHandler(configurationService);
+        handler = new InactiveAccountDeletionHandler(tokenService, accountDeletionService);
+        when(tokenService.createAccountDataApiAccessToken(any()))
+                .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
     }
 
     @Test
-    void shouldReportValidMessageAsFailureUntilDeletionIsImplemented() {
-        var event = createSQSEventWithBody("{\"publicSubjectId\": \"urn:fdc:gov.uk:2022:abc123\"}");
+    void shouldSuccessfullyDeleteAccountAndReportNoFailures() {
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+        doNothing()
+                .when(accountDeletionService)
+                .deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+        verify(tokenService).createAccountDataApiAccessToken(PUBLIC_SUBJECT_ID);
+        verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+    }
+
+    @Test
+    void shouldReportFailureWhenDeletionThrows() {
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+        doThrow(new RuntimeException("Data API returned error status 500"))
+                .when(accountDeletionService)
+                .deleteAccountViaDataApi(any(), any());
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+    }
+
+    @Test
+    void shouldReportFailureWhenTokenMintingFails() {
+        when(tokenService.createAccountDataApiAccessToken(any()))
+                .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(accountDeletionService);
     }
 
     @Test
@@ -46,6 +95,7 @@ class InactiveAccountDeletionHandlerTest {
 
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(accountDeletionService);
     }
 
     @Test
@@ -55,7 +105,7 @@ class InactiveAccountDeletionHandlerTest {
         SQSBatchResponse response = handler.handleRequest(event, context);
 
         assertThat(response.getBatchItemFailures(), hasSize(1));
-        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(accountDeletionService);
     }
 
     @Test
@@ -65,7 +115,7 @@ class InactiveAccountDeletionHandlerTest {
         SQSBatchResponse response = handler.handleRequest(event, context);
 
         assertThat(response.getBatchItemFailures(), hasSize(1));
-        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(accountDeletionService);
     }
 
     @Test
@@ -73,20 +123,28 @@ class InactiveAccountDeletionHandlerTest {
         SQSBatchResponse response = handler.handleRequest(null, context);
 
         assertThat(response.getBatchItemFailures(), is(empty()));
+        verifyNoInteractions(accountDeletionService);
     }
 
     @Test
-    void shouldProcessMultipleMessagesAndReportAllAsFailuresUntilDeletionIsImplemented() {
-        var validMessage = createSQSMessage("msg-good", "{\"publicSubjectId\": \"sub-1\"}");
-        var invalidMessage = createSQSMessage("msg-bad", "invalid json");
-        var anotherValid = createSQSMessage("msg-good-2", "{\"publicSubjectId\": \"sub-2\"}");
+    void shouldProcessBatchWithMixedSuccessAndFailure() {
+        var goodMessage = createSQSMessage("msg-good", "{\"publicSubjectId\": \"sub-1\"}");
+        var badMessage = createSQSMessage("msg-bad", "invalid json");
+        var failingMessage = createSQSMessage("msg-fail", "{\"publicSubjectId\": \"sub-2\"}");
+
+        doNothing().when(accountDeletionService).deleteAccountViaDataApi(eq("sub-1"), any());
+        doThrow(new RuntimeException("5xx"))
+                .when(accountDeletionService)
+                .deleteAccountViaDataApi(eq("sub-2"), any());
 
         var event = new SQSEvent();
-        event.setRecords(List.of(validMessage, invalidMessage, anotherValid));
+        event.setRecords(List.of(goodMessage, badMessage, failingMessage));
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
-        assertThat(response.getBatchItemFailures(), hasSize(3));
+        assertThat(response.getBatchItemFailures(), hasSize(2));
+        assertEquals("msg-bad", response.getBatchItemFailures().get(0).getItemIdentifier());
+        assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
     }
 
     private SQSEvent createSQSEventWithBody(String body) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -1,0 +1,105 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class InactiveAccountDeletionHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private InactiveAccountDeletionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new InactiveAccountDeletionHandler(configurationService);
+    }
+
+    @Test
+    void shouldReportValidMessageAsFailureUntilDeletionIsImplemented() {
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"urn:fdc:gov.uk:2022:abc123\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+    }
+
+    @Test
+    void shouldReportMalformedJsonAsFailure() {
+        var event = createSQSEventWithBody("not valid json");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+    }
+
+    @Test
+    void shouldReportMissingPublicSubjectIdAsFailure() {
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+    }
+
+    @Test
+    void shouldReportNullPublicSubjectIdAsFailure() {
+        var event = createSQSEventWithBody("{}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+    }
+
+    @Test
+    void shouldHandleNullEvent() {
+        SQSBatchResponse response = handler.handleRequest(null, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+    }
+
+    @Test
+    void shouldProcessMultipleMessagesAndReportAllAsFailuresUntilDeletionIsImplemented() {
+        var validMessage = createSQSMessage("msg-good", "{\"publicSubjectId\": \"sub-1\"}");
+        var invalidMessage = createSQSMessage("msg-bad", "invalid json");
+        var anotherValid = createSQSMessage("msg-good-2", "{\"publicSubjectId\": \"sub-2\"}");
+
+        var event = new SQSEvent();
+        event.setRecords(List.of(validMessage, invalidMessage, anotherValid));
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(3));
+    }
+
+    private SQSEvent createSQSEventWithBody(String body) {
+        var message = createSQSMessage("msg-1", body);
+        var event = new SQSEvent();
+        event.setRecords(List.of(message));
+        return event;
+    }
+
+    private SQSMessage createSQSMessage(String messageId, String body) {
+        var message = new SQSMessage();
+        message.setMessageId(messageId);
+        message.setBody(body);
+        return message;
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/InactiveAccountDeletionTokenServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/InactiveAccountDeletionTokenServiceTest.java
@@ -1,0 +1,93 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InactiveAccountDeletionTokenServiceTest {
+
+    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String AUDIENCE = "https://account.test.account.gov.uk";
+    private static final String ISSUER = "https://signin.test.account.gov.uk";
+    private static final String CLIENT_ID = "inactive-account-deletion";
+    private static final String SIGNING_KEY = "test-signing-key-id";
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccessTokenConstructorService accessTokenConstructorService =
+            mock(AccessTokenConstructorService.class);
+    private final Clock fixedClock =
+            Clock.fixed(Instant.parse("2026-08-17T12:00:00Z"), ZoneId.of("UTC"));
+    private final NowHelper.NowClock nowClock = new NowHelper.NowClock(fixedClock);
+
+    private InactiveAccountDeletionTokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getAuthToAccountDataApiAudience()).thenReturn(AUDIENCE);
+        when(configurationService.getAuthIssuerClaim()).thenReturn(ISSUER);
+        when(configurationService.getInactiveAccountDeletionClientId()).thenReturn(CLIENT_ID);
+        when(configurationService.getAuthToAccountDataSigningKey()).thenReturn(SIGNING_KEY);
+
+        tokenService =
+                new InactiveAccountDeletionTokenService(
+                        configurationService, accessTokenConstructorService, nowClock);
+    }
+
+    @Test
+    void shouldCreateAccessTokenWithCorrectParameters() {
+        var expectedToken = new BearerAccessToken("test-token-value");
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Result.success(expectedToken));
+
+        var result = tokenService.createAccountDataApiAccessToken(PUBLIC_SUBJECT_ID);
+
+        assertTrue(result.isSuccess());
+        assertEquals(expectedToken, result.getSuccess());
+
+        var expectedIssueTime = Date.from(fixedClock.instant());
+
+        verify(accessTokenConstructorService)
+                .createSignedAccessToken(
+                        eq(PUBLIC_SUBJECT_ID),
+                        eq(List.of(AccountDataScope.ACCOUNT_DELETE)),
+                        eq(expectedIssueTime),
+                        any(Date.class),
+                        eq(AUDIENCE),
+                        eq(ISSUER),
+                        eq(CLIENT_ID),
+                        eq(SIGNING_KEY));
+    }
+
+    @Test
+    void shouldReturnFailureWhenTokenCreationFails() {
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+        var result = tokenService.createAccountDataApiAccessToken(PUBLIC_SUBJECT_ID);
+
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
+    }
+}

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
@@ -1,0 +1,205 @@
+package uk.gov.di.accountmanagement.queuehandlers;
+
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import uk.gov.di.accountmanagement.lambda.InactiveAccountDeletionHandler;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SystemStubsExtension.class)
+class InactiveAccountDeletionHandlerIntegrationTest
+        extends HandlerIntegrationTest<SQSEvent, SQSBatchResponse> {
+
+    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String IAD_CLIENT_ID = "inactive-account-deletion-client";
+
+    private WireMockServer accountDataApiWireMockServer;
+
+    @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
+
+    @RegisterExtension
+    private static final KmsKeyExtension authToAccountDataSigningKey =
+            new KmsKeyExtension("auth-to-account-data-signing-key", KeyUsageType.SIGN_VERIFY);
+
+    @BeforeAll
+    static void setupEnvironment() {
+        environment.set("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "https://example.com/ADAPIAudience");
+        environment.set("AUTH_ISSUER_CLAIM", "https://signin.account.gov.uk/");
+        environment.set("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", IAD_CLIENT_ID);
+        environment.set("AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", authToAccountDataSigningKey.getKeyId());
+    }
+
+    @BeforeEach
+    void setUp() {
+        accountDataApiWireMockServer =
+                new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        accountDataApiWireMockServer.start();
+
+        var configService =
+                createConfigServiceWithAccountDataUri(
+                        "http://localhost:" + accountDataApiWireMockServer.port());
+        handler = new InactiveAccountDeletionHandler(configService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (accountDataApiWireMockServer != null) {
+            accountDataApiWireMockServer.stop();
+        }
+    }
+
+    @Test
+    void shouldSuccessfullyDeleteAccountViaDataApi() {
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                        .willReturn(aResponse().withStatus(204)));
+
+        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+        accountDataApiWireMockServer.verify(
+                1,
+                deleteRequestedFor(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                        .withHeader("Authorization", WireMock.matching("Bearer .+")));
+    }
+
+    @Test
+    void shouldReportFailureWhenDataApiReturns404() {
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                        .willReturn(aResponse().withStatus(404)));
+
+        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+    }
+
+    @Test
+    void shouldReportFailureWhenDataApiReturns500() {
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                        .willReturn(aResponse().withStatus(500)));
+
+        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+    }
+
+    @Test
+    void shouldReportFailureForMalformedMessage() {
+        var event = createSQSEventWithRawBody("not valid json");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        accountDataApiWireMockServer.verify(0, deleteRequestedFor(urlPathMatching("/accounts/.*")));
+    }
+
+    @Test
+    void shouldReportFailureForMissingPublicSubjectId() {
+        var event = createSQSEventWithRawBody("{\"publicSubjectId\": \"\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        accountDataApiWireMockServer.verify(0, deleteRequestedFor(urlPathMatching("/accounts/.*")));
+    }
+
+    @Test
+    void shouldProcessBatchWithMixedSuccessAndFailure() {
+        var successSubjectId = "urn:fdc:gov.uk:2022:success";
+        var failSubjectId = "urn:fdc:gov.uk:2022:fail";
+
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + successSubjectId))
+                        .willReturn(aResponse().withStatus(204)));
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + failSubjectId))
+                        .willReturn(aResponse().withStatus(500)));
+
+        var goodMessage = createSQSMessage("msg-good", successSubjectId);
+        var badMessage = createRawSQSMessage("msg-bad", "invalid json");
+        var failMessage = createSQSMessage("msg-fail", failSubjectId);
+
+        var event = new SQSEvent();
+        event.setRecords(List.of(goodMessage, badMessage, failMessage));
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(2));
+        assertEquals("msg-bad", response.getBatchItemFailures().get(0).getItemIdentifier());
+        assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
+
+        accountDataApiWireMockServer.verify(
+                1, deleteRequestedFor(urlPathMatching("/accounts/" + successSubjectId)));
+        accountDataApiWireMockServer.verify(
+                1, deleteRequestedFor(urlPathMatching("/accounts/" + failSubjectId)));
+    }
+
+    private SQSEvent createSQSEvent(String publicSubjectId) {
+        String body = "{\"publicSubjectId\": \"" + publicSubjectId + "\"}";
+        return createSQSEventWithRawBody(body);
+    }
+
+    private SQSEvent createSQSEventWithRawBody(String body) {
+        var message = createRawSQSMessage("msg-1", body);
+        var event = new SQSEvent();
+        event.setRecords(List.of(message));
+        return event;
+    }
+
+    private SQSMessage createSQSMessage(String messageId, String publicSubjectId) {
+        String body = "{\"publicSubjectId\": \"" + publicSubjectId + "\"}";
+        return createRawSQSMessage(messageId, body);
+    }
+
+    private SQSMessage createRawSQSMessage(String messageId, String body) {
+        var message = new SQSMessage();
+        message.setMessageId(messageId);
+        message.setBody(body);
+        return message;
+    }
+
+    private ConfigurationService createConfigServiceWithAccountDataUri(String accountDataUri) {
+        return new IntegrationTestConfigurationService(
+                notificationsQueue, tokenSigner, configurationParameters) {
+            @Override
+            public String getAccountDataURI() {
+                return accountDataUri;
+            }
+        };
+    }
+}

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -41,6 +41,12 @@ Resources:
               amcClientId,
             ]
           HOME_CLIENT_ID: "home"
+          INACTIVE_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              inactiveAccountDeletionClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref AuthorizerFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -120,6 +120,7 @@ Mappings:
       accountDataJwksUrl: https://5fgwu5kpd2.execute-api.eu-west-2.amazonaws.com/authdev1/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev1.dev.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
@@ -129,6 +130,7 @@ Mappings:
       accountDataJwksUrl: https://nw0dah7bxk.execute-api.eu-west-2.amazonaws.com/authdev2/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev2.dev.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
@@ -138,6 +140,7 @@ Mappings:
       accountDataJwksUrl: https://y3s69ubaz5.execute-api.eu-west-2.amazonaws.com/authdev3/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev3.dev.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     dev:
       cloudwatchLogRetentionInDays: 1
       IsSplunkEnabled: "No"
@@ -151,6 +154,7 @@ Mappings:
       accountDataJwksUrl: https://tze402cnbk.execute-api.eu-west-2.amazonaws.com/dev/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.dev.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     build:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -164,6 +168,7 @@ Mappings:
       accountDataJwksUrl: https://7ecg8e1o73.execute-api.eu-west-2.amazonaws.com/build/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.build.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     staging:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -178,6 +183,7 @@ Mappings:
       accountDataJwksUrl: https://z02rnzbqw8.execute-api.eu-west-2.amazonaws.com/staging/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.staging.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     integration:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -192,6 +198,7 @@ Mappings:
       accountDataJwksUrl: https://db10ia9pr6.execute-api.eu-west-2.amazonaws.com/integration/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.integration.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
     production:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -206,6 +213,7 @@ Mappings:
       accountDataJwksUrl: https://86n9innl95.execute-api.eu-west-2.amazonaws.com/production/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.account.gov.uk
       amcClientId: auth
+      inactiveAccountDeletionClientId: inactive-account-deletion
   LambdaConfiguration:
     account-delete:
       RunbookLink: "" # TODO: must be populated when runbook is created

--- a/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
@@ -22,10 +22,62 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               inactiveAccountDeletionClientId,
             ]
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${Env}-auth-to-account-data-signing-key
+            - Env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
       LoggingConfig:
         LogGroup: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
+        - Version: 2012-10-17
+          Statement:
+            - Sid: AllowKmsSignForAccountDataToken
+              Effect: Allow
+              Action:
+                - kms:Sign
+                - kms:GetPublicKey
+              Resource:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  authToAccountDataSigningKeyArn,
+                ]
+        - !If
+          - InactiveAccountDeletionStubEnabled
+          - !Ref InactiveAccountDeletionStubQueueProcessorSQSPolicy
+          - !Ref AWS::NoValue
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
@@ -16,6 +16,12 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          INACTIVE_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              inactiveAccountDeletionClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
@@ -1,0 +1,119 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  InactiveAccountDeletionQueueProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub
+        - ${Env}-inactive-account-deletion-queue-processor-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      AutoPublishAlias: active
+      ReservedConcurrentExecutions: 2
+      CodeUri: ./account-management-api/build/distributions/account-management-api.zip
+      Handler: uk.gov.di.accountmanagement.lambda.InactiveAccountDeletionHandler::handleRequest
+      Environment:
+        Variables:
+          ENVIRONMENT: !Sub
+            - "${env}"
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      LoggingConfig:
+        LogGroup: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
+      Policies:
+        - !Ref LambdaBasicExecutionPolicy
+      SnapStart:
+        ApplyOn: PublishedVersions
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+
+  InactiveAccountDeletionQueueProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - /aws/lambda/${Env}-inactive-account-deletion-queue-processor-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      RetentionInDays:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          cloudwatchLogRetentionInDays,
+        ]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-InactiveAccountDeletionQueueProcessorFunctionLogGroup"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+
+  InactiveAccountDeletionQueueProcessorFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub
+        - ${Env}-inactive-account-deletion-queue-processor-errors
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      FilterPattern: '{($.level = "ERROR")}'
+      LogGroupName: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub
+            - ${Env}-inactive-account-deletion-queue-processor-error-count
+            - Env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  InactiveAccountDeletionQueueProcessorFunctionErrorCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-inactive-account-deletion-queue-processor-lambda function. ${RunbookLink}"
+        - AlarmThreshold:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              lambdaLogAlarmThreshold,
+              DefaultValue: 5,
+            ]
+          Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "inactive-account-deletion-queue-processor",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-inactive-account-deletion-queue-processor-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub
+        - ${Env}-inactive-account-deletion-queue-processor-error-count
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          lambdaLogAlarmThreshold,
+          DefaultValue: 5,
+        ]
+
+  InactiveAccountDeletionQueueProcessorFunctionSubscriptionFilter:
+    Condition: IsSplunkEnabled
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -313,6 +313,7 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: rjlo8fsb55
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -350,6 +351,7 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ez2ro7vca7
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -387,6 +389,7 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 5ctgxqnq37
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -431,6 +434,7 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0aqzty84lj
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -477,6 +481,7 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.build.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ac3znt5m23
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -524,6 +529,7 @@ Mappings:
       legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:539729775994:key/d33e9077-8d66-4f63-99a1-f90e29b4aabe
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 7xgl7lexy4
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -572,6 +578,7 @@ Mappings:
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -620,6 +627,7 @@ Mappings:
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0218o1p9tj
+      inactiveAccountDeletionClientId: inactive-account-deletion
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -314,6 +314,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: rjlo8fsb55
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/e5a9a634-e113-44c4-8bef-388fb71041a0
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -352,6 +353,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ez2ro7vca7
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/73405f5d-b60a-4b17-881c-b0f3e26ef03d
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -390,6 +392,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 5ctgxqnq37
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/20e15b84-6196-4b0a-8f27-632f4b858bd1
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -435,6 +438,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0aqzty84lj
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/c0bc7d31-32f4-4f98-addd-170187956d8d
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -482,6 +486,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.build.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ac3znt5m23
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:058264536367:key/9a0c6ef7-ce45-42fe-b55e-48b09f9ff53e
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -530,6 +535,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 7xgl7lexy4
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:851725205974:key/ecfc81ec-546e-478d-ae04-5ed5d1b375a9
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -579,6 +585,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125600642:key/f0e0c444-b70e-4d2f-9d5a-9f0bcf1d6540
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -628,6 +635,7 @@ Mappings:
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0218o1p9tj
       inactiveAccountDeletionClientId: inactive-account-deletion
+      authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125303002:key/29d156dd-c893-4221-8fe1-f24882e0e401
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -652,6 +652,8 @@ Mappings:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
     reverification-result:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
+    inactive-account-deletion-queue-processor:
+      RunbookLink: "https://govukverify.atlassian.net/wiki/x/1QAJmwE"
     ticf-cri:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/UzdQFFH1"
 

--- a/ci/cloudformation/account-management/queue/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/queue/inactive-account-deletion.yaml
@@ -1,0 +1,91 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Conditions:
+  InactiveAccountDeletionStubEnabled:
+    Fn::Not:
+      - !Condition IsHigherEnv
+
+Resources:
+  # ============================================================================
+  # Stub SQS Queue + DLQ for dev/build environments
+  # ============================================================================
+
+  InactiveAccountDeletionStubQueue:
+    Type: AWS::SQS::Queue
+    Condition: InactiveAccountDeletionStubEnabled
+    Properties:
+      QueueName: !Sub
+        - ${Env}-stub-inactive-account-deletion-queue
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsDataKeyReusePeriodSeconds: 300
+      KmsMasterKeyId: alias/aws/sqs
+      MessageRetentionPeriod: 1209600
+      ReceiveMessageWaitTimeSeconds: 10
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt InactiveAccountDeletionStubDeadLetterQueue.Arn
+        maxReceiveCount: 1
+      VisibilityTimeout: 60
+      Tags:
+        - Key: Service
+          Value: inactive-account-deletion
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/account-management/queue/inactive-account-deletion.yaml
+
+  InactiveAccountDeletionStubDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Condition: InactiveAccountDeletionStubEnabled
+    Properties:
+      QueueName: !Sub
+        - ${Env}-stub-inactive-account-deletion-dlq
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsDataKeyReusePeriodSeconds: 300
+      KmsMasterKeyId: alias/aws/sqs
+      MessageRetentionPeriod: 1209600
+      Tags:
+        - Key: Service
+          Value: inactive-account-deletion
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/account-management/queue/inactive-account-deletion.yaml
+
+  # ============================================================================
+  # Event Source Mappings
+  # ============================================================================
+
+  InactiveAccountDeletionStubEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: InactiveAccountDeletionStubEnabled
+    Properties:
+      EventSourceArn: !GetAtt InactiveAccountDeletionStubQueue.Arn
+      FunctionName: !Ref InactiveAccountDeletionQueueProcessorFunction
+      BatchSize: 1
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+
+  # ============================================================================
+  # SQS IAM Policy for the queue processor Lambda
+  # ============================================================================
+
+  InactiveAccountDeletionStubQueueProcessorSQSPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: InactiveAccountDeletionStubEnabled
+    Properties:
+      Description: "IAM policy for the inactive account deletion queue processor to consume from the stub queue"
+      Path: !Sub
+        - /${Env}/account-management/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSQSAccess
+            Effect: Allow
+            Action:
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+            Resource:
+              - !GetAtt InactiveAccountDeletionStubQueue.Arn
+              - !GetAtt InactiveAccountDeletionStubDeadLetterQueue.Arn

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorService.java
@@ -32,6 +32,27 @@ public class AccessTokenConstructorService {
     public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
             String publicSubjectId,
             List<AccessTokenScope> scopes,
+            Date issueTime,
+            Date expiryDate,
+            String audience,
+            String issuer,
+            String clientId,
+            String signingKey) {
+        return createSignedAccessToken(
+                publicSubjectId,
+                scopes,
+                null,
+                issueTime,
+                expiryDate,
+                audience,
+                issuer,
+                clientId,
+                signingKey);
+    }
+
+    public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
+            String publicSubjectId,
+            List<AccessTokenScope> scopes,
             String sessionId,
             Date issueTime,
             Date expiryDate,
@@ -42,7 +63,7 @@ public class AccessTokenConstructorService {
         var scopeValue =
                 scopes.stream().map(AccessTokenScope::getValue).collect(Collectors.joining(" "));
 
-        var claims =
+        var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopeValue)
                         .issuer(issuer)
@@ -52,9 +73,13 @@ public class AccessTokenConstructorService {
                         .notBeforeTime(issueTime)
                         .subject(publicSubjectId)
                         .claim("client_id", clientId)
-                        .claim("sid", sessionId)
-                        .jwtID(UUID.randomUUID().toString())
-                        .build();
+                        .jwtID(UUID.randomUUID().toString());
+
+        if (sessionId != null && !sessionId.isEmpty()) {
+            claimsBuilder.claim("sid", sessionId);
+        }
+
+        var claims = claimsBuilder.build();
 
         return jwtService
                 .signJWT(claims, signingKey)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -754,6 +754,10 @@ public class ConfigurationService
         return System.getenv().getOrDefault("HOME_CLIENT_ID", "");
     }
 
+    public String getInactiveAccountDeletionClientId() {
+        return System.getenv().getOrDefault("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
     public String getAuthToAccountDataSigningKey() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", "");
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
@@ -142,8 +142,7 @@ class AccessTokenConstructorServiceTest {
     }
 
     @Test
-    void shouldCreateAccessTokenWithoutSidClaimWhenSessionIdIsEmpty()
-            throws ParseException, JOSEException {
+    void shouldCreateAccessTokenWithoutSidClaimWhenSessionIdIsEmpty() throws ParseException {
         var result =
                 accessTokenConstructorService.createSignedAccessToken(
                         PUBLIC_SUBJECT_ID,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
@@ -111,6 +111,60 @@ class AccessTokenConstructorServiceTest {
     }
 
     @Test
+    void shouldCreateAccessTokenWithoutSidClaimWhenSessionIdIsOmitted()
+            throws ParseException, JOSEException {
+        var result =
+                accessTokenConstructorService.createSignedAccessToken(
+                        PUBLIC_SUBJECT_ID,
+                        List.of(AccountDataScope.PASSKEY_CREATE),
+                        NOW,
+                        EXPIRY,
+                        AUDIENCE,
+                        ISSUER,
+                        AMC_CLIENT_ID,
+                        SIGNING_KEY_ALIAS);
+
+        assertTrue(result.isSuccess());
+        var token = result.getSuccess();
+        var signedJWT = SignedJWT.parse(token.getValue());
+        var claims = signedJWT.getJWTClaimsSet();
+
+        assertTrue(signedJWT.verify(new ECDSAVerifier(signingKey.toECPublicKey())));
+        assertEquals("passkey-create", claims.getClaim("scope"));
+        assertEquals(ISSUER, claims.getIssuer());
+        assertEquals(AUDIENCE, claims.getAudience().get(0));
+        assertEquals(PUBLIC_SUBJECT_ID, claims.getSubject());
+        assertEquals(AMC_CLIENT_ID, claims.getClaim("client_id"));
+        assertEquals(null, claims.getClaim("sid"));
+        assertEquals(NOW, claims.getIssueTime());
+        assertEquals(EXPIRY, claims.getExpirationTime());
+        assertEquals(NOW, claims.getNotBeforeTime());
+    }
+
+    @Test
+    void shouldCreateAccessTokenWithoutSidClaimWhenSessionIdIsEmpty()
+            throws ParseException, JOSEException {
+        var result =
+                accessTokenConstructorService.createSignedAccessToken(
+                        PUBLIC_SUBJECT_ID,
+                        List.of(AccountDataScope.PASSKEY_CREATE),
+                        "",
+                        NOW,
+                        EXPIRY,
+                        AUDIENCE,
+                        ISSUER,
+                        AMC_CLIENT_ID,
+                        SIGNING_KEY_ALIAS);
+
+        assertTrue(result.isSuccess());
+        var token = result.getSuccess();
+        var signedJWT = SignedJWT.parse(token.getValue());
+        var claims = signedJWT.getJWTClaimsSet();
+
+        assertEquals(null, claims.getClaim("sid"));
+    }
+
+    @Test
     void shouldReturnJwtFailureReasonIfThereIsSigningFailure() {
         // Arrange
         when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -565,6 +565,11 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getInactiveAccountDeletionClientIdShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getInactiveAccountDeletionClientId());
+    }
+
+    @Test
     void getMfaResetCallbackURIShouldDefault() {
         assertEquals(URI.create(""), configurationService.getMfaResetCallbackURI());
     }


### PR DESCRIPTION
## What

Added new SQS queue processor Lambda to consume IAD messages.

A new IAD token service mints access tokens for authenticating with the Account Data (AD) API. A new `inactive-account-deletion` client ID has been added and the AD API authoriser has been updated to allow this.

The queue processor triggers account deletion via the AD API for the public subject ID in the SQS message.

Added a stub SQS queue for the dev and build environments for testing.

A future PR under a subsequent ticket will link up with the home-owned SQS queue in staging and above. This queue processor will only be attached to the stub and home-owned queues, and will not be attached to an API gateway.

## How to review

1. Code review, suggested commit-by-commit
1. Optionally, deploy to a dev environment, identify an account you would like to delete in that dev environments `user-profile` DB table, copy the publicSubjectId value for that account, then within the AWS Console, locate the stub queue (not the DLQ!) and add a message with that ID of the format `{"publicSubjectId": "ID_HERE"}` and send, then review the Lambda logs and check the account has been deleted.

## Testing

I followed the above steps on authdev1 and confirmed the token was minted OK and the account was deleted successfully via the AD API.

<img width="1168" height="139" alt="deletion logs" src="https://github.com/user-attachments/assets/01113f2d-282c-41be-9444-98211719fe04" />

## Checklist

- [x] Deployment of this PR will not break active user journeys

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**