### PR TITLE
BAU: Fix local running since Gradle 9 bump

### DIFF
--- a/local-running/Dockerfile
+++ b/local-running/Dockerfile
@@ -18,6 +18,27 @@ COPY auth-external-api ./auth-external-api
 COPY frontend-api ./frontend-api
 COPY audit-events ./audit-events
 COPY account-data-api ./account-data-api
+COPY orchestration-shared ./orchestration-shared
+COPY client-registry-api ./client-registry-api
+COPY deprecation-checker ./deprecation-checker
+COPY interventions-api-stub ./interventions-api-stub
+COPY account-data-api-integration-tests ./account-data-api-integration-tests
+COPY test-services-api ./test-services-api
+COPY utils ./utils
+COPY identity-shared ./identity-shared
+COPY orchestration-shared-test ./orchestration-shared-test
+COPY oidc-api ./oidc-api
+COPY ipv-api ./ipv-api
+COPY account-management-api ./account-management-api
+COPY shared-test ./shared-test
+COPY delivery-receipts-api ./delivery-receipts-api
+COPY ticf-cri-stub ./ticf-cri-stub
+COPY sis-api ./sis-api
+COPY doc-checking-app-api ./doc-checking-app-api
+COPY delivery-receipts-integration-tests ./delivery-receipts-integration-tests
+COPY orchestration-local-running ./orchestration-local-running
+COPY integration-tests ./integration-tests
+COPY account-management-integration-tests ./account-management-integration-tests
 
 RUN --mount=type=cache,target=/root/.gradle ./gradlew :local-running:build --no-daemon
 RUN mkdir untarred && tar -xvf local-running/build/distributions/local-running.tar -C ./untarred


### PR DESCRIPTION
## What

Gradle 9 removed lenient project initialisation. Initialisation is the phase where Gradle maps out the location of, and relationships between, modules to build the project tree.

Before Gradle 9, if an included module was missing from the disk, Gradle would silently spin up an empty virtual module and allow the build to proceed. Because this leniency has been removed, all modules defined in settings.gradle must now physically exist on the filesystem to pass the initialisation phase.

We now copy all modules into the local-running Dockerfile so the full project tree can be successfully mapped. Because the local-running module does not depend on them, these extra modules are not configured or compiled after this step.

Warning here: https://docs.gradle.org/9.6.1/userguide/multi_project_builds.html#include_existing_projects_only:~:text=Starting%20with%20Gradle%209.0.0%2C%20this%20is%20enforced%20strictly%3A%20If%20a%20project%20directory%20is%20missing%20or%20read%2Donly%2C%20the%20build%20will%20fail.%20This%20replaces%20earlier%20behavior%20where%20Gradle%20would%20silently%20allow%20missing%20project%20directories

## How to review

1. Code Review
2. Run local running successfully

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
