### PR TITLE
AUT-5693: Disable IAD tracker writes on production now export complete

### DIFF
--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -500,7 +500,7 @@ Mappings:
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "7"
       inactiveAccountExportMaxInvocations: "150"
-      inactiveAccountExportTrackerWriteEnabled: "true"
+      inactiveAccountExportTrackerWriteEnabled: "false"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -499,7 +499,7 @@ Mappings:
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:026991849909:key/5489c67b-2c14-4b76-b6a3-a25148b14311
       inactiveAccountExportTableName: "inactive_account_tracker_store"
       inactiveAccountExportBatchWriteMaxRetries: "7"
-      inactiveAccountExportMaxInvocations: "150"
+      inactiveAccountExportMaxInvocations: "0"
       inactiveAccountExportTrackerWriteEnabled: "false"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#8809

Export has been completed, reverting to prevent further writes (without the flag being changed again), allowing the home-team to mutate the data we wrote