### PR TITLE
AUT 5607: Migrate `ManuallyDeleteAccountHandler` and `BulkRemoveAccountHandler` to Call Data API

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -184,7 +184,9 @@ public class AuthorizeHandler
                 List.of(
                         configurationService.getAMCClientId(),
                         configurationService.getHomeClientId(),
-                        configurationService.getInactiveAccountDeletionClientId());
+                        configurationService.getInactiveAccountDeletionClientId(),
+                        configurationService.getManualAccountDeletionClientId(),
+                        configurationService.getBulkAccountDeletionClientId());
         return allowedClientIds.contains(clientId);
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
@@ -54,6 +54,14 @@ public class ConfigurationService implements DynamoConfiguration {
         return System.getenv().getOrDefault("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", "");
     }
 
+    public String getManualAccountDeletionClientId() {
+        return System.getenv().getOrDefault("MANUAL_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
+    public String getBulkAccountDeletionClientId() {
+        return System.getenv().getOrDefault("BULK_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
     public String getAuthToAccountDataApiAudience() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "");
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -144,48 +144,17 @@ class AuthorizeHandlerTest {
                     JsonParser.parseString(new Gson().toJson(result)));
         }
 
-        @Test
-        void authorizeHandlerShouldAllowInactiveAccountDeletionClientId() throws JOSEException {
-            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
-
-            var bearerAccessToken =
-                    createBearerAccessTokenWithExpiry(
-                            expiryDateFiveMinutesFromNow,
-                            ecSigningKey,
-                            AccountDataScope.ACCOUNT_DELETE.getValue(),
-                            INACTIVE_ACCOUNT_DELETION_CLIENT_ID);
-
-            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
-
-            var result = handler.handleRequest(event, context);
-
-            var expectedPolicyDocument =
-                    """
-                            {
-                                "principalId": "%s",
-                                "context": {"scope": "%s"},
-                                "policyDocument": {
-                                    "version": "2012-10-17",
-                                    "statement": [{
-                                        "action": "execute-api:Invoke",
-                                        "effect": "Allow",
-                                        "resource": ["%s"]
-                                    }]
-                                }
-                            }
-                            """
-                            .formatted(
-                                    SUBJECT,
-                                    AccountDataScope.ACCOUNT_DELETE.getValue(),
-                                    METHOD_ARN);
-
-            assertEquals(
-                    JsonParser.parseString(expectedPolicyDocument),
-                    JsonParser.parseString(new Gson().toJson(result)));
+        static Stream<Arguments> deletionClientIds() {
+            return Stream.of(
+                    Arguments.of(INACTIVE_ACCOUNT_DELETION_CLIENT_ID),
+                    Arguments.of(MANUAL_ACCOUNT_DELETION_CLIENT_ID),
+                    Arguments.of(BULK_ACCOUNT_DELETION_CLIENT_ID));
         }
 
-        @Test
-        void authorizeHandlerShouldAllowManualAccountDeletionClientId() throws JOSEException {
+        @ParameterizedTest
+        @MethodSource("deletionClientIds")
+        void authorizeHandlerShouldAllowAccountDeletionClientIds(String clientId)
+                throws JOSEException {
             var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
@@ -193,47 +162,7 @@ class AuthorizeHandlerTest {
                             expiryDateFiveMinutesFromNow,
                             ecSigningKey,
                             AccountDataScope.ACCOUNT_DELETE.getValue(),
-                            MANUAL_ACCOUNT_DELETION_CLIENT_ID);
-
-            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
-
-            var result = handler.handleRequest(event, context);
-
-            var expectedPolicyDocument =
-                    """
-                            {
-                                "principalId": "%s",
-                                "context": {"scope": "%s"},
-                                "policyDocument": {
-                                    "version": "2012-10-17",
-                                    "statement": [{
-                                        "action": "execute-api:Invoke",
-                                        "effect": "Allow",
-                                        "resource": ["%s"]
-                                    }]
-                                }
-                            }
-                            """
-                            .formatted(
-                                    SUBJECT,
-                                    AccountDataScope.ACCOUNT_DELETE.getValue(),
-                                    METHOD_ARN);
-
-            assertEquals(
-                    JsonParser.parseString(expectedPolicyDocument),
-                    JsonParser.parseString(new Gson().toJson(result)));
-        }
-
-        @Test
-        void authorizeHandlerShouldAllowBulkAccountDeletionClientId() throws JOSEException {
-            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
-
-            var bearerAccessToken =
-                    createBearerAccessTokenWithExpiry(
-                            expiryDateFiveMinutesFromNow,
-                            ecSigningKey,
-                            AccountDataScope.ACCOUNT_DELETE.getValue(),
-                            BULK_ACCOUNT_DELETION_CLIENT_ID);
+                            clientId);
 
             event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -60,6 +60,8 @@ class AuthorizeHandlerTest {
     private static final String CLIENT_ID = "some-client-id";
     private static final String HOME_CLIENT_ID = "home-client-id";
     private static final String INACTIVE_ACCOUNT_DELETION_CLIENT_ID = "inactive-account-deletion";
+    private static final String MANUAL_ACCOUNT_DELETION_CLIENT_ID = "manual-account-deletion";
+    private static final String BULK_ACCOUNT_DELETION_CLIENT_ID = "bulk-account-deletion";
 
     private static ECKey ecSigningKey;
     private APIGatewayCustomAuthorizerEvent event;
@@ -81,6 +83,10 @@ class AuthorizeHandlerTest {
         when(configurationService.getHomeClientId()).thenReturn(HOME_CLIENT_ID);
         when(configurationService.getInactiveAccountDeletionClientId())
                 .thenReturn(INACTIVE_ACCOUNT_DELETION_CLIENT_ID);
+        when(configurationService.getManualAccountDeletionClientId())
+                .thenReturn(MANUAL_ACCOUNT_DELETION_CLIENT_ID);
+        when(configurationService.getBulkAccountDeletionClientId())
+                .thenReturn(BULK_ACCOUNT_DELETION_CLIENT_ID);
     }
 
     @AfterEach
@@ -148,6 +154,86 @@ class AuthorizeHandlerTest {
                             ecSigningKey,
                             AccountDataScope.ACCOUNT_DELETE.getValue(),
                             INACTIVE_ACCOUNT_DELETION_CLIENT_ID);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            var result = handler.handleRequest(event, context);
+
+            var expectedPolicyDocument =
+                    """
+                            {
+                                "principalId": "%s",
+                                "context": {"scope": "%s"},
+                                "policyDocument": {
+                                    "version": "2012-10-17",
+                                    "statement": [{
+                                        "action": "execute-api:Invoke",
+                                        "effect": "Allow",
+                                        "resource": ["%s"]
+                                    }]
+                                }
+                            }
+                            """
+                            .formatted(
+                                    SUBJECT,
+                                    AccountDataScope.ACCOUNT_DELETE.getValue(),
+                                    METHOD_ARN);
+
+            assertEquals(
+                    JsonParser.parseString(expectedPolicyDocument),
+                    JsonParser.parseString(new Gson().toJson(result)));
+        }
+
+        @Test
+        void authorizeHandlerShouldAllowManualAccountDeletionClientId() throws JOSEException {
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow,
+                            ecSigningKey,
+                            AccountDataScope.ACCOUNT_DELETE.getValue(),
+                            MANUAL_ACCOUNT_DELETION_CLIENT_ID);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            var result = handler.handleRequest(event, context);
+
+            var expectedPolicyDocument =
+                    """
+                            {
+                                "principalId": "%s",
+                                "context": {"scope": "%s"},
+                                "policyDocument": {
+                                    "version": "2012-10-17",
+                                    "statement": [{
+                                        "action": "execute-api:Invoke",
+                                        "effect": "Allow",
+                                        "resource": ["%s"]
+                                    }]
+                                }
+                            }
+                            """
+                            .formatted(
+                                    SUBJECT,
+                                    AccountDataScope.ACCOUNT_DELETE.getValue(),
+                                    METHOD_ARN);
+
+            assertEquals(
+                    JsonParser.parseString(expectedPolicyDocument),
+                    JsonParser.parseString(new Gson().toJson(result)));
+        }
+
+        @Test
+        void authorizeHandlerShouldAllowBulkAccountDeletionClientId() throws JOSEException {
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow,
+                            ecSigningKey,
+                            AccountDataScope.ACCOUNT_DELETE.getValue(),
+                            BULK_ACCOUNT_DELETION_CLIENT_ID);
 
             event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
@@ -74,6 +74,18 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getManualAccountDeletionClientIdShouldDefaultToEmptyString() {
+        environment.set("MANUAL_ACCOUNT_DELETION_CLIENT_ID", null);
+        assertEquals("", configurationService.getManualAccountDeletionClientId());
+    }
+
+    @Test
+    void getBulkAccountDeletionClientIdShouldDefaultToEmptyString() {
+        environment.set("BULK_ACCOUNT_DELETION_CLIENT_ID", null);
+        assertEquals("", configurationService.getBulkAccountDeletionClientId());
+    }
+
+    @Test
     void getAuthToAccountDataApiAudienceShouldDefaultToEmptyString() {
         environment.set("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", null);
         assertEquals("", configurationService.getAuthToAccountDataApiAudience());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
@@ -11,12 +11,14 @@ import uk.gov.di.accountmanagement.entity.BulkUserDeleteResponse;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.accountmanagement.exceptions.BulkRemoveAccountException;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.AccountDeletionTokenService;
 import uk.gov.di.accountmanagement.services.AwsSnsClient;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -65,18 +67,23 @@ public class BulkRemoveAccountHandler
                         configurationService.getSnsEndpointUri());
         var structuredAuditService = new StructuredAuditService(configurationService);
         var dynamoDeleteService = new DynamoDeleteService(configurationService);
+        var accountDataApiService = new AccountDataApiService(configurationService);
         var accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         emailSqsClient,
                         structuredAuditService,
                         configurationService,
-                        dynamoDeleteService);
+                        dynamoDeleteService,
+                        accountDataApiService);
+        var accountDeletionTokenService = new AccountDeletionTokenService(configurationService);
         this.manualAccountDeletionService =
                 new ManualAccountDeletionService(
                         accountDeletionService,
                         legacyAccountDeletionSnsClient,
-                        configurationService);
+                        configurationService,
+                        accountDeletionTokenService,
+                        configurationService.getBulkAccountDeletionClientId());
     }
 
     public BulkRemoveAccountHandler() {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -4,11 +4,13 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.AccountDeletionTokenService;
 import uk.gov.di.accountmanagement.services.AwsSnsClient;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -41,18 +43,23 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
                         configurationService.getLegacyAccountDeletionTopicArn());
         var structuredAuditService = new StructuredAuditService(configurationService);
         var dynamoDeleteService = new DynamoDeleteService(configurationService);
