### PR TITLE
Bau/migrate time api

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -15,12 +15,12 @@ import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.accountmanagement.services.TokenValidationService;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RemoteJwksService;
 
+import java.time.Clock;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -33,18 +33,20 @@ public class AuthoriseAccessTokenHandler
         implements RequestHandler<TokenAuthorizerContext, AuthPolicy> {
 
     private static final Logger LOG = LogManager.getLogger(AuthoriseAccessTokenHandler.class);
+    private final Clock clock;
 
     private final TokenValidationService tokenValidationService;
 
-    public AuthoriseAccessTokenHandler(TokenValidationService tokenValidationService) {
+    public AuthoriseAccessTokenHandler(TokenValidationService tokenValidationService, Clock clock) {
         this.tokenValidationService = tokenValidationService;
+        this.clock = clock;
     }
 
     public AuthoriseAccessTokenHandler() {
-        this(ConfigurationService.getInstance());
+        this(ConfigurationService.getInstance(), Clock.systemUTC());
     }
 
-    public AuthoriseAccessTokenHandler(ConfigurationService configurationService) {
+    public AuthoriseAccessTokenHandler(ConfigurationService configurationService, Clock clock) {
         tokenValidationService =
                 new TokenValidationService(
                         new JwksService(
@@ -52,6 +54,7 @@ public class AuthoriseAccessTokenHandler
                                 new KmsConnectionService(configurationService)),
                         new RemoteJwksService(configurationService.getAccessTokenJwksUrl()),
                         configurationService);
+        this.clock = clock;
     }
 
     @Override
@@ -72,7 +75,7 @@ public class AuthoriseAccessTokenHandler
             SignedJWT signedAccessToken = SignedJWT.parse(accessToken.getValue());
             JWTClaimsSet claimsSet = signedAccessToken.getJWTClaimsSet();
 
-            Date currentDateTime = NowHelper.now();
+            Date currentDateTime = Date.from(clock.instant());
             if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 0)) {
                 LOG.warn(
                         "Access Token expires at: {}. CurrentDateTime is: {}",

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -28,7 +28,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
@@ -42,6 +41,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -70,6 +70,7 @@ public class UpdateEmailHandler
     private final AuditService auditService;
     private final ConfigurationService configurationService;
     private final StructuredAuditService structuredAuditService;
+    private final Clock nowClock;
 
     public UpdateEmailHandler() {
         this(ConfigurationService.getInstance());
@@ -82,7 +83,8 @@ public class UpdateEmailHandler
             CodeStorageService codeStorageService,
             AuditService auditService,
             ConfigurationService configurationService,
-            StructuredAuditService structuredAuditService) {
+            StructuredAuditService structuredAuditService,
+            Clock nowClock) {
         this.dynamoService = dynamoService;
         this.dynamoEmailCheckResultService = dynamoEmailCheckResultService;
         this.sqsClient = sqsClient;
@@ -90,6 +92,7 @@ public class UpdateEmailHandler
         this.auditService = auditService;
         this.configurationService = configurationService;
         this.structuredAuditService = structuredAuditService;
+        this.nowClock = nowClock;
     }
 
     public UpdateEmailHandler(ConfigurationService configurationService) {
@@ -106,6 +109,7 @@ public class UpdateEmailHandler
         this.auditService = new AuditService(configurationService);
         this.configurationService = configurationService;
         this.structuredAuditService = new StructuredAuditService(configurationService);
+        this.nowClock = Clock.systemUTC();
     }
 
     @Override
@@ -264,7 +268,7 @@ public class UpdateEmailHandler
                                 auditContext.sessionId()),
                         new AuthEmailFraudCheckBypassed.Extensions(
                                 JourneyType.REGISTRATION.getValue(),
-                                NowHelper.toUnixTimestamp(NowHelper.now())));
+                                nowClock.instant().getEpochSecond()));
 
         structuredAuditService.submitAuditEvent(newAuditEvent);
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -15,11 +15,12 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.accountmanagement.services.TokenValidationService;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,18 +44,20 @@ class AuthoriseAccessTokenHandlerTest {
             "arn:aws:execute-api:eu-west-2:123456789012:ymy8tbxw7b/*/POST/";
     private static final List<String> SCOPES = List.of("openid", "email", "phone", "am");
     private static final List<String> INVALID_SCOPES = List.of("openid", "email", "phone");
+    private static final Clock TEST_CLOCK =
+            Clock.fixed(Instant.parse("2026-06-15T12:00:00Z"), ZoneOffset.UTC);
 
     private static final Subject SUBJECT = new Subject("some-subject");
 
     @BeforeEach
     public void setUp() {
-        handler = new AuthoriseAccessTokenHandler(tokenValidationService);
+        handler = new AuthoriseAccessTokenHandler(tokenValidationService, TEST_CLOCK);
     }
 
     @Test
     public void shouldReturnAuthPolicyForSuccessfulRequest() throws JOSEException {
         BearerAccessToken signedAccessToken =
-                new BearerAccessToken(createSignedAccessToken(SCOPES).serialize());
+                new BearerAccessToken(createSignedAccessToken(SCOPES, TEST_CLOCK).serialize());
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
@@ -86,7 +89,7 @@ class AuthoriseAccessTokenHandlerTest {
     @Test
     public void shouldThrowExceptionWhenAccessTokenHasInvalidSignature() throws JOSEException {
         BearerAccessToken signedAccessToken =
-                new BearerAccessToken(createSignedAccessToken(SCOPES).serialize());
+                new BearerAccessToken(createSignedAccessToken(SCOPES, TEST_CLOCK).serialize());
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
@@ -104,7 +107,7 @@ class AuthoriseAccessTokenHandlerTest {
 
     @Test
     public void shouldThrowExceptionWhenInvalidAccessTokenIsSentInRequest() throws JOSEException {
-        String invalidAccessToken = createSignedAccessToken(SCOPES).serialize();
+        String invalidAccessToken = createSignedAccessToken(SCOPES, TEST_CLOCK).serialize();
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(TOKEN_TYPE, invalidAccessToken, METHOD_ARN);
 
@@ -135,7 +138,8 @@ class AuthoriseAccessTokenHandlerTest {
     @Test
     public void shouldThrowExceptionWhenAccessTokenHasInvalidScopes() throws JOSEException {
         BearerAccessToken signedAccessToken =
-                new BearerAccessToken(createSignedAccessToken(INVALID_SCOPES).serialize());
+                new BearerAccessToken(
+                        createSignedAccessToken(INVALID_SCOPES, TEST_CLOCK).serialize());
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
@@ -151,15 +155,22 @@ class AuthoriseAccessTokenHandlerTest {
         assertEquals("Unauthorized", exception.getMessage());
     }
 
-    private SignedJWT createSignedAccessToken(List<String> scopes) throws JOSEException {
+    private SignedJWT createSignedAccessToken(List<String> scopes, Clock clock)
+            throws JOSEException {
         ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
         JWSSigner signer = new ECDSASigner(ecJWK);
         return TokenGeneratorHelper.generateSignedToken(
-                CLIENT_ID, "http://example.com", scopes, signer, SUBJECT, "14342354354353");
+                CLIENT_ID,
+                "http://example.com",
+                scopes,
+                signer,
+                SUBJECT,
+                "14342354354353",
+                clock.instant().plus(2, ChronoUnit.MINUTES));
     }
 
     private SignedJWT createSignedExpiredAccessToken(List<String> scopes) throws JOSEException {
-        Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
+        Instant expiryDate = Instant.now(TEST_CLOCK).minus(2, ChronoUnit.MINUTES);
         ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
         JWSSigner signer = new ECDSASigner(ecJWK);
         return TokenGeneratorHelper.generateSignedToken(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
@@ -33,7 +31,6 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
@@ -46,6 +43,9 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.helper.CommonTestVariables;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -97,6 +97,8 @@ class UpdateEmailHandlerTest {
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", SALT);
+    private static final Clock TEST_NOW_CLOCK =
+            Clock.fixed(Instant.parse("2026-06-15T12:00:00Z"), ZoneOffset.UTC);
     private final AuditContext auditContext =
             new AuditContext(
                     CLIENT_ID,
@@ -126,7 +128,8 @@ class UpdateEmailHandlerTest {
                         codeStorageService,
                         auditService,
                         configurationService,
-                        structuredAuditService);
+                        structuredAuditService,
+                        TEST_NOW_CLOCK);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
     }
@@ -180,40 +183,33 @@ class UpdateEmailHandlerTest {
         when(dynamoEmailCheckResultService.getEmailCheckStore(NEW_EMAIL_ADDRESS))
                 .thenReturn(Optional.empty());
 
-        long mockedTimestamp = 1719376320;
-        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass
-                    .when(() -> NowHelper.toUnixTimestamp(NowHelper.now()))
-                    .thenReturn(mockedTimestamp);
-            var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
-            handler.handleRequest(event, context);
+        var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
+        handler.handleRequest(event, context);
 
-            assertThat(
-                    logging.events(),
-                    hasItem(
-                            withMessageContaining(
-                                    "UpdateEmailHandler: Experian email verification status: PENDING")));
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "UpdateEmailHandler: Experian email verification status: PENDING")));
 
-            ArgumentCaptor<AuthEmailFraudCheckBypassed> auditEventCaptor =
-                    ArgumentCaptor.forClass(AuthEmailFraudCheckBypassed.class);
-            verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
+        ArgumentCaptor<AuthEmailFraudCheckBypassed> auditEventCaptor =
+                ArgumentCaptor.forClass(AuthEmailFraudCheckBypassed.class);
+        verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
 
-            AuthEmailFraudCheckBypassed capturedEvent = auditEventCaptor.getValue();
-            assertThat(capturedEvent.eventName(), is("AUTH_EMAIL_FRAUD_CHECK_BYPASSED"));
-            assertThat(capturedEvent.clientId(), is(auditContext.clientId()));
-            assertThat(capturedEvent.user().email(), is(NEW_EMAIL_ADDRESS));
-            assertThat(capturedEvent.user().ipAddress(), is(auditContext.ipAddress()));
-            assertThat(
-                    capturedEvent.user().persistentSessionId(),
-                    is(auditContext.persistentSessionId()));
-            assertThat(capturedEvent.user().govukSigninJourneyId(), is(auditContext.sessionId()));
-            assertThat(capturedEvent.user().userId(), is(expectedCommonSubject));
-            assertThat(
-                    capturedEvent.extensions().journeyType(),
-                    is(JourneyType.REGISTRATION.getValue()));
-            assertThat(
-                    capturedEvent.extensions().assessmentCheckedAtTimestamp(), is(mockedTimestamp));
-        }
+        AuthEmailFraudCheckBypassed capturedEvent = auditEventCaptor.getValue();
+        assertThat(capturedEvent.eventName(), is("AUTH_EMAIL_FRAUD_CHECK_BYPASSED"));
+        assertThat(capturedEvent.clientId(), is(auditContext.clientId()));
+        assertThat(capturedEvent.user().email(), is(NEW_EMAIL_ADDRESS));
+        assertThat(capturedEvent.user().ipAddress(), is(auditContext.ipAddress()));
+        assertThat(
+                capturedEvent.user().persistentSessionId(), is(auditContext.persistentSessionId()));
+        assertThat(capturedEvent.user().govukSigninJourneyId(), is(auditContext.sessionId()));
+        assertThat(capturedEvent.user().userId(), is(expectedCommonSubject));
+        assertThat(
+                capturedEvent.extensions().journeyType(), is(JourneyType.REGISTRATION.getValue()));
+        assertThat(
+                capturedEvent.extensions().assessmentCheckedAtTimestamp(),
+                is(TEST_NOW_CLOCK.instant().getEpochSecond()));
     }
 
     private static Stream<Arguments> successfulEmailCheckResultStatus() {
@@ -249,39 +245,32 @@ class UpdateEmailHandlerTest {
         when(dynamoEmailCheckResultService.getEmailCheckStore(NEW_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(resultStore));
 
-        long mockedTimestamp = 1719376320;
-        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass
-                    .when(() -> NowHelper.toUnixTimestamp(NowHelper.now()))
-                    .thenReturn(mockedTimestamp);
-            var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
-            handler.handleRequest(event, context);
+        var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
+        handler.handleRequest(event, context);
 
-            assertThat(
-                    logging.events(),
-                    hasItem(
-                            withMessageContaining(
-                                    String.format(
-                                            "UpdateEmailHandler: Experian email verification status: %s",
-                                            status))));
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                String.format(
+                                        "UpdateEmailHandler: Experian email verification status: %s",
+                                        status))));
 
-            ArgumentCaptor<AuthEmailFraudCheckDecisionUsed> auditEventCaptor =
-                    ArgumentCaptor.forClass(AuthEmailFraudCheckDecisionUsed.class);
-            verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
+        ArgumentCaptor<AuthEmailFraudCheckDecisionUsed> auditEventCaptor =
+                ArgumentCaptor.forClass(AuthEmailFraudCheckDecisionUsed.class);
+        verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
 
-            AuthEmailFraudCheckDecisionUsed capturedEvent = auditEventCaptor.getValue();
-            assertThat(capturedEvent.eventName(), is("AUTH_EMAIL_FRAUD_CHECK_DECISION_USED"));
-            assertThat(capturedEvent.clientId(), is(CLIENT_ID));
-            assertThat(capturedEvent.user().email(), is(NEW_EMAIL_ADDRESS));
-            assertThat(capturedEvent.user().ipAddress(), is(auditContext.ipAddress()));
-            assertThat(
-                    capturedEvent.user().persistentSessionId(),
-                    is(auditContext.persistentSessionId()));
-            assertThat(capturedEvent.user().govukSigninJourneyId(), is(auditContext.sessionId()));
-            assertThat(capturedEvent.user().userId(), is(expectedCommonSubject));
-            assertThat(capturedEvent.extensions(), is(expectedExtensions));
-            assertThat(capturedEvent.restricted(), is(expectedRestricted));
-        }
+        AuthEmailFraudCheckDecisionUsed capturedEvent = auditEventCaptor.getValue();
+        assertThat(capturedEvent.eventName(), is("AUTH_EMAIL_FRAUD_CHECK_DECISION_USED"));
+        assertThat(capturedEvent.clientId(), is(CLIENT_ID));
+        assertThat(capturedEvent.user().email(), is(NEW_EMAIL_ADDRESS));
+        assertThat(capturedEvent.user().ipAddress(), is(auditContext.ipAddress()));
+        assertThat(
+                capturedEvent.user().persistentSessionId(), is(auditContext.persistentSessionId()));
+        assertThat(capturedEvent.user().govukSigninJourneyId(), is(auditContext.sessionId()));
+        assertThat(capturedEvent.user().userId(), is(expectedCommonSubject));
+        assertThat(capturedEvent.extensions(), is(expectedExtensions));
+        assertThat(capturedEvent.restricted(), is(expectedRestricted));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -33,6 +33,9 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -61,6 +64,8 @@ class AuthoriseAccessTokenIntegrationTest
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private static KeyPair ecKeyPair;
     private Date validDate;
+    private static final Clock TEST_NOW_CLOCK =
+            Clock.fixed(Instant.ofEpochSecond(4102444800L), ZoneOffset.UTC);
 
     @RegisterExtension public static final JwksExtension jwksExtension = new JwksExtension();
 
@@ -83,7 +88,7 @@ class AuthoriseAccessTokenIntegrationTest
 
     @BeforeEach
     void setup() {
-        handler = new AuthoriseAccessTokenHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new AuthoriseAccessTokenHandler(TEST_CONFIGURATION_SERVICE, TEST_NOW_CLOCK);
         ecKeyPair = createTestEncryptionKeyPair();
         JWKSet jwkSet =
                 new JWKSet(
@@ -95,7 +100,7 @@ class AuthoriseAccessTokenIntegrationTest
                                         .algorithm(JWSAlgorithm.ES256)
                                         .build()));
         jwksExtension.init(jwkSet);
-        validDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
+        validDate = Date.from(TEST_NOW_CLOCK.instant().plus(5, ChronoUnit.MINUTES));
     }
 
     private static KeyPair createTestEncryptionKeyPair() {
@@ -188,7 +193,8 @@ class AuthoriseAccessTokenIntegrationTest
                     }
                 };
 
-        var customHandler = new AuthoriseAccessTokenHandler(configServiceWithTestToken);
+        var customHandler =
+                new AuthoriseAccessTokenHandler(configServiceWithTestToken, TEST_NOW_CLOCK);
 
         var scopes =
                 asList(
@@ -233,7 +239,7 @@ class AuthoriseAccessTokenIntegrationTest
                         .claim("scope", scopes)
                         .issuer("issuer-id")
                         .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
+                        .issueTime(Date.from(TEST_NOW_CLOCK.instant()))
                         .subject(publicSubject)
                         .jwtID(UUID.randomUUID().toString());
         clientIdOpt.ifPresent(clientId -> claimsSetBuilder.claim("client_id", clientId));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -11,6 +11,7 @@ import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -33,7 +34,7 @@ public class TokenGeneratorHelper {
         Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
         return generateSignedToken(
-                clientId, issuerUrl, scopes, signer, subject, keyId, expiryDate, null);
+                clientId, issuerUrl, scopes, signer, subject, keyId, expiryDate.toInstant(), null);
     }
 
     public static SignedJWT generateSignedToken(
@@ -43,7 +44,7 @@ public class TokenGeneratorHelper {
             JWSSigner signer,
             Subject subject,
             String keyId,
-            Date expiryDate) {
+            Instant expiryDate) {
 
         return generateSignedToken(
                 clientId, issuerUrl, scopes, signer, subject, keyId, expiryDate, null);
@@ -56,14 +57,14 @@ public class TokenGeneratorHelper {
             JWSSigner signer,
             Subject subject,
             String keyId,
-            Date expiryDate,
+            Instant expiryDate,
             OIDCClaimsRequest identityClaims) {
 
         JWTClaimsSet.Builder claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
                         .issuer(issuerUrl)
-                        .expirationTime(expiryDate)
+                        .expirationTime(Date.from(expiryDate))
                         .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
                         .subject(subject.getValue())

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -14,8 +14,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
+import java.time.Clock;
+
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
-import static uk.gov.di.authentication.shared.helpers.NowHelper.now;
 
 public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, Void> {
 
@@ -23,17 +24,21 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
     private final Json objectMapper = SerializationService.getInstance();
     private final DynamoEmailCheckResultService db;
     private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final Clock clock;
 
     public EmailCheckResultWriterHandler(
             DynamoEmailCheckResultService databaseService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            CloudwatchMetricsService cloudwatchMetricsService,
+            Clock clock) {
         this.db = databaseService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.clock = clock;
     }
 
     public EmailCheckResultWriterHandler(ConfigurationService configService) {
         this.db = new DynamoEmailCheckResultService(configService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configService);
+        this.clock = Clock.systemUTC();
     }
 
     public EmailCheckResultWriterHandler() {
@@ -65,7 +70,7 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                         emailCheckResult.govukSigninJourneyId(),
                         emailCheckResult.emailCheckResponse());
 
-                long currentTime = now().getTime();
+                long currentTime = clock.millis();
                 long timeOfInitialRequest = emailCheckResult.timeOfInitialRequest();
                 long duration = currentTime - timeOfInitialRequest;
                 LOG.info(

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
@@ -6,17 +6,16 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.EmailCheckResponse;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 
+import java.time.Clock;
 import java.time.Instant;
-import java.util.Date;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,9 +29,11 @@ class EmailCheckResultWriterHandlerTest {
     private static final String TEST_MSG_EMAIL = "test@test.com";
     private static final long TEST_MSG_TIME_TO_EXIST = 1706870420L;
     private static final String TEST_MSG_REF_NUMBER = "123456-abc1234def5678";
-    private static final long TEST_TIME_OF_INITIAL_REQUEST = Instant.now().toEpochMilli();
+    private static final Clock TEST_TIME_NOW =
+            Clock.fixed(Instant.ofEpochSecond(4102444800L), ZoneOffset.UTC);
     private static final long REQUEST_DURATION = 1000L;
-    private static final long TEST_TIME_NOW = TEST_TIME_OF_INITIAL_REQUEST + REQUEST_DURATION;
+    private static final long TEST_TIME_OF_INITIAL_REQUEST =
+            TEST_TIME_NOW.instant().toEpochMilli() - REQUEST_DURATION;
     private static DynamoEmailCheckResultService dbMock;
     private static CloudwatchMetricsService cloudWatchMock;
     private static ArgumentCaptor<String> emailCaptor;
@@ -57,7 +58,7 @@ class EmailCheckResultWriterHandlerTest {
 
     @BeforeEach
     void setUp() {
-        handler = new EmailCheckResultWriterHandler(dbMock, cloudWatchMock);
+        handler = new EmailCheckResultWriterHandler(dbMock, cloudWatchMock, TEST_TIME_NOW);
         Mockito.reset(dbMock, cloudWatchMock);
     }
 
@@ -65,49 +66,41 @@ class EmailCheckResultWriterHandlerTest {
     void shouldProcessValidSQSEventWithSingleMessageAndSaveToDatabase() {
         var emailCheckResultStatus = EmailCheckResultStatus.ALLOW;
         SQSEvent event = getSqsEventWithSingleMessage(true, emailCheckResultStatus);
-        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass
-                    .when(NowHelper::now)
-                    .thenReturn(Date.from(Instant.ofEpochMilli(TEST_TIME_NOW)));
-            handler.emailCheckResultWriterHandler(event);
+        handler.emailCheckResultWriterHandler(event);
 
-            verify(dbMock)
-                    .saveEmailCheckResult(
-                            emailCaptor.capture(), statusCaptor.capture(),
-                            timeToExistCaptor.capture(), referenceNumberCaptor.capture(),
-                            govukSigninJourneyIdCaptor.capture(),
-                                    emailCheckResponseCaptor.capture());
+        verify(dbMock)
+                .saveEmailCheckResult(
+                        emailCaptor.capture(), statusCaptor.capture(),
+                        timeToExistCaptor.capture(), referenceNumberCaptor.capture(),
+                        govukSigninJourneyIdCaptor.capture(), emailCheckResponseCaptor.capture());
 
-            assertEquals(TEST_MSG_EMAIL, emailCaptor.getValue());
-            assertEquals(emailCheckResultStatus, statusCaptor.getValue());
-            assertEquals(TEST_MSG_TIME_TO_EXIST, timeToExistCaptor.getValue());
-            assertEquals(TEST_MSG_REF_NUMBER, referenceNumberCaptor.getValue());
-            assertEquals("test-journey-id", govukSigninJourneyIdCaptor.getValue());
+        assertEquals(TEST_MSG_EMAIL, emailCaptor.getValue());
+        assertEquals(emailCheckResultStatus, statusCaptor.getValue());
+        assertEquals(TEST_MSG_TIME_TO_EXIST, timeToExistCaptor.getValue());
+        assertEquals(TEST_MSG_REF_NUMBER, referenceNumberCaptor.getValue());
+        assertEquals("test-journey-id", govukSigninJourneyIdCaptor.getValue());
 
-            var capturedEmailCheckResponse = emailCheckResponseCaptor.getValue();
-            assertNotNull(capturedEmailCheckResponse);
+        var capturedEmailCheckResponse = emailCheckResponseCaptor.getValue();
+        assertNotNull(capturedEmailCheckResponse);
 
-            var extensions = capturedEmailCheckResponse.extensions().getAsJsonObject();
-            assertEquals("testValue1", extensions.get("extensionsTestString").getAsString());
-            assertEquals(123, extensions.get("extensionsTestNumber").getAsNumber().intValue());
-            assertEquals(true, extensions.get("extensionsTestBoolean").getAsBoolean());
+        var extensions = capturedEmailCheckResponse.extensions().getAsJsonObject();
+        assertEquals("testValue1", extensions.get("extensionsTestString").getAsString());
+        assertEquals(123, extensions.get("extensionsTestNumber").getAsNumber().intValue());
+        assertEquals(true, extensions.get("extensionsTestBoolean").getAsBoolean());
 
-            var testObject = extensions.get("extensionsTestObject").getAsJsonObject();
-            assertEquals(
-                    "testNestedValue", testObject.get("extensionsTestNestedString").getAsString());
-            assertEquals(
-                    456, testObject.get("extensionsTestNestedNumber").getAsNumber().intValue());
+        var testObject = extensions.get("extensionsTestObject").getAsJsonObject();
+        assertEquals("testNestedValue", testObject.get("extensionsTestNestedString").getAsString());
+        assertEquals(456, testObject.get("extensionsTestNestedNumber").getAsNumber().intValue());
 
-            var testChildObject = testObject.get("extensionsTestChildObject").getAsJsonObject();
-            assertEquals(
-                    "testDeepValue", testChildObject.get("extensionsTestDeepString").getAsString());
-            assertEquals(false, testChildObject.get("extensionsTestDeepBoolean").getAsBoolean());
+        var testChildObject = testObject.get("extensionsTestChildObject").getAsJsonObject();
+        assertEquals(
+                "testDeepValue", testChildObject.get("extensionsTestDeepString").getAsString());
+        assertEquals(false, testChildObject.get("extensionsTestDeepBoolean").getAsBoolean());
 
-            var restricted = capturedEmailCheckResponse.restricted().getAsJsonObject();
-            assertEquals("testValue2", restricted.get("restrictedTestString").getAsString());
+        var restricted = capturedEmailCheckResponse.restricted().getAsJsonObject();
+        assertEquals("testValue2", restricted.get("restrictedTestString").getAsString());
 
-            verify(cloudWatchMock).logEmailCheckDuration(REQUEST_DURATION);
-        }
+        verify(cloudWatchMock).logEmailCheckDuration(REQUEST_DURATION);
     }
 
     @Test


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
