### PR TITLE
AUT-5613: Emit deletion audit event in IAD queue processor Lambda

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AccountDeletionReason.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AccountDeletionReason.java
@@ -4,4 +4,5 @@ public enum AccountDeletionReason {
     USER_INITIATED,
     SUPPORT_INITIATED,
     SECURITY_INITIATED,
+    INACTIVE_ACCOUNT,
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -7,10 +7,15 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.InactiveAccountDeletionMessage;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
@@ -18,6 +23,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -32,6 +38,8 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
     private final InactiveAccountDeletionTokenService tokenService;
     private final AccountDeletionService accountDeletionService;
     private final DynamoService dynamoService;
+    private final StructuredAuditService structuredAuditService;
+    private final ConfigurationService configurationService;
 
     public InactiveAccountDeletionHandler() {
         this(ConfigurationService.getInstance());
@@ -44,15 +52,21 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                 new AccountDeletionService(
                         null, null, null, configurationService, null, accountDataApiService);
         this.dynamoService = new DynamoService(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
+        this.configurationService = configurationService;
     }
 
     public InactiveAccountDeletionHandler(
             InactiveAccountDeletionTokenService tokenService,
             AccountDeletionService accountDeletionService,
-            DynamoService dynamoService) {
+            DynamoService dynamoService,
+            StructuredAuditService structuredAuditService,
+            ConfigurationService configurationService) {
         this.tokenService = tokenService;
         this.accountDeletionService = accountDeletionService;
         this.dynamoService = dynamoService;
+        this.structuredAuditService = structuredAuditService;
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -82,11 +96,9 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                         message.publicSubjectId());
 
                 var userProfile = getUserProfile(message.publicSubjectId());
-                LOG.info(
-                        "Retrieved UserProfile for publicSubjectId: {}",
-                        userProfile.getPublicSubjectID());
 
                 deleteAccount(message.publicSubjectId());
+                emitAuditEvent(userProfile);
             } catch (Exception e) {
                 LOG.error(
                         "Failed to process inactive account deletion message with id: {}",
@@ -121,6 +133,40 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
         var token = tokenResult.getSuccess().getValue();
 
         accountDeletionService.deleteAccountViaDataApi(publicSubjectId, token);
+    }
+
+    private void emitAuditEvent(UserProfile userProfile) {
+        try {
+            var internalCommonSubjectIdentifier =
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                            userProfile,
+                            configurationService.getInternalSectorUri(),
+                            dynamoService);
+            var auditContext =
+                    new AuditContext(
+                            StructuredAuditService.UNKNOWN,
+                            StructuredAuditService.UNKNOWN,
+                            StructuredAuditService.UNKNOWN,
+                            internalCommonSubjectIdentifier.getValue(),
+                            userProfile.getEmail(),
+                            StructuredAuditService.UNKNOWN,
+                            userProfile.getPhoneNumber(),
+                            StructuredAuditService.UNKNOWN,
+                            StructuredAuditService.UNKNOWN);
+            var auditEvent =
+                    AuthDeleteAccount.create(
+                            auditContext,
+                            userProfile.getPublicSubjectID(),
+                            userProfile.getLegacySubjectID(),
+                            AccountDeletionReason.INACTIVE_ACCOUNT.name(),
+                            Clock.systemUTC());
+            structuredAuditService.submitAuditEvent(auditEvent);
+        } catch (Exception e) {
+            LOG.error(
+                    "Failed to submit AUTH_DELETE_ACCOUNT audit event for publicSubjectId: {}",
+                    userProfile.getPublicSubjectID(),
+                    e);
+        }
     }
 
     private InactiveAccountDeletionMessage parseMessage(SQSMessage msg) throws JsonException {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -10,13 +10,16 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.InactiveAccountDeletionMessage;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceId;
@@ -28,6 +31,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
     private final Json objectMapper = SerializationService.getInstance();
     private final InactiveAccountDeletionTokenService tokenService;
     private final AccountDeletionService accountDeletionService;
+    private final DynamoService dynamoService;
 
     public InactiveAccountDeletionHandler() {
         this(ConfigurationService.getInstance());
@@ -39,13 +43,16 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
         this.accountDeletionService =
                 new AccountDeletionService(
                         null, null, null, configurationService, null, accountDataApiService);
+        this.dynamoService = new DynamoService(configurationService);
     }
 
     public InactiveAccountDeletionHandler(
             InactiveAccountDeletionTokenService tokenService,
-            AccountDeletionService accountDeletionService) {
+            AccountDeletionService accountDeletionService,
+            DynamoService dynamoService) {
         this.tokenService = tokenService;
         this.accountDeletionService = accountDeletionService;
+        this.dynamoService = dynamoService;
     }
 
     @Override
@@ -74,6 +81,11 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                         "Processing inactive account deletion for publicSubjectId: {}",
                         message.publicSubjectId());
 
+                var userProfile = getUserProfile(message.publicSubjectId());
+                LOG.info(
+                        "Retrieved UserProfile for publicSubjectId: {}",
+                        userProfile.getPublicSubjectID());
+
                 deleteAccount(message.publicSubjectId());
             } catch (Exception e) {
                 LOG.error(
@@ -89,6 +101,15 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                 failures.size(),
                 event.getRecords().size());
         return new SQSBatchResponse(failures);
+    }
+
+    private UserProfile getUserProfile(String publicSubjectId) {
+        Optional<UserProfile> maybeUserProfile =
+                dynamoService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
+        return maybeUserProfile.orElseThrow(
+                () ->
+                        new RuntimeException(
+                                "UserProfile not found for publicSubjectId: " + publicSubjectId));
     }
 
     private void deleteAccount(String publicSubjectId) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -193,7 +193,9 @@ public class AccountDeletionService {
             var response = accountDataApiService.deleteAccount(publicSubjectId, token);
             int statusCode = response.statusCode();
             if (statusCode == 204) {
-                LOG.info("Successfully deleted account via Data API");
+                LOG.info(
+                        "Successfully deleted account via Data API for publicSubjectId: {}",
+                        publicSubjectId);
             } else if (statusCode == 404) {
                 LOG.error("Account not found in Data API for publicSubjectId: {}", publicSubjectId);
                 throw new RuntimeException(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -11,8 +11,11 @@ import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
 import uk.gov.di.authentication.shared.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -38,13 +41,18 @@ class InactiveAccountDeletionHandlerTest {
             mock(InactiveAccountDeletionTokenService.class);
     private final AccountDeletionService accountDeletionService =
             mock(AccountDeletionService.class);
+    private final DynamoService dynamoService = mock(DynamoService.class);
     private InactiveAccountDeletionHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new InactiveAccountDeletionHandler(tokenService, accountDeletionService);
+        handler =
+                new InactiveAccountDeletionHandler(
+                        tokenService, accountDeletionService, dynamoService);
         when(tokenService.createAccountDataApiAccessToken(any()))
                 .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(any()))
+                .thenReturn(Optional.of(userProfileWithPublicSubjectId(PUBLIC_SUBJECT_ID)));
     }
 
     @Test
@@ -127,11 +135,39 @@ class InactiveAccountDeletionHandlerTest {
     }
 
     @Test
+    void shouldReportFailureWhenUserProfileNotFound() {
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                .thenReturn(Optional.empty());
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(accountDeletionService);
+    }
+
+    @Test
+    void shouldProceedToDeletionWhenUserProfileFound() {
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+        verify(dynamoService).getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID);
+        verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+    }
+
+    @Test
     void shouldProcessBatchWithMixedSuccessAndFailure() {
         var goodMessage = createSQSMessage("msg-good", "{\"publicSubjectId\": \"sub-1\"}");
         var badMessage = createSQSMessage("msg-bad", "invalid json");
         var failingMessage = createSQSMessage("msg-fail", "{\"publicSubjectId\": \"sub-2\"}");
 
+        when(dynamoService.getOptionalUserProfileFromPublicSubject("sub-1"))
+                .thenReturn(Optional.of(userProfileWithPublicSubjectId("sub-1")));
+        when(dynamoService.getOptionalUserProfileFromPublicSubject("sub-2"))
+                .thenReturn(Optional.of(userProfileWithPublicSubjectId("sub-2")));
         doNothing().when(accountDeletionService).deleteAccountViaDataApi(eq("sub-1"), any());
         doThrow(new RuntimeException("5xx"))
                 .when(accountDeletionService)
@@ -145,6 +181,12 @@ class InactiveAccountDeletionHandlerTest {
         assertThat(response.getBatchItemFailures(), hasSize(2));
         assertEquals("msg-bad", response.getBatchItemFailures().get(0).getItemIdentifier());
         assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
+    }
+
+    private UserProfile userProfileWithPublicSubjectId(String publicSubjectId) {
+        var userProfile = new UserProfile();
+        userProfile.setPublicSubjectID(publicSubjectId);
+        return userProfile;
     }
 
     private SQSEvent createSQSEventWithBody(String body) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -7,11 +7,16 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
+import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.List;
@@ -27,6 +32,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -34,7 +40,10 @@ import static org.mockito.Mockito.when;
 class InactiveAccountDeletionHandlerTest {
 
     private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String LEGACY_SUBJECT_ID = "legacy-subject-id";
+    private static final String EMAIL = "test@example.com";
     private static final String TOKEN_VALUE = "test-bearer-token";
+    private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
 
     private final Context context = mock(Context.class);
     private final InactiveAccountDeletionTokenService tokenService =
@@ -42,17 +51,26 @@ class InactiveAccountDeletionHandlerTest {
     private final AccountDeletionService accountDeletionService =
             mock(AccountDeletionService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private InactiveAccountDeletionHandler handler;
 
     @BeforeEach
     void setUp() {
         handler =
                 new InactiveAccountDeletionHandler(
-                        tokenService, accountDeletionService, dynamoService);
+                        tokenService,
+                        accountDeletionService,
+                        dynamoService,
+                        structuredAuditService,
+                        configurationService);
         when(tokenService.createAccountDataApiAccessToken(any()))
                 .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
         when(dynamoService.getOptionalUserProfileFromPublicSubject(any()))
                 .thenReturn(Optional.of(userProfileWithPublicSubjectId(PUBLIC_SUBJECT_ID)));
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(dynamoService.getOrGenerateSalt(any())).thenReturn(new byte[] {0x1});
     }
 
     @Test
@@ -80,6 +98,7 @@ class InactiveAccountDeletionHandlerTest {
 
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        verifyNoInteractions(structuredAuditService);
     }
 
     @Test
@@ -93,6 +112,7 @@ class InactiveAccountDeletionHandlerTest {
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
         verifyNoInteractions(accountDeletionService);
+        verifyNoInteractions(structuredAuditService);
     }
 
     @Test
@@ -145,6 +165,7 @@ class InactiveAccountDeletionHandlerTest {
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
         verifyNoInteractions(accountDeletionService);
+        verifyNoInteractions(structuredAuditService);
     }
 
     @Test
@@ -155,6 +176,55 @@ class InactiveAccountDeletionHandlerTest {
 
         assertThat(response.getBatchItemFailures(), is(empty()));
         verify(dynamoService).getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID);
+        verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+    }
+
+    @Test
+    void shouldEmitAuthDeleteAccountAuditEventOnSuccessfulDeletion() {
+        var userProfile = userProfileWithPublicSubjectId(PUBLIC_SUBJECT_ID);
+        userProfile.setLegacySubjectID(LEGACY_SUBJECT_ID);
+        userProfile.setEmail(EMAIL);
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                .thenReturn(Optional.of(userProfile));
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+        var captor = ArgumentCaptor.forClass(AuthDeleteAccount.class);
+        verify(structuredAuditService).submitAuditEvent(captor.capture());
+        var auditEvent = captor.getValue();
+
+        assertEquals("AUTH_DELETE_ACCOUNT", auditEvent.eventName());
+        assertEquals(PUBLIC_SUBJECT_ID, auditEvent.user().publicSubjectId());
+        assertEquals(LEGACY_SUBJECT_ID, auditEvent.user().legacySubjectId());
+        assertEquals(
+                AccountDeletionReason.INACTIVE_ACCOUNT.name(),
+                auditEvent.extensions().accountDeletionReason());
+    }
+
+    @Test
+    void shouldNotEmitAuditEventWhenDeletionFails() {
+        doThrow(new RuntimeException("Data API returned error status 500"))
+                .when(accountDeletionService)
+                .deleteAccountViaDataApi(any(), any());
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        handler.handleRequest(event, context);
+
+        verifyNoInteractions(structuredAuditService);
+    }
+
+    @Test
+    void shouldNotReportFailureWhenAuditEmissionFails() {
+        doThrow(new RuntimeException("Failed to send to SQS"))
+                .when(structuredAuditService)
+                .submitAuditEvent(any());
+        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
         verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
     }
 
@@ -181,11 +251,13 @@ class InactiveAccountDeletionHandlerTest {
         assertThat(response.getBatchItemFailures(), hasSize(2));
         assertEquals("msg-bad", response.getBatchItemFailures().get(0).getItemIdentifier());
         assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
+        verify(structuredAuditService, times(1)).submitAuditEvent(any());
     }
 
     private UserProfile userProfileWithPublicSubjectId(String publicSubjectId) {
         var userProfile = new UserProfile();
         userProfile.setPublicSubjectID(publicSubjectId);
+        userProfile.setSubjectID(publicSubjectId);
         return userProfile;
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
@@ -32,6 +32,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_DELETE_ACCOUNT;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
 
 @ExtendWith(SystemStubsExtension.class)
 class InactiveAccountDeletionHandlerIntegrationTest
@@ -40,6 +42,7 @@ class InactiveAccountDeletionHandlerIntegrationTest
     private static final String TEST_EMAIL = "inactive-account-test@example.com";
     private static final String TEST_PASSWORD = "password-1";
     private static final String IAD_CLIENT_ID = "inactive-account-deletion-client";
+    private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
 
     private WireMockServer accountDataApiWireMockServer;
     private String publicSubjectId;
@@ -56,11 +59,13 @@ class InactiveAccountDeletionHandlerIntegrationTest
         environment.set("AUTH_ISSUER_CLAIM", "https://signin.account.gov.uk/");
         environment.set("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", IAD_CLIENT_ID);
         environment.set("AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", authToAccountDataSigningKey.getKeyId());
+        environment.set("INTERNAl_SECTOR_URI", INTERNAL_SECTOR_URI);
     }
 
     @BeforeEach
     void setUp() {
         publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
+        txmaAuditQueue.clear();
 
         accountDataApiWireMockServer =
                 new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
@@ -94,6 +99,8 @@ class InactiveAccountDeletionHandlerIntegrationTest
                 1,
                 deleteRequestedFor(urlPathMatching("/accounts/" + publicSubjectId))
                         .withHeader("Authorization", WireMock.matching("Bearer .+")));
+        assertTxmaAuditEventsSubmittedWithMatchingNames(
+                txmaAuditQueue, List.of(AUTH_DELETE_ACCOUNT));
     }
 
     @Test
@@ -203,6 +210,11 @@ class InactiveAccountDeletionHandlerIntegrationTest
             @Override
             public String getAccountDataURI() {
                 return accountDataUri;
+            }
+
+            @Override
+            public String getTxmaAuditQueueUrl() {
+                return txmaAuditQueue.getQueueUrl();
             }
         };
     }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