+        var accountDataApiService = new AccountDataApiService(configurationService);
         var accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         emailSqsClient,
                         structuredAuditService,
                         configurationService,
-                        dynamoDeleteService);
+                        dynamoDeleteService,
+                        accountDataApiService);
+        var accountDeletionTokenService = new AccountDeletionTokenService(configurationService);
         this.manualAccountDeletionService =
                 new ManualAccountDeletionService(
                         accountDeletionService,
                         legacyAccountDeletionSnsClient,
-                        configurationService);
+                        configurationService,
+                        accountDeletionTokenService,
+                        configurationService.getManualAccountDeletionClientId());
     }
 
     public ManuallyDeleteAccountHandler() {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionTokenService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionTokenService.java
@@ -1,0 +1,63 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class AccountDeletionTokenService {
+
+    private static final Logger LOG = LogManager.getLogger(AccountDeletionTokenService.class);
+
+    private static final long ACCESS_TOKEN_LIFETIME_MINUTES = 5L;
+
+    private final ConfigurationService configurationService;
+    private final AccessTokenConstructorService accessTokenConstructorService;
+    private final NowHelper.NowClock nowClock;
+
+    public AccountDeletionTokenService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.accessTokenConstructorService =
+                new AccessTokenConstructorService(configurationService);
+        this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
+    }
+
+    public AccountDeletionTokenService(
+            ConfigurationService configurationService,
+            AccessTokenConstructorService accessTokenConstructorService,
+            NowHelper.NowClock nowClock) {
+        this.configurationService = configurationService;
+        this.accessTokenConstructorService = accessTokenConstructorService;
+        this.nowClock = nowClock;
+    }
+
+    public Result<JwtFailureReason, BearerAccessToken> createAccountDataApiAccessToken(
+            String publicSubjectId, String clientId) {
+        return accessTokenConstructorService
+                .createSignedAccessToken(
+                        publicSubjectId,
+                        List.of(AccountDataScope.ACCOUNT_DELETE),
+                        nowClock.now(),
+                        nowClock.nowPlus(ACCESS_TOKEN_LIFETIME_MINUTES, ChronoUnit.MINUTES),
+                        configurationService.getAuthToAccountDataApiAudience(),
+                        configurationService.getAuthIssuerClaim(),
+                        clientId,
+                        configurationService.getAuthToAccountDataSigningKey())
+                .mapFailure(
+                        failure -> {
+                            LOG.error(
+                                    "Error creating account-delete access token. Error: {}",
+                                    failure);
+                            return failure;
+                        });
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -1,11 +1,14 @@
 package uk.gov.di.accountmanagement.services;
 
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.accountmanagement.entity.LegacyAccountDeletionMessage;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -92,15 +95,18 @@ public class ManualAccountDeletionService {
                 || !configurationService.isAccountDeletionDataApiEnabled()) {
             return Optional.empty();
         }
-        var tokenResult =
+        Result<JwtFailureReason, BearerAccessToken> tokenResult =
                 accountDeletionTokenService.createAccountDataApiAccessToken(
                         userProfile.getPublicSubjectID(), clientId);
-        if (tokenResult.isFailure()) {
-            throw new RuntimeException(
-                    "Failed to mint account-delete token for publicSubjectId: "
-                            + userProfile.getPublicSubjectID());
-        }
-        return Optional.of(tokenResult.getSuccess().getValue());
+        return tokenResult.fold(
+                failure -> {
+                    throw new RuntimeException(
+                            "Failed to mint account-delete token for publicSubjectId: "
+                                    + userProfile.getPublicSubjectID()
+                                    + ". Reason: "
+                                    + failure);
+                },
+                token -> Optional.of(token.getValue()));
     }
 
     private String getCommonSubjectId(UserProfile userProfile) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -88,7 +88,8 @@ public class ManualAccountDeletionService {
     }
 
     private Optional<String> getAccountDataApiToken(UserProfile userProfile) {
-        if (accountDeletionTokenService == null) {
+        if (accountDeletionTokenService == null
+                || !configurationService.isAccountDeletionDataApiEnabled()) {
             return Optional.empty();
         }
         var tokenResult =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -8,7 +8,6 @@ import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.accountmanagement.entity.LegacyAccountDeletionMessage;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -20,15 +19,33 @@ public class ManualAccountDeletionService {
     private final AccountDeletionService accountDeletionService;
     private final AwsSnsClient legacyAccountDeletionSnsClient;
     private final ConfigurationService configurationService;
+    private final AccountDeletionTokenService accountDeletionTokenService;
+    private final String clientId;
     private static final Logger LOG = LogManager.getLogger(ManualAccountDeletionService.class);
 
     public ManualAccountDeletionService(
             AccountDeletionService accountDeletionService,
             AwsSnsClient legacyAccountDeletionSnsClient,
             ConfigurationService configurationService) {
+        this(
+                accountDeletionService,
+                legacyAccountDeletionSnsClient,
+                configurationService,
+                null,
+                null);
+    }
+
+    public ManualAccountDeletionService(
+            AccountDeletionService accountDeletionService,
+            AwsSnsClient legacyAccountDeletionSnsClient,
+            ConfigurationService configurationService,
+            AccountDeletionTokenService accountDeletionTokenService,
+            String clientId) {
         this.accountDeletionService = accountDeletionService;
         this.legacyAccountDeletionSnsClient = legacyAccountDeletionSnsClient;
         this.configurationService = configurationService;
+        this.accountDeletionTokenService = accountDeletionTokenService;
+        this.clientId = clientId;
     }
 
     public DeletedAccountIdentifiers manuallyDeleteAccount(UserProfile userProfile) {
@@ -55,19 +72,34 @@ public class ManualAccountDeletionService {
                     userProfile,
                     AuditService.UNKNOWN,
                     accountDeletionReason,
-                    sendNotification);
-            var deletedAccountPayload =
-                    SerializationService.getInstance()
-                            .writeValueAsString(legacyAccountDeletionMessage);
-            legacyAccountDeletionSnsClient.publish(deletedAccountPayload);
-            return accountIdentifiers;
-        } catch (Json.JsonException e) {
+                    sendNotification,
+                    getAccountDataApiToken(userProfile));
+        } catch (RuntimeException e) {
             LOG.error(
                     "Error while deleting account: {}. Identifiers: {}",
                     e.getMessage(),
                     accountIdentifiers);
-            throw new RuntimeException(e);
+            throw e;
         }
+        var deletedAccountPayload =
+                SerializationService.getInstance().writeValueAsString(legacyAccountDeletionMessage);
+        legacyAccountDeletionSnsClient.publish(deletedAccountPayload);
+        return accountIdentifiers;
+    }
+
+    private Optional<String> getAccountDataApiToken(UserProfile userProfile) {
+        if (accountDeletionTokenService == null) {
+            return Optional.empty();
+        }
+        var tokenResult =
+                accountDeletionTokenService.createAccountDataApiAccessToken(
+                        userProfile.getPublicSubjectID(), clientId);
+        if (tokenResult.isFailure()) {
+            throw new RuntimeException(
+                    "Failed to mint account-delete token for publicSubjectId: "
+                            + userProfile.getPublicSubjectID());
+        }
+        return Optional.of(tokenResult.getSuccess().getValue());
     }
 
     private String getCommonSubjectId(UserProfile userProfile) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionTokenServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionTokenServiceTest.java
@@ -1,0 +1,92 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AccountDeletionTokenServiceTest {
+
+    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:abc123";
+    private static final String AUDIENCE = "https://account.test.account.gov.uk";
+    private static final String ISSUER = "https://signin.test.account.gov.uk";
+    private static final String CLIENT_ID = "bulk-account-deletion";
+    private static final String SIGNING_KEY = "test-signing-key-id";
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccessTokenConstructorService accessTokenConstructorService =
+            mock(AccessTokenConstructorService.class);
+    private final Clock fixedClock =
+            Clock.fixed(Instant.parse("2026-08-17T12:00:00Z"), ZoneId.of("UTC"));
+    private final NowHelper.NowClock nowClock = new NowHelper.NowClock(fixedClock);
+
+    private AccountDeletionTokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getAuthToAccountDataApiAudience()).thenReturn(AUDIENCE);
+        when(configurationService.getAuthIssuerClaim()).thenReturn(ISSUER);
+        when(configurationService.getAuthToAccountDataSigningKey()).thenReturn(SIGNING_KEY);
+
+        tokenService =
+                new AccountDeletionTokenService(
+                        configurationService, accessTokenConstructorService, nowClock);
+    }
+
+    @Test
+    void shouldCreateAccessTokenWithCorrectParameters() {
+        var expectedToken = new BearerAccessToken("test-token-value");
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Result.success(expectedToken));
+
+        var result = tokenService.createAccountDataApiAccessToken(PUBLIC_SUBJECT_ID, CLIENT_ID);
+
+        assertTrue(result.isSuccess());
+        assertEquals(expectedToken, result.getSuccess());
+
+        var expectedIssueTime = Date.from(fixedClock.instant());
+
+        verify(accessTokenConstructorService)
+                .createSignedAccessToken(
+                        eq(PUBLIC_SUBJECT_ID),
+                        eq(List.of(AccountDataScope.ACCOUNT_DELETE)),
+                        eq(expectedIssueTime),
+                        any(Date.class),
+                        eq(AUDIENCE),
+                        eq(ISSUER),
+                        eq(CLIENT_ID),
+                        eq(SIGNING_KEY));
+    }
+
+    @Test
+    void shouldReturnFailureWhenTokenCreationFails() {
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+        var result = tokenService.createAccountDataApiAccessToken(PUBLIC_SUBJECT_ID, CLIENT_ID);
+
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
@@ -164,6 +165,7 @@ class ManualAccountDeletionServiceTest {
         @Test
         void shouldMintTokenAndPassItToRemoveAccount() throws Json.JsonException {
             // given
+            when(configurationService.isAccountDeletionDataApiEnabled()).thenReturn(true);
             when(accountDeletionTokenService.createAccountDataApiAccessToken(
                             PUBLIC_SUBJECT_ID, CLIENT_ID))
                     .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
@@ -183,8 +185,29 @@ class ManualAccountDeletionServiceTest {
         }
 
         @Test
+        void shouldFallBackToDynamoWhenFeatureFlagIsOff() throws Json.JsonException {
+            // given
+            when(configurationService.isAccountDeletionDataApiEnabled()).thenReturn(false);
+
+            // when
+            underTestWithMinter.manuallyDeleteAccount(USER_PROFILE);
+
+            // then
+            verify(accountDeletionService)
+                    .removeAccount(
+                            Optional.empty(),
+                            USER_PROFILE,
+                            AuditService.UNKNOWN,
+                            AccountDeletionReason.SUPPORT_INITIATED,
+                            true,
+                            Optional.empty());
+            verifyNoInteractions(accountDeletionTokenService);
+        }
+
+        @Test
         void shouldThrowIfTokenMintingFails() {
             // given
+            when(configurationService.isAccountDeletionDataApiEnabled()).thenReturn(true);
             when(accountDeletionTokenService.createAccountDataApiAccessToken(
                             PUBLIC_SUBJECT_ID, CLIENT_ID))
                     .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -1,31 +1,41 @@
 package uk.gov.di.accountmanagement.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
+import uk.gov.di.authentication.shared.entity.JwtFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class ManualAccountDeletionServiceTest {
     private final AccountDeletionService accountDeletionService =
@@ -45,6 +55,10 @@ class ManualAccountDeletionServiceTest {
             ByteBuffer.wrap(
                     "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw="
                             .getBytes(StandardCharsets.UTF_8));
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(ManualAccountDeletionService.class);
 
     @BeforeEach
     void setUp() {
@@ -68,7 +82,8 @@ class ManualAccountDeletionServiceTest {
                         USER_PROFILE,
                         AuditService.UNKNOWN,
                         AccountDeletionReason.SUPPORT_INITIATED,
-                        true);
+                        true,
+                        Optional.empty());
     }
 
     @Test
@@ -120,13 +135,69 @@ class ManualAccountDeletionServiceTest {
     }
 
     @Test
-    void shouldThrowExceptionIfAccountDeletionFails() throws Json.JsonException {
+    void shouldThrowExceptionIfAccountDeletionFails() {
         // given
-        doThrow(new Json.JsonException("error"))
+        doThrow(new RuntimeException("error"))
                 .when(accountDeletionService)
-                .removeAccount(any(), any(), any(), any(), anyBoolean());
+                .removeAccount(any(), any(), any(), any(), anyBoolean(), any());
 
         // then
         assertThrows(RuntimeException.class, () -> underTest.manuallyDeleteAccount(USER_PROFILE));
+        assertThat(
+                logging.events(), hasItem(withMessageContaining("Error while deleting account")));
+    }
+
+    @Nested
+    class WithTokenMinting {
+        private final AccountDeletionTokenService accountDeletionTokenService =
+                mock(AccountDeletionTokenService.class);
+        private static final String CLIENT_ID = "manual-account-deletion";
+        private static final String TOKEN_VALUE = "test-bearer-token";
+        private final ManualAccountDeletionService underTestWithMinter =
+                new ManualAccountDeletionService(
+                        accountDeletionService,
+                        legacyAccountDeletionSnsClient,
+                        configurationService,
+                        accountDeletionTokenService,
+                        CLIENT_ID);
+
+        @Test
+        void shouldMintTokenAndPassItToRemoveAccount() throws Json.JsonException {
+            // given
+            when(accountDeletionTokenService.createAccountDataApiAccessToken(
+                            PUBLIC_SUBJECT_ID, CLIENT_ID))
+                    .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
+
+            // when
+            underTestWithMinter.manuallyDeleteAccount(USER_PROFILE);
+
+            // then
+            verify(accountDeletionService)
+                    .removeAccount(
+                            Optional.empty(),
+                            USER_PROFILE,
+                            AuditService.UNKNOWN,
+                            AccountDeletionReason.SUPPORT_INITIATED,
+                            true,
+                            Optional.of(TOKEN_VALUE));
+        }
+
+        @Test
+        void shouldThrowIfTokenMintingFails() {
+            // given
+            when(accountDeletionTokenService.createAccountDataApiAccessToken(
+                            PUBLIC_SUBJECT_ID, CLIENT_ID))
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+            // then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> underTestWithMinter.manuallyDeleteAccount(USER_PROFILE));
+            verify(accountDeletionService, never())
+                    .removeAccount(any(), any(), any(), any(), anyBoolean(), any());
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Error while deleting account")));
+        }
     }
 }

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -47,6 +47,18 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               inactiveAccountDeletionClientId,
             ]
+          MANUAL_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              manualAccountDeletionClientId,
+            ]
+          BULK_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              bulkAccountDeletionClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref AuthorizerFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -121,6 +121,8 @@ Mappings:
       frontendBaseUrl: https://signin.authdev1.dev.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
@@ -131,6 +133,8 @@ Mappings:
       frontendBaseUrl: https://signin.authdev2.dev.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
@@ -141,6 +145,8 @@ Mappings:
       frontendBaseUrl: https://signin.authdev3.dev.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     dev:
       cloudwatchLogRetentionInDays: 1
       IsSplunkEnabled: "No"
@@ -155,6 +161,8 @@ Mappings:
       frontendBaseUrl: https://signin.dev.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     build:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -169,6 +177,8 @@ Mappings:
       frontendBaseUrl: https://signin.build.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     staging:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -184,6 +194,8 @@ Mappings:
       frontendBaseUrl: https://signin.staging.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     integration:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -199,6 +211,8 @@ Mappings:
       frontendBaseUrl: https://signin.integration.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
     production:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -214,6 +228,8 @@ Mappings:
       frontendBaseUrl: https://signin.account.gov.uk
       amcClientId: auth
       inactiveAccountDeletionClientId: inactive-account-deletion
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
   LambdaConfiguration:
     account-delete:
       RunbookLink: "" # TODO: must be populated when runbook is created

--- a/ci/cloudformation/account-management/function/bulk-remove-account.yaml
+++ b/ci/cloudformation/account-management/function/bulk-remove-account.yaml
@@ -69,6 +69,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               bulkAccountDeletionClientId,
             ]
+          ACCOUNT_DELETION_DATA_API_ENABLED:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              accountDeletionDataApiEnabled,
+            ]
           LEGACY_ACCOUNT_DELETION_TOPIC_ARN: !If
             - IsHigherEnv
             - !FindInMap [

--- a/ci/cloudformation/account-management/function/bulk-remove-account.yaml
+++ b/ci/cloudformation/account-management/function/bulk-remove-account.yaml
@@ -32,6 +32,43 @@ Resources:
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${env}-auth-to-account-data-signing-key
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
+          BULK_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              bulkAccountDeletionClientId,
+            ]
           LEGACY_ACCOUNT_DELETION_TOPIC_ARN: !If
             - IsHigherEnv
             - !FindInMap [

--- a/ci/cloudformation/account-management/function/bulk-remove-account.yaml
+++ b/ci/cloudformation/account-management/function/bulk-remove-account.yaml
@@ -82,6 +82,23 @@ Resources:
         LogGroup: !Ref BulkRemoveAccountFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
+        - Version: 2012-10-17
+          Statement:
+            - Sid: AllowKmsSignForAccountDataToken
+              Effect: Allow
+              Action:
+                - kms:Sign
+                - kms:GetPublicKey
+              Resource:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  authToAccountDataSigningKeyArn,
+                ]
         - !Ref AuditSigningKeyLambdaKmsSigningPolicy
         - !Ref DynamoUserReadWriteAccessPolicy
         - !Ref DynamoUserDeleteAccessPolicy

--- a/ci/cloudformation/account-management/function/manually-delete-account.yaml
+++ b/ci/cloudformation/account-management/function/manually-delete-account.yaml
@@ -76,6 +76,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               manualAccountDeletionClientId,
             ]
