### PR TITLE
Bau/logs for each handler start

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -64,6 +64,7 @@ public class AuthorizeHandler
     @Override
     public IamPolicyResponseV1 handleRequest(
             APIGatewayCustomAuthorizerEvent apiGatewayCustomAuthorizerEvent, Context context) {
+        LOG.info("Account data AuthorizeHandler called");
         var token = apiGatewayCustomAuthorizerEvent.getAuthorizationToken();
         try {
             var accessToken = AccessToken.parse(token, AccessTokenType.BEARER);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -77,7 +77,7 @@ public class AuthenticateHandler
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachTraceId();
         attachSessionIdToLogs(sessionId);
-        LOG.info("Request received to the AuthenticateHandler");
+        LOG.info("AuthenticateHandler called");
 
         var auditContext =
                 new AuditContext(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -64,7 +64,7 @@ public class AuthoriseAccessTokenHandler
 
     public AuthPolicy authoriseAccessTokenHandler(TokenAuthorizerContext input) {
         attachTraceId();
-        LOG.info("Request received in AuthoriseAccessTokenHandler");
+        LOG.info("AuthoriseAccessTokenHandler called");
         try {
             String token = input.getAuthorizationToken();
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
@@ -88,6 +88,7 @@ public class BulkRemoveAccountHandler
         ThreadContext.clearMap();
         attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
+        LOG.info("BulkRemoveAccountHandler called");
 
         if (!configurationService.isBulkAccountDeletionEnabled()) {
             throw new BulkRemoveAccountException(
@@ -95,8 +96,6 @@ public class BulkRemoveAccountHandler
         }
 
         try {
-            LOG.info("BulkRemoveAccountHandler received request");
-
             validateRequest(request);
 
             String reference = request.reference();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -148,6 +148,8 @@ public class MFAMethodsCreateHandler
 
         addSessionIdToLogs(input);
 
+        LOG.info("MFAMethodsCreateHandler called");
+
         var maybePassedGuardConditions = getUserProfileWhenGuardConditionsPassed(input);
 
         if (maybePassedGuardConditions.isFailure()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -98,6 +98,8 @@ public class MFAMethodsDeleteHandler
 
         addSessionIdToLogs(input);
 
+        LOG.info("MFAMethodsDeleteHandler called");
+
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
         var mfaIdentifier = input.getPathParameters().get("mfaIdentifier");
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -147,6 +147,8 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input, Context context) throws Json.JsonException {
         addSessionIdToLogs(input);
 
+        LOG.info("MFAMethodsPutHandler called");
+
         var validRequestOrErrorResponse = validatePutRequest(input);
 
         if (validRequestOrErrorResponse.isFailure()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -67,6 +67,8 @@ public class MFAMethodsRetrieveHandler
 
         addSessionIdToLogs(input);
 
+        LOG.info("MFAMethodsRetrieveHandlder called");
+
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
 
         if (publicSubjectId.isEmpty()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -107,6 +107,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
     public void notificationRequestHandler(SQSEvent event) {
         attachTraceId();
+        LOG.info("Account Management NotificationHandler called");
         for (SQSMessage msg : event.getRecords()) {
             processMessage(msg);
         }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -107,7 +107,7 @@ public class PasskeysDeleteProxyHandler
 
     public APIGatewayProxyResponseEvent passkeyDeleteProxyHandler(
             APIGatewayProxyRequestEvent input, Context context) {
-        LOG.info("PasskeysDeleteProxyHandler invoked");
+        LOG.info("PasskeysDeleteProxyHandler called");
 
         PasskeysDeleteRequest request = extractPasskeyDeleteRequest(input);
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
@@ -50,7 +50,7 @@ public class PasskeysRetrieveProxyHandler
 
     public APIGatewayProxyResponseEvent passkeyRetrieveProxyHandler(
             APIGatewayProxyRequestEvent input, Context context) {
-        LOG.info("PasskeysRetrieveProxyHandler invoked");
+        LOG.info("PasskeysRetrieveProxyHandler called");
 
         var publicSubjectId = input.getPathParameters().getOrDefault("publicSubjectId", "");
         if (publicSubjectId.isEmpty()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -108,7 +108,7 @@ public class RemoveAccountHandler
                             input.getHeaders(), SESSION_ID_HEADER, "");
             attachTraceId();
             attachSessionIdToLogs(sessionId);
-            LOG.info("RemoveAccountHandler received request");
+            LOG.info("RemoveAccountHandler called");
             RemoveAccountRequest removeAccountRequest =
                     objectMapper.readValue(input.getBody(), RemoveAccountRequest.class);
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -189,7 +189,7 @@ public class SendOtpNotificationHandler
     public APIGatewayProxyResponseEvent sendOtpRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) throws JsonException {
         attachTraceId();
-        LOG.info("Request received in SendOtp Lambda");
+        LOG.info("SendOtpNotificationHandler called");
 
         Map<String, String> headers = input.getHeaders();
         String sessionId = getHeaderValueOrElse(headers, SESSION_ID_HEADER, "");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -123,7 +123,7 @@ public class UpdateEmailHandler
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachTraceId();
         attachSessionIdToLogs(sessionId);
-        LOG.info("UpdateEmailHandler received request");
+        LOG.info("UpdateEmailHandler called");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(
                         getUserLanguageFromRequestHeaders(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -107,7 +107,7 @@ public class UpdatePasswordHandler
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachTraceId();
         attachSessionIdToLogs(sessionId);
-        LOG.info("UpdatePasswordHandler received request");
+        LOG.info("UpdatePasswordHandler called");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(
                         getUserLanguageFromRequestHeaders(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -101,7 +101,7 @@ public class UpdatePhoneNumberHandler
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachTraceId();
         attachSessionIdToLogs(sessionId);
-        LOG.info("UpdatePhoneNumberHandler received request");
+        LOG.info("UpdatePhoneNumberHandler called");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(
                         getUserLanguageFromRequestHeaders(

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -123,7 +123,7 @@ public class TokenHandler
 
     public APIGatewayProxyResponseEvent tokenRequestHandler(APIGatewayProxyRequestEvent input) {
         attachTraceId();
-        LOG.info("Request received to the TokenHandler");
+        LOG.info("TokenHandler called");
 
         Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(input.getBody());
         Optional<ErrorObject> invalidRequestParamError =

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -98,7 +98,7 @@ public class UserInfoHandler
     public APIGatewayProxyResponseEvent userInfoRequestHandler(APIGatewayProxyRequestEvent input) {
         ThreadContext.clearMap();
         attachTraceId();
-        LOG.info("Request received to the UserInfoHandler");
+        LOG.info("UserInfoHandler called");
         Map<String, String> headers = input.getHeaders();
 
         Optional<String> authorisationHeader =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
@@ -46,7 +46,7 @@ public class ADJWKSHandler implements RequestHandler<Object, Void> {
 
     @Override
     public Void handleRequest(Object event, Context context) {
-        LOG.info("AD JWKS lambda invoked");
+        LOG.info("ADJWKSHandler callled");
         JWK authToADSigningJwk = jwksService.getPublicAuthToAccountDataSigningJwkWithOpaqueId();
 
         var jwks = new JWKSet(authToADSigningJwk).toString(true);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -138,6 +138,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
             Context context,
             AMCAuthorizeRequest request,
             UserContext userContext) {
+        LOG.info("AMCAuthorizeHandler called");
 
         AuthSessionItem authSessionItem = userContext.getAuthSession();
         var userProfile =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -124,7 +124,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
             AMCCallbackRequest request,
             UserContext userContext) {
 
-        LOG.info("Request received to AMCCallbackHandler");
+        LOG.info("AMCCallbackHandler called");
 
         var verifyStateResult = verifyState(request.state(), userContext);
         if (verifyStateResult.isFailure()) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
@@ -48,7 +48,7 @@ public class AMCJWKSHandler implements RequestHandler<Object, Void> {
 
     @Override
     public Void handleRequest(Object event, Context context) {
-        LOG.info("AMC JWKS lambda invoked");
+        LOG.info("AMCJWKSHandler called");
         JWK authToAMCSigningJwk = jwksService.getPublicAuthToAMCSigningJwkWithOpaqueId();
         JWK authToAccountManagementSigningJwk =
                 jwksService.getPublicAuthToAccountManagementSigningJwkWithOpaqueId();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -144,7 +144,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         String persistentSessionID =
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
         attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionID);
-        LOG.info("Request received to the AccountInterventionsHandler");
+        LOG.info("AccountInterventionsHandler called");
 
         if (!configurationService.isAccountInterventionServiceCallEnabled()) {
             LOG.info(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
@@ -70,7 +70,7 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
             AccountRecoveryRequest request,
             UserContext userContext) {
         try {
-            LOG.info("Request received to AccountRecoveryHandler");
+            LOG.info("AccountRecoveryHandler called");
             LOG.info("Checking if block is present");
             var commonSubjectId =
                     ClientSubjectHelper.getSubjectWithSectorIdentifier(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -91,6 +91,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
             AuthCodeRequest authCodeRequest,
             UserContext userContext) {
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
+        LOG.info("AuthenticationAuthCodeHandler called");
+
         try {
             var userProfile = userContext.getUserProfile();
             if (userProfile.isEmpty()) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -77,7 +77,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
             CheckEmailFraudBlockRequest request,
             UserContext userContext) {
         try {
-            LOG.info("Request received to CheckEmailFraudBlockHandler");
+            LOG.info("CheckEmailFraudBlockHandler called");
             LOG.info("Checking if block is present");
 
             var status = EmailCheckResultStatus.PENDING;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -121,6 +121,8 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             CheckReauthUserRequest request,
             UserContext userContext) {
 
+        LOG.info("CheckReAuthUserHandler called");
+
         var internalPairwiseId = userContext.getAuthSession().getInternalCommonSubjectId();
 
         var auditContext =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -111,7 +111,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
         try {
-            LOG.info("Processing request");
+            LOG.info("CheckUserExistsHandler called");
 
             String emailAddress = request.getEmail().toLowerCase();
             Optional<ErrorResponse> errorResponse =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
@@ -59,6 +59,7 @@ public class IDReverificationStateHandler
         try {
             ThreadContext.clearMap();
             attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
+            LOG.info("IDReverificationStateHandler called");
             var txmaAuditEncoded = getTxmaAuditEncodedHeaderOrUnknown(input);
             var auditContext =
                     AuditContext.emptyAuditContext().withTxmaAuditEncoded(txmaAuditEncoded);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -182,6 +182,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             Context context,
             LoginRequest request,
             UserContext userContext) {
+        LOG.info("LoginHandler called");
 
         AuthSessionItem authSession = userContext.getAuthSession();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -161,7 +161,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
             attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
-            LOG.info("MfaHandler received request");
+            LOG.info("MfaHandler called");
 
             String email = request.getEmail().toLowerCase(Locale.ROOT);
             JourneyType journeyType =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -86,7 +86,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             Context context,
             MfaResetRequest request,
             UserContext userContext) {
-        LOG.info("MFA Reset Authorization request received");
+        LOG.info("MfaResetAuthorizeHandler called");
         try {
             String clientSessionId = userContext.getClientSessionId();
             AuthSessionItem authSession = userContext.getAuthSession();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandler.java
@@ -48,8 +48,7 @@ public class MfaResetJarJwkHandler
 
     public APIGatewayProxyResponseEvent mfaResetJarJwkHandler() {
         attachTraceId();
-        LOG.info(
-                "Request for Auth reverification request JAR signature verification key received.");
+        LOG.info("MfaResetJarJwkHandler called");
         try {
 
             List<JWK> signingKeys = new ArrayList<>();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
@@ -51,7 +51,7 @@ public class MfaResetStorageTokenJwkHandler
     public APIGatewayProxyResponseEvent mfaResetStorageTokenJwkHandler() {
         try {
             attachTraceId();
-            LOG.info("Request for Auth MFA storage token signature verification key received.");
+            LOG.info("MfaResetStorageTokenJwkHandler called");
 
             List<JWK> signingKeys = new ArrayList<>();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -97,6 +97,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, SQSBatchRes
 
     public SQSBatchResponse notificationRequestHandler(SQSEvent event) {
         attachTraceId();
+        LOG.info("NotificationHandler called");
 
         var failures = new ArrayList<SQSBatchResponse.BatchItemFailure>();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -155,7 +155,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             Context context,
             ResetPasswordCompletionRequest request,
             UserContext userContext) {
-        LOG.info("Request received to ResetPasswordHandler");
+        LOG.info("ResetPasswordHandler called");
 
         Optional<ErrorResponse> passwordValidationError =
                 passwordValidator.validate(request.password());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -151,7 +151,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             UserContext userContext) {
         attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
-        LOG.info("Processing request");
+        LOG.info("ResetPasswordRequestHandler called");
         try {
             if (Objects.isNull(userContext.getAuthSession().getEmailAddress())
                     || !userContext.getAuthSession().validateSession(request.getEmail())) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -94,6 +94,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
             Context context,
             ReverificationResultRequest request,
             UserContext userContext) {
+        LOG.info("ReverificationResultHandler called");
 
         var baseAuditContext =
                 auditContextFromUserContext(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -192,6 +192,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             UserContext userContext) {
 
         attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
+        LOG.info("SendNotificationHandler called");
         var auditContext =
                 auditContextFromUserContext(
                         userContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -92,7 +92,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
         AuthSessionItem authSessionItem = userContext.getAuthSession();
 
-        LOG.info("Received request");
+        LOG.info("SignUpHandler called");
 
         Optional<ErrorResponse> passwordValidationError =
                 passwordValidator.validate(request.getPassword());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -110,7 +110,7 @@ public class StartHandler
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
         attachTraceId();
-        LOG.info("Start request received");
+        LOG.info("StartHandler called");
         var sessionIdOpt =
                 getOptionalHeaderValueFromHeaders(
                         input.getHeaders(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -53,7 +53,7 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
     @Override
     public Void handleRequest(InternalTICFCRIRequest input, Context context) {
         attachTraceId();
-        LOG.debug("received request to TICF CRI Handler");
+        LOG.debug("TicfCriHandler called");
         var environmentForMetrics = Map.entry("Environment", configurationService.getEnvironment());
         try {
             var response = sendRequest(input);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -97,7 +97,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
         AuthSessionItem authSession = userContext.getAuthSession();
         LogLineHelper.attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
-        LOG.info("Processing request");
+        LOG.info("UpdateProfileHandler called");
 
         if (!authSession.validateSession(request.getEmail())) {
             LOG.info("Invalid session");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -174,7 +174,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             Context context,
             VerifyCodeRequest codeRequest,
             UserContext userContext) {
-        LOG.info("Processing request");
+        LOG.info("VerifyCodeHandler called");
 
         AuthSessionItem authSession = userContext.getAuthSession();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -191,6 +191,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Context context,
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext) {
+        LOG.info("VerifyMfaCodeHandler called");
 
         AuthSessionItem authSession = userContext.getAuthSession();
 
@@ -208,8 +209,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         extractPersistentIdFromHeaders(input.getHeaders()));
-
-        LOG.info("Invoking verify MFA code handler");
 
         if (isInvalidCodeRequestType(codeRequest, journeyType))
             return generateApiGatewayProxyErrorResponse(400, INVALID_NOTIFICATION_TYPE);


### PR DESCRIPTION
It's really useful to have consistent logging at the start of each handler.

This has been particularly useful when investigating race conditions.

Make all the existing logs consistent with the format "[XYZ]Handler called". This will allow us to e.g. filter the logs for a journey id for all the "*Handler called" logs, which will allow us to easily trace all the backend calls for an individual journey.