@@ -37,10 +37,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class InactiveAccountDeletionHandlerIntegrationTest
         extends HandlerIntegrationTest<SQSEvent, SQSBatchResponse> {
 
-    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String TEST_EMAIL = "inactive-account-test@example.com";
+    private static final String TEST_PASSWORD = "password-1";
     private static final String IAD_CLIENT_ID = "inactive-account-deletion-client";
 
     private WireMockServer accountDataApiWireMockServer;
+    private String publicSubjectId;
 
     @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
 
@@ -58,6 +60,8 @@ class InactiveAccountDeletionHandlerIntegrationTest
 
     @BeforeEach
     void setUp() {
+        publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
+
         accountDataApiWireMockServer =
                 new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         accountDataApiWireMockServer.start();
@@ -78,27 +82,27 @@ class InactiveAccountDeletionHandlerIntegrationTest
     @Test
     void shouldSuccessfullyDeleteAccountViaDataApi() {
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(204)));
 
-        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+        var event = createSQSEvent(publicSubjectId);
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
         assertThat(response.getBatchItemFailures(), is(empty()));
         accountDataApiWireMockServer.verify(
                 1,
-                deleteRequestedFor(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                deleteRequestedFor(urlPathMatching("/accounts/" + publicSubjectId))
                         .withHeader("Authorization", WireMock.matching("Bearer .+")));
     }
 
     @Test
     void shouldReportFailureWhenDataApiReturns404() {
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(404)));
 
