### PR TITLE
ATO-2687: Point stub domains correctly

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2906,7 +2906,14 @@ Resources:
                 ]
           AUTHENTICATION_BACKEND_URI: !If
             - UseAuthStub
-            - "https://authstub.oidc.authdev3.dev.account.gov.uk/"
+            - !Sub
+              - https://authstub.${OidcDomain}/
+              - OidcDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    oidcDomainName,
+                  ]
             - !Sub
               - https://${AuthExternalApiId}-${VpcId}.execute-api.eu-west-2.amazonaws.com/${AuthEnvironment}/
               - AuthExternalApiId:
@@ -2966,12 +2973,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_AUTHORISATION_CALLBACK_URI: !Sub
             - https://oidc.${ServiceDomain}/ipv-callback
@@ -2993,12 +3000,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}/authorize
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}/authorize
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchIPVTokenSigningKmsKeyAlias
           IPV_JWKS_URL: !If
@@ -3012,12 +3019,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}/.well-known/jwks.json
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}/.well-known/jwks.json
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           ORCH_CLIENT_ID: orchestrationAuth
           AUTH_SIGNING_KEY_ALIAS: !Ref OrchAuthSigningKmsKeyAlias
@@ -3033,7 +3040,14 @@ Resources:
                 ]
           AUTH_FRONTEND_BASE_URL: !If
             - UseAuthStub
-            - "https://authstub.oidc.authdev3.dev.account.gov.uk/"
+            - !Sub
+              - https://authstub.${OidcDomain}/
+              - OidcDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    oidcDomainName,
+                  ]
             - !Sub
               - https://signin.${ServiceDomain}/
               - ServiceDomain:
@@ -3926,7 +3940,14 @@ Resources:
                 ]
           AUTH_FRONTEND_BASE_URL: !If
             - UseAuthStub
-            - "https://authstub.oidc.authdev3.dev.account.gov.uk/"
+            - !Sub
+              - https://authstub.${OidcDomain}/
+              - OidcDomain:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    oidcDomainName,
+                  ]
             - !Sub
               - https://signin.${ServiceDomain}/
               - ServiceDomain:
@@ -5077,12 +5098,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_AUTHORISATION_CALLBACK_URI: !If
             - IpvExists
@@ -5095,12 +5116,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}/ipv-callback
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}/ipv-callback
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_AUTHORISATION_CLIENT_ID: authOrchestrator
           IPV_AUTHORISATION_URI: !If
@@ -5114,12 +5135,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}/authorize
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}/authorize
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_BACKEND_URI: !If
             - IpvExists
@@ -5132,12 +5153,12 @@ Resources:
                     serviceDomain,
                   ]
             - !Sub
-              - https://ipvstub.oidc.${ServiceDomain}
-              - ServiceDomain:
+              - https://ipvstub.${OidcDomain}
+              - OidcDomain:
                   !FindInMap [
                     EnvironmentConfiguration,
                     !Ref Environment,
-                    serviceDomain,
+                    oidcDomainName,
                   ]
           IPV_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchIPVTokenSigningKmsKeyAlias
           IPV_JWKS_URL: !If


### PR DESCRIPTION
### Wider context of change

Now that the oidc hosted zone is in our accounts, we can move our stub to the oidc domain, instead of using the authdev3 subdomain.

### What’s changed

- Points the stub domain as `ipvstub.oidc.dev.account.gov.uk` and `authstub.oidc.dev.account.gov.uk` in dev

### Manual testing

- Deployed alongside https://github.com/govuk-one-login/orch-stubs/pull/589 and ran through an ipv stub journey in dev

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
