### PR TITLE
BAU: Pin SonarQube plugin to 7.3.1.8318 to fix implicit dependency errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "gradle"
         versions: ["[9.0,)"]
+      - dependency-name: "org.sonarqube"
+        versions: ["[7.4.0,)"]
       - dependency-name: "com.nimbusds:oauth2-oidc-sdk"
       - dependency-name: "org.junit*:*"
         update-types: ["version-update:semver-patch"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,6 @@ xray = [
 [plugins]
 dockerCompose = "com.avast.gradle.docker-compose:0.17.21"
 pact = "au.com.dius.pact:4.7.0"
-sonar = "org.sonarqube:7.4.0.8496"
+sonar = "org.sonarqube:7.3.1.8318"
 spotbugs = "com.github.spotbugs:6.5.10"
 spotless = "com.diffplug.spotless:8.9.0"


### PR DESCRIPTION

## What

Pin SonarQube plugin to 7.3.1.8318 to fix implicit dependency errors

The SonarQube Gradle plugin 7.4.0.8496 reintroduces a regression (SCANGRADLE-441) where sonarResolver tasks fail with implicit dependency validation errors on Gradle 9.6.1 in multi-project builds.

Affected tasks:

- :account-management-api:sonarResolver
- :account-data-api:sonarResolver
- :account-management-integration-tests:sonarResolver

Fix:

- Downgrade org.sonarqube plugin to 7.3.1.8318 (last known-good version)
- Add dependabot ignore rule for org.sonarqube [7.4.0,) to prevent upgrading back until SonarSource ships a fix

## How to review


1. Code Review
1. Check that the sonar tasks are running correctly