-        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+        var event = createSQSEvent(publicSubjectId);
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
@@ -108,10 +112,10 @@ class InactiveAccountDeletionHandlerIntegrationTest
     @Test
     void shouldReportFailureWhenDataApiReturns500() {
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + PUBLIC_SUBJECT_ID))
+                delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(500)));
 
-        var event = createSQSEvent(PUBLIC_SUBJECT_ID);
+        var event = createSQSEvent(publicSubjectId);
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
@@ -140,19 +144,19 @@ class InactiveAccountDeletionHandlerIntegrationTest
 
     @Test
     void shouldProcessBatchWithMixedSuccessAndFailure() {
-        var successSubjectId = "urn:fdc:gov.uk:2022:success";
-        var failSubjectId = "urn:fdc:gov.uk:2022:fail";
+        var successPublicSubjectId = userStore.signUp("success-user@example.com", TEST_PASSWORD);
+        var failPublicSubjectId = userStore.signUp("fail-user@example.com", TEST_PASSWORD);
 
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + successSubjectId))
+                delete(urlPathMatching("/accounts/" + successPublicSubjectId))
                         .willReturn(aResponse().withStatus(204)));
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + failSubjectId))
+                delete(urlPathMatching("/accounts/" + failPublicSubjectId))
                         .willReturn(aResponse().withStatus(500)));
 
