### PR TITLE
AUT-5692: Disable IAD tracker writes on integration now export complete

### DIFF
--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -456,7 +456,7 @@ Mappings:
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "7"
       inactiveAccountExportMaxInvocations: "150"
-      inactiveAccountExportTrackerWriteEnabled: "true"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#8808

Export has been completed, reverting to prevent further writes (without the flag being changed again), allowing the home-team to mutate the data we wrote