### PR TITLE
BAU: Fix orch local running

### DIFF
--- a/orchestration-local-running/Dockerfile
+++ b/orchestration-local-running/Dockerfile
@@ -4,21 +4,9 @@ WORKDIR /app
 
 RUN yum update -y && yum install -y findutils-4.5.11-6.amzn2 tar-1.26-35.amzn2.0.4 && yum clean all && rm -rf /var/cache/yum
 
-COPY gradle ./gradle
-COPY gradlew ./
-COPY *.gradle ./
+ADD . .
 
 RUN ./gradlew --version
-
-COPY spotbugsExclude.xml ./
-COPY orchestration-local-running ./orchestration-local-running
-COPY orchestration-shared ./orchestration-shared
-COPY oidc-api ./oidc-api
-COPY ipv-api ./ipv-api
-COPY doc-checking-app-api ./doc-checking-app-api
-COPY client-registry-api ./client-registry-api
-COPY sis-api ./sis-api
-
 RUN --mount=type=cache,target=/root/.gradle ./gradlew :orchestration-local-running:build --no-daemon
 RUN mkdir untarred && tar -xvf orchestration-local-running/build/distributions/orchestration-local-running.tar -C ./untarred
 


### PR DESCRIPTION
### Wider context of change

In gradle versions below 9 it was ok to have missing project dependencies. However, gradle v9 onwards requires you to define all project dependencies in the container, even if we aren't using them. This causes local running to break because it only copies the projects we use into the docker container.

### What’s changed

This PR updates the dockerfile for orch local running to copy the entire project into the docker container, which fixes the gradle v9 issue.

It's worth noting that local running doesn't fully work yet, the orch stubs need updating to create the ipv stub tables in the docker dynamo service. This PR will fix the following issues: https://github.com/govuk-one-login/orch-stubs/pull/615

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