-        var goodMessage = createSQSMessage("msg-good", successSubjectId);
+        var goodMessage = createSQSMessage("msg-good", successPublicSubjectId);
         var badMessage = createRawSQSMessage("msg-bad", "invalid json");
-        var failMessage = createSQSMessage("msg-fail", failSubjectId);
+        var failMessage = createSQSMessage("msg-fail", failPublicSubjectId);
 
         var event = new SQSEvent();
         event.setRecords(List.of(goodMessage, badMessage, failMessage));
@@ -164,9 +168,9 @@ class InactiveAccountDeletionHandlerIntegrationTest
         assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
 
         accountDataApiWireMockServer.verify(
-                1, deleteRequestedFor(urlPathMatching("/accounts/" + successSubjectId)));
+                1, deleteRequestedFor(urlPathMatching("/accounts/" + successPublicSubjectId)));
         accountDataApiWireMockServer.verify(
-                1, deleteRequestedFor(urlPathMatching("/accounts/" + failSubjectId)));
+                1, deleteRequestedFor(urlPathMatching("/accounts/" + failPublicSubjectId)));
     }
 
     private SQSEvent createSQSEvent(String publicSubjectId) {

--- a/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
@@ -61,12 +61,21 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               frontendBaseUrl,
             ]
+          TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
+          INTERNAl_SECTOR_URI: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://identity.${SubEnvironment}.dev.account.gov.uk"
+              - !Sub "https://identity.${Environment}.account.gov.uk"
+            - "https://identity.account.gov.uk"
       LoggingConfig:
         LogGroup: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref UserProfileTableKmsPolicy
