### PR TITLE
AUT-5614: Update last signed in value when auth code issuance

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -133,6 +133,9 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
 
             var state = State.parse(authCodeRequest.state());
             var redirectUri = URI.create(authCodeRequest.redirectUri());
+
+            authenticationService.updateLastSignedIn(userProfile.get().getEmail());
+
             var authorizationResponse =
                     new AuthorizationSuccessResponse(
                             redirectUri, authorisationCode, null, state, null);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -147,8 +147,7 @@ class AuthenticationAuthCodeHandlerTest {
         @Test
         void shouldReturn200AndSaveNewAuthCodeRequest() throws URISyntaxException {
             when(configurationService.getAuthCodeExpiry()).thenReturn(Long.valueOf(12));
-            var userProfile = new UserProfile();
-            userProfile.setSubjectID(TEST_SUBJECT_ID);
+            var userProfile = new UserProfile().withSubjectID(TEST_SUBJECT_ID).withEmail(EMAIL);
             when(authenticationService.getUserProfileFromEmail(CommonTestVariables.EMAIL))
                     .thenReturn(Optional.of(userProfile));
             var event = validAuthCodeRequest();
@@ -175,6 +174,7 @@ class AuthenticationAuthCodeHandlerTest {
             assertTrue(uri.getQuery().contains(TEST_STATE));
             assertFalse(uri.getQuery().contains("random_query_parameter"));
 
+            verify(authenticationService, times(1)).updateLastSignedIn(EMAIL);
             verify(cloudwatchMetricsService)
                     .incrementCounter(
                             CloudwatchMetrics.AUTH_CODE_ISSUED,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -21,6 +22,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -1011,6 +1013,21 @@ class DynamoServiceIntegrationTest {
             assertThat(
                     updatedUserProfile.getLastSkippedAddingPasskey(),
                     equalTo(fixedDateTime.toString()));
+        }
+    }
+
+    @Test
+    void shouldSetLastSignedInOnUserProfile() {
+        userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+        Instant fixedInstant = Instant.parse("2026-01-01T00:00:00Z");
+        try (MockedStatic<Instant> mockedInstant =
+                Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+
+            dynamoService.updateLastSignedIn(TEST_EMAIL);
+
+            UserProfile updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+            assertEquals(fixedInstant.toString(), updatedUserProfile.getLastSignedIn());
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -27,6 +27,8 @@ public interface AuthenticationService {
 
     void updatePhoneNumber(String email, String profileInformation);
 
+    void updateLastSignedIn(String email);
+
     /**
      * Deprecated - use getUserProfileByEmailMaybe instead. Can't literally deprecate it, because
      * -Werror will complain.

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -178,6 +179,14 @@ public class DynamoService implements AuthenticationService {
                                         .partitionValue(email.toLowerCase(Locale.ROOT))
                                         .build())
                         .withPhoneNumber(formattedPhoneNumber));
+    }
+
+    @Override
+    public void updateLastSignedIn(String email) {
+        var key = Key.builder().partitionValue(email.toLowerCase(Locale.ROOT)).build();
+        var userProfile = dynamoUserProfileTable.getItem(key);
+        userProfile.withLastSignedIn(Instant.now().toString());
+        dynamoUserProfileTable.updateItem(userProfile);
     }
 
     @Override


### PR DESCRIPTION
## What

Update the `lastSignedIn` value stored on a user's `UserProfile` when they finish signing in an reach /auth-code

## How to review

1. Code Review
1. Deploy and sign in, seeing your `lastSignedIn` value after hitting /auth-code

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
