### PR TITLE
BAU: DO NOT MERGE: Filter AZ data source to exclude eu-west-2d (Redis resources)

### DIFF
--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -39,4 +39,9 @@ data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-name"
+    values = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+  }
+}

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -70,4 +70,9 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-name"
+    values = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+  }
+}


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Filter AZ data source to exclude eu-west-2d.

Used by the two ElastiCache replication groups - [code link](https://github.com/search?q=repo%3Agovuk-one-login%2Fauthentication-api+preferred_cache_cluster_azs&type=code).

Old account pipelines (only data stores in use there now)

My current understanding is that this is zero-downtime as it's filtering down to 3 AZs which I believe is what we're already running

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Testing

1. Deployed same "core" networking infra fix ([PR](https://github.com/govuk-one-login/infrastructure/pull/650)) to dev.
1. Then deployed this fix to dev (using the workflow)
1. Observed a passing pipeline
1. Reviewed the deploy AM action, observed `Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`

My current understanding is that this is zero-downtime as it's filtering down to 3 AZs which I believe is what we're already running

<img width="1403" height="325" alt="Screenshot 2026-08-20 at 15 54 29" src="https://github.com/user-attachments/assets/a21ed9d7-e46d-461b-8b39-8b18b4ab53d8" />

<img width="506" height="66" alt="Screenshot 2026-08-20 at 15 54 51" src="https://github.com/user-attachments/assets/0e9ac577-0715-4f00-ae45-5a2e3836b5c5" />
