### PR TITLE
ATO-2679: Return an error when request object expired

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -370,12 +370,14 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         return Optional.of(new AuthRequestError(error, uri, state));
     }
 
-    private void validateTimestampClaims(JWTClaimsSet jwtClaimsSet) {
+    private void validateTimestampClaims(JWTClaimsSet jwtClaimsSet)
+            throws InvalidAuthorizeRequestException {
         try {
             claimsVerifier.verify(jwtClaimsSet, null);
         } catch (BadJWTException e) {
             LOG.warn("Error validating time based claims in request object: {}", e.getMessage());
-            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
+            throw new InvalidAuthorizeRequestException(
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_OBJECT_CODE, "Request expired"));
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -59,7 +59,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1024,8 +1023,8 @@ class RequestObjectAuthorizeValidatorTest {
                             .build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
 
-            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
-            assertDoesNotThrow(() -> validator.validate(authRequest));
+            assertThrows(
+                    InvalidAuthorizeRequestException.class, () -> validator.validate(authRequest));
         }
 
         @Test
@@ -1035,8 +1034,8 @@ class RequestObjectAuthorizeValidatorTest {
                             .notBeforeTime(fixedNowClock.nowPlus(2, ChronoUnit.MINUTES))
                             .build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-            // ATO-2769: Throw InvalidAuthorizeRequestException here once we've checked logging
-            assertDoesNotThrow(() -> validator.validate(authRequest));
+            assertThrows(
+                    InvalidAuthorizeRequestException.class, () -> validator.validate(authRequest));
         }
 
         @Test


### PR DESCRIPTION

### Wider context of change
Some RPs choose to send authorise requests in the form of signed JWT Authorise requests (JARs). As these are JWTs, they come with some default timestamp based claims, such as exp and nbf.  We previously added logging for this, and having reviewed this we can now throw an exception here, which is caught and returns a `invalid_request_object` error

### What’s changed

- Throws an Invalid Authorise Request exception when timestamp claim validation fails on a JAR 

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