+          ACCOUNT_DELETION_DATA_API_ENABLED:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              accountDeletionDataApiEnabled,
+            ]
           LEGACY_ACCOUNT_DELETION_TOPIC_ARN: !If
             - IsHigherEnv
             - !FindInMap [

--- a/ci/cloudformation/account-management/function/manually-delete-account.yaml
+++ b/ci/cloudformation/account-management/function/manually-delete-account.yaml
@@ -89,6 +89,23 @@ Resources:
         LogGroup: !Ref ManuallyDeleteAccountFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
+        - Version: 2012-10-17
+          Statement:
+            - Sid: AllowKmsSignForAccountDataToken
+              Effect: Allow
+              Action:
+                - kms:Sign
+                - kms:GetPublicKey
+              Resource:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  authToAccountDataSigningKeyArn,
+                ]
         - !Ref AuditSigningKeyLambdaKmsSigningPolicy
         - !Ref DynamoUserReadWriteAccessPolicy
         - !Ref DynamoUserDeleteAccessPolicy

--- a/ci/cloudformation/account-management/function/manually-delete-account.yaml
+++ b/ci/cloudformation/account-management/function/manually-delete-account.yaml
@@ -39,6 +39,43 @@ Resources:
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${env}-auth-to-account-data-signing-key
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
+          MANUAL_ACCOUNT_DELETION_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              manualAccountDeletionClientId,
+            ]
           LEGACY_ACCOUNT_DELETION_TOPIC_ARN: !If
             - IsHigherEnv
             - !FindInMap [

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -315,6 +315,8 @@ Mappings:
       accountDataApiId: rjlo8fsb55
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/e5a9a634-e113-44c4-8bef-388fb71041a0
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -354,6 +356,8 @@ Mappings:
       accountDataApiId: ez2ro7vca7
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/73405f5d-b60a-4b17-881c-b0f3e26ef03d
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -393,6 +397,8 @@ Mappings:
       accountDataApiId: 5ctgxqnq37
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/20e15b84-6196-4b0a-8f27-632f4b858bd1
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -439,6 +445,8 @@ Mappings:
       accountDataApiId: 0aqzty84lj
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/c0bc7d31-32f4-4f98-addd-170187956d8d
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -487,6 +495,8 @@ Mappings:
       accountDataApiId: ac3znt5m23
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:058264536367:key/9a0c6ef7-ce45-42fe-b55e-48b09f9ff53e
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -536,6 +546,8 @@ Mappings:
       accountDataApiId: 7xgl7lexy4
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:851725205974:key/ecfc81ec-546e-478d-ae04-5ed5d1b375a9
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -586,6 +598,8 @@ Mappings:
       accountDataApiId: hoidt6wujb
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125600642:key/f0e0c444-b70e-4d2f-9d5a-9f0bcf1d6540
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -636,6 +650,8 @@ Mappings:
       accountDataApiId: 0218o1p9tj
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125303002:key/29d156dd-c893-4221-8fe1-f24882e0e401
+      manualAccountDeletionClientId: manual-account-deletion
+      bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -317,6 +317,7 @@ Mappings:
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/e5a9a634-e113-44c4-8bef-388fb71041a0
       manualAccountDeletionClientId: manual-account-deletion
       bulkAccountDeletionClientId: bulk-account-deletion
+      accountDeletionDataApiEnabled: true
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -357,6 +358,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/73405f5d-b60a-4b17-881c-b0f3e26ef03d
       manualAccountDeletionClientId: manual-account-deletion
+      accountDeletionDataApiEnabled: true
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -398,6 +400,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/20e15b84-6196-4b0a-8f27-632f4b858bd1
       manualAccountDeletionClientId: manual-account-deletion
+      accountDeletionDataApiEnabled: true
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -446,6 +449,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:975050272416:key/c0bc7d31-32f4-4f98-addd-170187956d8d
       manualAccountDeletionClientId: manual-account-deletion
+      accountDeletionDataApiEnabled: true
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -496,6 +500,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:058264536367:key/9a0c6ef7-ce45-42fe-b55e-48b09f9ff53e
       manualAccountDeletionClientId: manual-account-deletion
+      accountDeletionDataApiEnabled: true
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -548,6 +553,7 @@ Mappings:
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:851725205974:key/ecfc81ec-546e-478d-ae04-5ed5d1b375a9
       manualAccountDeletionClientId: manual-account-deletion
       bulkAccountDeletionClientId: bulk-account-deletion
+      accountDeletionDataApiEnabled: false
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -599,6 +605,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125600642:key/f0e0c444-b70e-4d2f-9d5a-9f0bcf1d6540
       manualAccountDeletionClientId: manual-account-deletion
+      accountDeletionDataApiEnabled: false
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -652,6 +659,7 @@ Mappings:
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125303002:key/29d156dd-c893-4221-8fe1-f24882e0e401
       manualAccountDeletionClientId: manual-account-deletion
       bulkAccountDeletionClientId: bulk-account-deletion
+      accountDeletionDataApiEnabled: false
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -500,7 +500,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:058264536367:key/9a0c6ef7-ce45-42fe-b55e-48b09f9ff53e
       manualAccountDeletionClientId: manual-account-deletion
-      accountDeletionDataApiEnabled: true
+      accountDeletionDataApiEnabled: false
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -837,6 +837,12 @@ public class ConfigurationService
                 .equals(FEATURE_SWITCH_ON);
     }
 
