### PR TITLE
ATO-2829: Bump pipeline to v2.116.0

### DIFF
--- a/ci/stack-orchestration/deploy-build.sh
+++ b/ci/stack-orchestration/deploy-build.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
 VPC_STACK_VERSION="v2.14.3"
-SECURE_PIPELINE_STACK_VERSION="v2.105.0"
+SECURE_PIPELINE_STACK_VERSION="v2.116.0"
 GITHUB_IDENTITY_STACK_VERSION="v1.1.1"
 SIGNER_STACK_VERSION="v1.0.7"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"

--- a/ci/stack-orchestration/deploy-dev.sh
+++ b/ci/stack-orchestration/deploy-dev.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
 VPC_STACK_VERSION="v2.14.3"
-SECURE_PIPELINE_STACK_VERSION="v2.105.0"
+SECURE_PIPELINE_STACK_VERSION="v2.116.0"
 GITHUB_IDENTITY_STACK_VERSION="v1.1.1"
 SIGNER_STACK_VERSION="v1.0.8"
 CLOUDWATCH_ALARM_STACK_VERSION="v0.0.10"

--- a/ci/stack-orchestration/deploy-integration.sh
+++ b/ci/stack-orchestration/deploy-integration.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
 VPC_STACK_VERSION="v2.14.3"
-SECURE_PIPELINE_STACK_VERSION="v2.105.0"
+SECURE_PIPELINE_STACK_VERSION="v2.116.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 

--- a/ci/stack-orchestration/deploy-production.sh
+++ b/ci/stack-orchestration/deploy-production.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
 VPC_STACK_VERSION="v2.14.3"
-SECURE_PIPELINE_STACK_VERSION="v2.105.0"
+SECURE_PIPELINE_STACK_VERSION="v2.116.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 

--- a/ci/stack-orchestration/deploy-staging.sh
+++ b/ci/stack-orchestration/deploy-staging.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
 VPC_STACK_VERSION="v2.14.3"
-SECURE_PIPELINE_STACK_VERSION="v2.105.0"
+SECURE_PIPELINE_STACK_VERSION="v2.116.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 CLOUDWATCH_ALARM_STACK_VERSION="v0.0.10"


### PR DESCRIPTION
### Wider context of change

Github introduced a new feature to the OIDC token flow, called immutable subject claims. This means that the "sub" claim in the ID token issued now contains additional information such as Org ID and Repo Id instead of just the repo and branch info.[1]

As we plan to fork this repo, this will create a new repo which has this feature enforced by default. So we will need to bump the pipeline version to ensure we are on a version that supports this, which for the dev platform pipeline is v2.116.0[2]

[1] - https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/
[2] - https://github.com/govuk-one-login/devplatform-deploy/releases/tag/sam-deploy-pipeline%2Fv2.116.0

### What’s changed

- Bumps all of the sam deploy pipelines to  v2.116.0

### Manual testing

- Deployed to dev and ran the deployment script `./deploy-dev -p` and then deployed via the github action 
- This is deployed to all envs, so this just documents the current state of our infra

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
