### PR TITLE
ATO-2610 refactors to simplify main body of AuthorisationHandler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -261,15 +261,7 @@ public class AuthorisationHandler
 
         AuthenticationRequest authRequest;
         try {
-            Map<String, String> parameterMap = input.getQueryStringParameters();
-            Map<String, List<String>> requestParameters =
-                    parameterMap.entrySet().stream()
-                            .collect(
-                                    Collectors.toMap(
-                                            Map.Entry::getKey, entry -> List.of(entry.getValue())));
-            authRequest = AuthenticationRequest.parse(requestParameters);
-            authRequest = stripOutReauthenticateQueryParams(authRequest);
-            authRequest = stripOutLoginHintQueryParams(authRequest);
+            authRequest = parseRequest(input);
         } catch (ParseException e) {
             LOG.warn("Authentication request could not be parsed", e);
             return generateParseExceptionResponse(e, user);
@@ -493,6 +485,21 @@ public class AuthorisationHandler
                     String.format(
                             "Authentication request does not support %s requests", usedHttpMethod));
         }
+    }
+
+    private AuthenticationRequest parseRequest(APIGatewayProxyRequestEvent input)
+            throws ParseException {
+        AuthenticationRequest authRequest;
+        Map<String, String> parameterMap = input.getQueryStringParameters();
+        Map<String, List<String>> requestParameters =
+                parameterMap.entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey, entry -> List.of(entry.getValue())));
+        authRequest = AuthenticationRequest.parse(requestParameters);
+        authRequest = stripOutReauthenticateQueryParams(authRequest);
+        authRequest = stripOutLoginHintQueryParams(authRequest);
+        return authRequest;
     }
 
     private void sendAuthRequestParsedAuditEvent(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -287,24 +287,10 @@ public class AuthorisationHandler
             return generateBadRequestResponse(user, e.getMessage(), clientId);
         }
 
-        boolean isJarValidationRequired =
+        boolean clientRequiresJarValidation =
                 orchestrationAuthorizationService.isJarValidationRequired(client);
-        if (isJarValidationRequired && authRequest.getRequestObject() == null) {
-            String errorMsg = "JAR required for client but request does not contain Request Object";
-            LOG.warn(errorMsg);
-            if (client.getRedirectUrls().contains(authRequest.getRedirectionURI().toString())) {
-                LOG.warn("Redirecting");
-                return generateErrorResponse(
-                        authRequest.getRedirectionURI(),
-                        authRequest.getState(),
-                        authRequest.getResponseMode(),
-                        new ErrorObject(ACCESS_DENIED_CODE, errorMsg),
-                        client.getClientID(),
-                        user);
-            } else {
-                LOG.warn("Redirect URI {} is invalid for client", authRequest.getRedirectionURI());
-                return generateBadRequestResponse(user, errorMsg, client.getClientID());
-            }
+        if (clientRequiresJarValidation && authRequest.getRequestObject() == null) {
+            return handleJarValidationBadRequest(authRequest, client, user);
         }
 
         Optional<AuthRequestError> authRequestError;
@@ -500,6 +486,25 @@ public class AuthorisationHandler
         authRequest = stripOutReauthenticateQueryParams(authRequest);
         authRequest = stripOutLoginHintQueryParams(authRequest);
         return authRequest;
+    }
+
+    private APIGatewayProxyResponseEvent handleJarValidationBadRequest(
+            AuthenticationRequest authRequest, ClientRegistry client, TxmaAuditUser user) {
+        String errorMsg = "JAR required for client but request does not contain Request Object";
+        LOG.warn(errorMsg);
+        if (client.getRedirectUrls().contains(authRequest.getRedirectionURI().toString())) {
+            LOG.warn("Redirecting");
+            return generateErrorResponse(
+                    authRequest.getRedirectionURI(),
+                    authRequest.getState(),
+                    authRequest.getResponseMode(),
+                    new ErrorObject(ACCESS_DENIED_CODE, errorMsg),
+                    client.getClientID(),
+                    user);
+        } else {
+            LOG.warn("Redirect URI {} is invalid for client", authRequest.getRedirectionURI());
+            return generateBadRequestResponse(user, errorMsg, client.getClientID());
+        }
     }
 
     private void sendAuthRequestParsedAuditEvent(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -287,7 +287,6 @@ public class AuthorisationHandler
             return generateBadRequestResponse(user, e.getMessage(), clientId);
         }
 
-        Optional<AuthRequestError> authRequestError;
         boolean isJarValidationRequired =
                 orchestrationAuthorizationService.isJarValidationRequired(client);
         if (isJarValidationRequired && authRequest.getRequestObject() == null) {
@@ -308,6 +307,7 @@ public class AuthorisationHandler
             }
         }
 
+        Optional<AuthRequestError> authRequestError;
         try {
             if (authRequest.getRequestObject() == null) {
                 LOG.info("Validating request query params");


### PR DESCRIPTION
### Wider context of change

* Trying to simplify/shorten handlers to improve maintainability
* Making it easier to adapt the AuthoriseHandler to accommodate future requirements, like PAR

### What’s changed

Work that was happening in the main body of the handler is extracted into methods.  The idea is to be able to move later to grouping dependencies and possibly moving work in helper methods out into other classes, potentially making use of polymorphism to deal with different types of request or different processing requirements.


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

BAU: move noisy http method check out of main handler
(https://github.com/govuk-one-login/authentication-api/pull/8722)
