### PR TITLE
BAU: Populate Gradle build cache on push to main

### DIFF
--- a/.github/workflows/warm-configuration-cache.yml
+++ b/.github/workflows/warm-configuration-cache.yml
@@ -5,6 +5,7 @@ env:
   GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -29,7 +30,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run --no-daemon spotlessCheck
+        run: ./gradlew --no-daemon spotlessCheck
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -49,7 +50,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x account-data-api-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x account-data-api-integration-tests:test -x spotlessApply -x spotlessCheck
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -58,6 +59,39 @@ jobs:
 
   run-integration-tests-api:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -69,7 +103,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run :integration-tests:test --tests "uk.gov.di.authentication.api.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+        run: ./gradlew :integration-tests:test --tests "uk.gov.di.authentication.api.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -78,6 +112,39 @@ jobs:
 
   run-integration-tests-services:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -89,7 +156,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run :integration-tests:test --tests "uk.gov.di.authentication.services.*" --tests "uk.gov.di.authentication.shared.services.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+        run: ./gradlew :integration-tests:test --tests "uk.gov.di.authentication.services.*" --tests "uk.gov.di.authentication.shared.services.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -98,6 +165,39 @@ jobs:
 
   run-integration-tests-orchestration:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -109,7 +209,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run :integration-tests:test --tests "uk.gov.di.orchestration.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+        run: ./gradlew :integration-tests:test --tests "uk.gov.di.orchestration.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -118,6 +218,39 @@ jobs:
 
   run-integration-tests-utils:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -129,7 +262,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run :integration-tests:test --tests "uk.gov.di.authentication.utils.*" --tests "uk.gov.di.authentication.queuehandlers.*" --tests "uk.gov.di.authentication.contract.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+        run: ./gradlew :integration-tests:test --tests "uk.gov.di.authentication.utils.*" --tests "uk.gov.di.authentication.queuehandlers.*" --tests "uk.gov.di.authentication.contract.*" :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -138,6 +271,39 @@ jobs:
 
   run-account-management-and-delivery-receipts-tests:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -150,8 +316,8 @@ jobs:
           cache-read-only: false
       - name: Warm CC
         run: |
-          ./gradlew --dry-run :account-management-integration-tests:test :account-management-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
-          ./gradlew --dry-run :delivery-receipts-integration-tests:test :delivery-receipts-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+          ./gradlew :account-management-integration-tests:test :account-management-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+          ./gradlew :delivery-receipts-integration-tests:test :delivery-receipts-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -160,6 +326,30 @@ jobs:
 
   run-account-data-api-integration-tests:
     runs-on: ubuntu-24.04-arm
+    services:
+      localstack:
+        image: localstack/localstack:4.6.0@sha256:5a97e0f9917a3f0d9630bb13b9d8ccf10cbe52f33252807d3b4e21418cc21348
+        env:
+          SERVICES: "sqs, sns, kms, ssm, s3, secretsmanager"
+          DEFAULT_REGION: eu-west-2
+          GATEWAY_LISTEN: 0.0.0.0:45678
+          LOCALSTACK_HOST: localhost:45678
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
+        ports:
+          - 45678:45678
+      dynamodb:
+        image: amazon/dynamodb-local:3.0.0@sha256:2fed5e3a965a4ba5aa6ac82baec57058b5a3848e959d705518f3fd579a77e76b
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -171,7 +361,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
       - name: Warm CC
-        run: ./gradlew --dry-run :account-data-api-integration-tests:test :account-data-api-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+        run: ./gradlew :account-data-api-integration-tests:test :account-data-api-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Save CC
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -197,23 +387,3 @@ jobs:
         with:
           path: .gradle/configuration-cache/
           key: ${{ runner.os }}-cc-sonar-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}
-
-  run-code-analysis:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
-        with:
-          gradle-version: wrapper
-          cache-read-only: false
-      - name: Warm CC
-        run: ./gradlew --dry-run --no-daemon --no-parallel test testCodeCoverageReport sonar -x spotlessApply -x spotlessCheck
-      - name: Save CC
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .gradle/configuration-cache/
-          key: ${{ runner.os }}-cc-sonar-on-merge-${{ hashFiles('**/build.gradle', 'gradle.properties', 'gradle/libs.versions.toml', 'settings.gradle') }}


### PR DESCRIPTION
## What

- Add `workflow_dispatch` so GH cache can be populated manually
- Remove `--dry-run` from gradlew test invocations in warm-configuration-cache.yml. This will trigger a full gradle build, populating the build cache on push to main
- As this happens on push to main, this happens silently in the background _after_ a PR has gone through the merge queue successfully. This will _not_ block merge to main, even if this approach doesn't work as planned.
- This will hopefully mean that on new PRs, if given gradle submodules have not changed (and so the hashes of module contents the gradle/GH cache uses as a key have not changed), the test job will skip and refer to a cached test output
- Even though integration tests are treated as their own modules, their hash is calculated based on the contents of modules they are dependent on. As an example, if ADAPI integration tests do not change but ADAPI application code changes, the integration tests will run due to the `testImplementation project(":account-data-api")` line in the ADAPI integration tests build.gradle file.
- Also removed the run-code-analysis job as this runs in the sonar-analysis-on-merge workflow, which also runs on push to main, so this is redundant.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