+        - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
         - Version: 2012-10-17
           Statement:
             - Sid: AllowKmsSignForAccountDataToken

--- a/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
+++ b/ci/cloudformation/account-management/function/inactive-account-deletion.yaml
@@ -16,6 +16,14 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          DYNAMO_ARN_PREFIX: !Sub
+            - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
+            - DataStoreAccountId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dataStoreAccountId,
+                ]
           INACTIVE_ACCOUNT_DELETION_CLIENT_ID:
             !FindInMap [
               EnvironmentConfiguration,
@@ -57,6 +65,8 @@ Resources:
         LogGroup: !Ref InactiveAccountDeletionQueueProcessorFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
+        - !Ref DynamoUserReadAccessPolicy
+        - !Ref UserProfileTableKmsPolicy
         - Version: 2012-10-17
           Statement:
             - Sid: AllowKmsSignForAccountDataToken


### PR DESCRIPTION
## What

Emits the `AUTH_DELETE_ACCOUNT` audit event, with the `account_deletion_reason` set to `INACTIVE_ACCOUNT`, from the IAD queue processor Lambda upon successful deletion.

Fetches the user profile prior to deletion to retrieve the legacy subject ID required for the audit event. Uses `UNKNOWN` for unavailable context fields.

## How to review

1. Code review
1. Optionally, deploy the AM API to a dev environment, identify an account you would like to delete in that dev environments user-profile DB table, copy the publicSubjectId value for that account, then within the AWS Console, locate the stub queue (not the DLQ!) and add a message with that ID of the format {"publicSubjectId": "ID_HERE"} and send, then review the Lambda logs and check the account has been deleted. Verify the `AUTH_DELETE_ACCOUNT` event is emitted to the TxMA audit queue with the correct metadata and reasons.

## Testing

Followed the above steps on authdev2, verified that the audit event was added to `authdev2-account-mgmt-txma-audit-queue`, and that this conforms to the event catalogue entry:

<details>
<summary>Redacted audit event from dev</summary>

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": 1787760776,
  "event_timestamp_ms": 1787760776165,
  "client_id": "",
  "component_id": "AUTH",
  "user": {
    "email": "[valid email here]",
    "govuk_signin_journey_id": "",
    "ip_address": "",
    "persistent_session_id": "",
    "public_subject_id": "[valid pub sub id here]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[valid user id here]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "INACTIVE_ACCOUNT"
  }
}
```

</details>

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A: Changes apply to a background queue processor for inactive accounts.**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
