### PR TITLE
BAU: Increase AMCCallbackFunctionErrorCloudwatchAlarm alarm threshold

### DIFF
--- a/ci/cloudformation/auth/function/amc-callback.yaml
+++ b/ci/cloudformation/auth/function/amc-callback.yaml
@@ -130,13 +130,7 @@ Resources:
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-amc-callback-lambda function. ${RunbookLink}"
-        - AlarmThreshold:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              lambdaLogAlarmThreshold,
-              DefaultValue: 5,
-            ]
+        - AlarmThreshold: 20
           Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           RunbookLink:
             !FindInMap [
@@ -156,13 +150,7 @@ Resources:
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
-      Threshold:
-        !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          lambdaLogAlarmThreshold,
-          DefaultValue: 5,
-        ]
+      Threshold: 20
 
   AMCCallbackFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What

This alarm has been very noisy in slack. There is an investigation into the cause for this but in the meantime, in order to keep noise to a minimum, we will increase the threshold.

## How to review

1. Code review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->



<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->



<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->



<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->



<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