+    public boolean isAccountDeletionDataApiEnabled() {
+        return System.getenv()
+                .getOrDefault("ACCOUNT_DELETION_DATA_API_ENABLED", FEATURE_SWITCH_OFF)
+                .equals(FEATURE_SWITCH_ON);
+    }
+
     public boolean isBulkAccountDeletionEnabled() {
         return !List.of(INTEGRATION.getValue(), PRODUCTION.getValue()).contains(getEnvironment());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -758,6 +758,14 @@ public class ConfigurationService
         return System.getenv().getOrDefault("INACTIVE_ACCOUNT_DELETION_CLIENT_ID", "");
     }
 
+    public String getManualAccountDeletionClientId() {
+        return System.getenv().getOrDefault("MANUAL_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
+    public String getBulkAccountDeletionClientId() {
+        return System.getenv().getOrDefault("BULK_ACCOUNT_DELETION_CLIENT_ID", "");
+    }
+
     public String getAuthToAccountDataSigningKey() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", "");
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -570,6 +570,16 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getManualAccountDeletionClientIdShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getManualAccountDeletionClientId());
+    }
+
+    @Test
+    void getBulkAccountDeletionClientIdShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getBulkAccountDeletionClientId());
+    }
+
+    @Test
     void getMfaResetCallbackURIShouldDefault() {
         assertEquals(URI.create(""), configurationService.getMfaResetCallbackURI());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -234,6 +234,11 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void isAccountDeletionDataApiEnabledShouldDefaultToFalse() {
+        assertFalse(configurationService.isAccountDeletionDataApiEnabled());
+    }
+
+    @Test
     void getTicfCRILambdaNameShouldDefault() {
         assertEquals("", configurationService.getTicfCRILambdaIdentifier());
     }


### PR DESCRIPTION
## What
  
  Migrates the manual and bulk account deletion lambdas (`ManuallyDeleteAccountHandler`,
  `BulkRemoveAccountHandler`) to call the Data API instead of writing to DynamoDB
  directly, matching how user-initiated deletion already works.
  
  Neither lambda has a user session, so each mints its own short-lived access token
  via a new `AccountDeletionTokenService`, signed with the existing
  auth-to-account-data KMS key. Each lambda uses its own client ID
  (`manual-account-deletion`, `bulk-account-deletion`), added to the Data API
  authoriser's allow list alongside the existing AMC, Home and
  inactive-account-deletion clients.
  
  The token is passed through the existing `removeAccount` call rather than
  bypassing it, so the audit event, legacy SNS publish and (for manual deletion)
  the user notification email are all preserved.
  
  Gated behind `ACCOUNT_DELETION_DATA_API_ENABLED`, on for authdev1, authdev2,
  authdev3, dev and build, off for staging, integration and production pending
  sign-off.

  The existing DynamoDB path is kept in place, since the feature flag's fallback depends on it; 
  removing it is deferred   to the cleanup ticket that also removes the flag, as the ticket specifies.
  
  ## How to review
  
  1. Code review.
  2. Deployed and manually tested on authdev2 for both lambdas (manual delete and
     bulk delete), including the flag toggle. Logs confirm token minting, KMS
     signing, authoriser acceptance and a successful Data API response for both
     client IDs.
  3. Optionally, redeploy to a dev environment and repeat: invoke
     `manually-delete-account-lambda` with a test email, or
     `bulk-remove-account-lambda` with a `BulkUserDeleteRequest` payload, and
     check CloudWatch for `AccountDeletionService` logging
     "Successfully deleted account via Data API".
  
  ## Checklist
  
  - [x] Assessed the impact on active user sessions and confirmed no breaking changes
  - [x] Orch and Auth mutual dependencies have been checked for breaking changes - N/A
  - [x] Stub-orchestration has been updated (or no changes required) - no changes required
  - [x] A UCD review has been performed (or no review required) - no review required, no user-facing or frontend change
  
  ## Related PRs
  
  Builds on #8781 (AUT-5609), which added the `inactive-account-deletion` client
  ID and the `kms:Sign` policy pattern this PR follows for its own two client IDs.
  