### PR TITLE
AUT-5775: Add LastSignedIn attribute to UserProfile entity

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -28,6 +28,7 @@ public class UserProfile {
     public static final String ATTRIBUTE_MFA_METHODS_MIGRATED = "mfaMethodsMigrated";
     public static final String ATTRIBUTE_MFA_IDENTIFIER = "MFAIdentifier";
     public static final String ATTRIBUTE_LAST_SKIPPED_ADDING_PASSKEY = "LastSkippedAddingPasskey";
+    public static final String ATTRIBUTE_LAST_SIGNED_IN = "LastSignedIn";
 
     private String email;
     private String subjectID;
@@ -45,6 +46,7 @@ public class UserProfile {
     private boolean mfaMethodsMigrated;
     private String mfaIdentifier;
     private String lastSkippedAddingPasskey;
+    private String lastSignedIn;
 
     public UserProfile() {}
 
@@ -274,6 +276,20 @@ public class UserProfile {
 
     public UserProfile withLastSkippedAddingPasskey(String lastSkippedAddingPasskey) {
         this.lastSkippedAddingPasskey = lastSkippedAddingPasskey;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_LAST_SIGNED_IN)
+    public String getLastSignedIn() {
+        return lastSignedIn;
+    }
+
+    public void setLastSignedIn(String lastSignedIn) {
+        this.lastSignedIn = lastSignedIn;
+    }
+
+    public UserProfile withLastSignedIn(String lastSignedIn) {
+        this.lastSignedIn = lastSignedIn;
         return this;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -21,6 +21,7 @@ class UserProfileTest {
     private static final String CLIENT_ID = "client-id";
     private static final Date CREATED_DATE_TIME = NowHelper.nowMinus(30, ChronoUnit.SECONDS);
     private static final Date UPDATED_DATE_TIME = NowHelper.now();
+    private static final Date LAST_SIGNED_IN_DATE_TIME = NowHelper.now();
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
     private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
@@ -43,6 +44,7 @@ class UserProfileTest {
         assertThat(userProfile.isPhoneNumberVerified(), equalTo(true));
         assertThat(userProfile.getCreated(), equalTo(CREATED_DATE_TIME.toString()));
         assertThat(userProfile.getUpdated(), equalTo(UPDATED_DATE_TIME.toString()));
+        assertThat(userProfile.getLastSignedIn(), equalTo(LAST_SIGNED_IN_DATE_TIME.toString()));
         assertThat(userProfile.getTermsAndConditions(), equalTo(TERMS_AND_CONDITIONS));
         assertThat(userProfile.getLegacySubjectID(), equalTo(LEGACY_SUBJECT_ID));
         assertThat(userProfile.getSalt(), equalTo(SALT));
@@ -60,6 +62,7 @@ class UserProfileTest {
                 .withTermsAndConditions(TERMS_AND_CONDITIONS)
                 .withSalt(SALT)
                 .withCreated(CREATED_DATE_TIME.toString())
-                .withUpdated(UPDATED_DATE_TIME.toString());
+                .withUpdated(UPDATED_DATE_TIME.toString())
+                .withLastSignedIn(LAST_SIGNED_IN_DATE_TIME.toString());
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Adds `LastSignedIn` attribute to `UserProfile` entity.

AUT-5614 will handle updating this attributes value on auth code issuance. This change has been split out of that ticket to unblock other tickets.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Testing

Deployed to dev just to double check, ran through a sign in journey successfully

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)
