### PR TITLE
BAU: Refactor account deletion classes

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -128,13 +128,22 @@ public class RemoveAccountHandler
                             .map(headers -> headers.get("X-ADAPI-AccessToken"))
                             .filter(t -> !t.isEmpty());
 
-            accountDeletionService.removeAccount(
-                    Optional.of(input),
-                    userProfile,
-                    TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
-                    AccountDeletionReason.USER_INITIATED,
-                    true,
-                    token);
+            if (token.isPresent()) {
+                accountDeletionService.removeAccount(
+                        Optional.of(input),
+                        userProfile,
+                        TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
+                        AccountDeletionReason.USER_INITIATED,
+                        true,
+                        token.get());
+            } else {
+                accountDeletionService.removeAccount(
+                        Optional.of(input),
+                        userProfile,
+                        TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
+                        AccountDeletionReason.USER_INITIATED,
+                        true);
+            }
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (UserNotFoundException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -130,7 +130,7 @@ public class RemoveAccountHandler
 
             if (token.isPresent()) {
                 accountDeletionService.removeAccount(
-                        Optional.of(input),
+                        input,
                         userProfile,
                         TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
                         AccountDeletionReason.USER_INITIATED,
@@ -138,7 +138,7 @@ public class RemoveAccountHandler
                         token.get());
             } else {
                 accountDeletionService.removeAccount(
-                        Optional.of(input),
+                        input,
                         userProfile,
                         TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
                         AccountDeletionReason.USER_INITIATED,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.accountmanagement.services;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
@@ -75,9 +76,8 @@ public class AccountDeletionService {
             Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
             String txmaAuditEncoded,
-            AccountDeletionReason reason)
-            throws Json.JsonException {
-        removeAccount(input, userProfile, txmaAuditEncoded, reason, true, Optional.empty());
+            AccountDeletionReason reason) {
+        removeAccount(input, userProfile, txmaAuditEncoded, reason, true);
     }
 
     public void removeAccount(
@@ -85,10 +85,19 @@ public class AccountDeletionService {
             UserProfile userProfile,
             String txmaAuditEncoded,
             AccountDeletionReason reason,
-            boolean sendNotification)
-            throws Json.JsonException {
-        removeAccount(
-                input, userProfile, txmaAuditEncoded, reason, sendNotification, Optional.empty());
+            boolean sendNotification) {
+        var internalCommonSubjectIdentifier = calculateICS(userProfile);
+
+        dynamoDeleteService.deleteAccount(
+                userProfile.getEmail(),
+                internalCommonSubjectIdentifier.getValue(),
+                userProfile.getPublicSubjectID());
+        LOG.info("User account deleted via DynamoDB directly, not via ADAPI");
+
+        if (sendNotification) sendNotifyRequest(userProfile);
+
+        emitAuditEvent(
+                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
     }
 
     public void removeAccount(
@@ -97,41 +106,39 @@ public class AccountDeletionService {
             String txmaAuditEncoded,
             AccountDeletionReason reason,
             boolean sendNotification,
-            Optional<String> accountDataApiToken) {
-        LOG.info("Calculating internal common subject identifier");
-        var internalCommonSubjectIdentifier =
-                ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                        userProfile,
-                        configurationService.getInternalSectorUri(),
-                        authenticationService);
-        LOG.info("Internal common subject identifier: {}", internalCommonSubjectIdentifier);
-        var email = userProfile.getEmail();
+            String accountDataApiToken) {
+        var internalCommonSubjectIdentifier = calculateICS(userProfile);
 
         LOG.info("Deleting user account");
-        if (accountDataApiToken.isPresent() && accountDataApiService != null) {
-            deleteAccountViaDataApi(userProfile.getPublicSubjectID(), accountDataApiToken.get());
-        } else {
-            dynamoDeleteService.deleteAccount(
-                    email,
-                    internalCommonSubjectIdentifier.getValue(),
-                    userProfile.getPublicSubjectID());
-            LOG.info("User account deleted via DynamoDB directly, not via ADAPI");
-        }
 
-        if (sendNotification) {
-            try {
-                LOG.info("User account removed. Adding notification message to SQS queue");
-                NotifyRequest notifyRequest =
-                        new NotifyRequest(
-                                email,
-                                NotificationType.DELETE_ACCOUNT,
-                                LocaleHelper.SupportedLanguage.EN);
-                sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
-            } catch (Exception e) {
-                LOG.error("Failed to send account deletion email: ", e);
-            }
-        }
+        deleteAccountViaDataApi(userProfile.getPublicSubjectID(), accountDataApiToken);
 
+        if (sendNotification) sendNotifyRequest(userProfile);
+
+        emitAuditEvent(
+                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+    }
+
+    private void sendNotifyRequest(UserProfile userProfile) {
+        try {
+            LOG.info("User account removed. Adding notification message to SQS queue");
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(
+                            userProfile.getEmail(),
+                            NotificationType.DELETE_ACCOUNT,
+                            LocaleHelper.SupportedLanguage.EN);
+            sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
+        } catch (Exception e) {
+            LOG.error("Failed to send account deletion email: ", e);
+        }
+    }
+
+    private void emitAuditEvent(
+            Optional<APIGatewayProxyRequestEvent> input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            Subject internalCommonSubjectIdentifier) {
         String persistentSessionID = StructuredAuditService.UNKNOWN;
         String ipAddress = StructuredAuditService.UNKNOWN;
         if (input.isPresent()) {
@@ -186,6 +193,17 @@ public class AccountDeletionService {
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }
+    }
+
+    private Subject calculateICS(UserProfile userProfile) {
+        LOG.info("Calculating internal common subject identifier");
+        var internalCommonSubjectIdentifier =
+                ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                        userProfile,
+                        configurationService.getInternalSectorUri(),
+                        authenticationService);
+        LOG.info("Internal common subject identifier: {}", internalCommonSubjectIdentifier);
+        return internalCommonSubjectIdentifier;
     }
 
     public void deleteAccountViaDataApi(String publicSubjectId, String token) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -26,7 +26,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.time.Clock;
-import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
@@ -73,16 +72,20 @@ public class AccountDeletionService {
                 null);
     }
 
+    /**
+     * Removes a user account directly via DynamoDB.
+     *
+     * <p>This method calculates the internal common subject identifier, deletes the user's account
+     * records from DynamoDB directly, optionally sends a deletion notification via SQS, and emits a
+     * standard audit event.
+     *
+     * @param userProfile The profile of the user whose account is being deleted.
+     * @param txmaAuditEncoded The encoded TxMA audit information.
+     * @param reason The reason for the account deletion.
+     * @param sendNotification {@code true} to send an account deletion email notification; {@code
+     *     false} otherwise.
+     */
     public void removeAccount(
-            Optional<APIGatewayProxyRequestEvent> input,
-            UserProfile userProfile,
-            String txmaAuditEncoded,
-            AccountDeletionReason reason) {
-        removeAccount(input, userProfile, txmaAuditEncoded, reason, true);
-    }
-
-    public void removeAccount(
-            Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
             String txmaAuditEncoded,
             AccountDeletionReason reason,
@@ -97,20 +100,60 @@ public class AccountDeletionService {
 
         if (sendNotification) sendNotifyRequest(userProfile);
 
-        if (input.isPresent()) {
-            emitAuditEvent(
-                    input.get(),
-                    userProfile,
-                    txmaAuditEncoded,
-                    reason,
-                    internalCommonSubjectIdentifier);
-        } else {
-            emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
-        }
+        emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
     }
 
+    /**
+     * Removes a user account directly via DynamoDB, incorporating HTTP request context for enriched
+     * auditing.
+     *
+     * <p>This method performs a direct DynamoDB deletion and optionally sends a notification.
+     * Unlike the standard method, it extracts IP addresses, session IDs, and client IDs from the
+     * provided API Gateway request event to construct a more detailed audit context.
+     *
+     * @param input The API Gateway request event containing headers and context for auditing.
+     * @param userProfile The profile of the user whose account is being deleted.
+     * @param txmaAuditEncoded The encoded TxMA audit information.
+     * @param reason The reason for the account deletion.
+     * @param sendNotification {@code true} to send an account deletion email notification; {@code
+     *     false} otherwise.
+     */
     public void removeAccount(
-            Optional<APIGatewayProxyRequestEvent> input,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            boolean sendNotification) {
+        var internalCommonSubjectIdentifier = calculateICS(userProfile);
+
+        dynamoDeleteService.deleteAccount(
+                userProfile.getEmail(),
+                internalCommonSubjectIdentifier.getValue(),
+                userProfile.getPublicSubjectID());
+        LOG.info("User account deleted via DynamoDB directly, not via ADAPI");
+
+        if (sendNotification) sendNotifyRequest(userProfile);
+
+        emitAuditEvent(
+                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+    }
+
+    /**
+     * Removes a user account by delegating to the Account Data API.
+     *
+     * <p>This method deletes the user by invoking the external Account Data API using the provided
+     * authentication token. It optionally sends a deletion notification via SQS and emits a
+     * standard audit event.
+     *
+     * @param userProfile The profile of the user whose account is being deleted.
+     * @param txmaAuditEncoded The encoded TxMA audit information.
+     * @param reason The reason for the account deletion.
+     * @param sendNotification {@code true} to send an account deletion email notification; {@code
+     *     false} otherwise.
+     * @param accountDataApiToken The authorization token required to authenticate with the Account
+     *     Data API.
+     */
+    public void removeAccount(
             UserProfile userProfile,
             String txmaAuditEncoded,
             AccountDeletionReason reason,
@@ -124,16 +167,43 @@ public class AccountDeletionService {
 
         if (sendNotification) sendNotifyRequest(userProfile);
 
-        if (input.isPresent()) {
-            emitAuditEvent(
-                    input.get(),
-                    userProfile,
-                    txmaAuditEncoded,
-                    reason,
-                    internalCommonSubjectIdentifier);
-        } else {
-            emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
-        }
+        emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+    }
+
+    /**
+     * Removes a user account by delegating to the Account Data API, incorporating HTTP request
+     * context for enriched auditing.
+     *
+     * <p>This method deletes the user via the external Account Data API and optionally sends a
+     * notification. It extracts IP addresses, session IDs, and client IDs from the provided API
+     * Gateway request event to construct a highly detailed audit context.
+     *
+     * @param input The API Gateway request event containing headers and context for auditing.
+     * @param userProfile The profile of the user whose account is being deleted.
+     * @param txmaAuditEncoded The encoded TxMA audit information.
+     * @param reason The reason for the account deletion.
+     * @param sendNotification {@code true} to send an account deletion email notification; {@code
+     *     false} otherwise.
+     * @param accountDataApiToken The authorization token required to authenticate with the Account
+     *     Data API.
+     */
+    public void removeAccount(
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            boolean sendNotification,
+            String accountDataApiToken) {
+        var internalCommonSubjectIdentifier = calculateICS(userProfile);
+
+        LOG.info("Deleting user account");
+
+        deleteAccountViaDataApi(userProfile.getPublicSubjectID(), accountDataApiToken);
+
+        if (sendNotification) sendNotifyRequest(userProfile);
+
+        emitAuditEvent(
+                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
     }
 
     private void sendNotifyRequest(UserProfile userProfile) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -96,8 +97,16 @@ public class AccountDeletionService {
 
         if (sendNotification) sendNotifyRequest(userProfile);
 
-        emitAuditEvent(
-                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+        if (input.isPresent()) {
+            emitAuditEvent(
+                    input.get(),
+                    userProfile,
+                    txmaAuditEncoded,
+                    reason,
+                    internalCommonSubjectIdentifier);
+        } else {
+            emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+        }
     }
 
     public void removeAccount(
@@ -115,8 +124,16 @@ public class AccountDeletionService {
 
         if (sendNotification) sendNotifyRequest(userProfile);
 
-        emitAuditEvent(
-                input, userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+        if (input.isPresent()) {
+            emitAuditEvent(
+                    input.get(),
+                    userProfile,
+                    txmaAuditEncoded,
+                    reason,
+                    internalCommonSubjectIdentifier);
+        } else {
+            emitAuditEvent(userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
+        }
     }
 
     private void sendNotifyRequest(UserProfile userProfile) {
@@ -134,65 +151,101 @@ public class AccountDeletionService {
     }
 
     private void emitAuditEvent(
-            Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
             String txmaAuditEncoded,
             AccountDeletionReason reason,
             Subject internalCommonSubjectIdentifier) {
-        String persistentSessionID = StructuredAuditService.UNKNOWN;
-        String ipAddress = StructuredAuditService.UNKNOWN;
-        if (input.isPresent()) {
-            persistentSessionID =
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.get().getHeaders());
-            attachLogFieldToLogs(PERSISTENT_SESSION_ID, ipAddress);
-            ipAddress = IpAddressHelper.extractIpAddress(input.get());
-        }
-
         try {
-            var clientId =
-                    input.map(
-                                    n ->
-                                            n.getRequestContext()
-                                                    .getAuthorizer()
-                                                    .getOrDefault(
-                                                            "clientId",
-                                                            StructuredAuditService.UNKNOWN)
-                                                    .toString())
-                            .orElse(StructuredAuditService.UNKNOWN);
-            var clientSessionId =
-                    input.map(
-                                    n ->
-                                            ClientSessionIdHelper.extractSessionIdFromHeaders(
-                                                    n.getHeaders()))
-                            .orElse(StructuredAuditService.UNKNOWN);
-            var sessionId =
-                    input.map(
-                                    n ->
-                                            RequestHeaderHelper.getHeaderValueOrElse(
-                                                    n.getHeaders(), SESSION_ID_HEADER, ""))
-                            .orElse(StructuredAuditService.UNKNOWN);
-            var auditContext =
-                    new AuditContext(
-                            clientId,
-                            clientSessionId,
-                            sessionId,
-                            internalCommonSubjectIdentifier.getValue(),
-                            userProfile.getEmail(),
-                            ipAddress,
-                            userProfile.getPhoneNumber(),
-                            persistentSessionID,
-                            txmaAuditEncoded);
             var auditEvent =
-                    AuthDeleteAccount.create(
-                            auditContext,
-                            userProfile.getPublicSubjectID(),
-                            userProfile.getLegacySubjectID(),
-                            reason.name(),
-                            Clock.systemUTC());
+                    createAuditEvent(
+                            userProfile, txmaAuditEncoded, reason, internalCommonSubjectIdentifier);
             structuredAuditService.submitAuditEvent(auditEvent);
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }
+    }
+
+    private void emitAuditEvent(
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            Subject internalCommonSubjectIdentifier) {
+
+        try {
+            var auditEvent =
+                    createAuditEvent(
+                            input,
+                            userProfile,
+                            txmaAuditEncoded,
+                            reason,
+                            internalCommonSubjectIdentifier);
+            structuredAuditService.submitAuditEvent(auditEvent);
+        } catch (Exception e) {
+            LOG.error("Failed to audit account deletion: ", e);
+        }
+    }
+
+    private static AuthDeleteAccount createAuditEvent(
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            Subject internalCommonSubjectIdentifier) {
+        var auditContext =
+                new AuditContext(
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        internalCommonSubjectIdentifier.getValue(),
+                        userProfile.getEmail(),
+                        AuditService.UNKNOWN,
+                        userProfile.getPhoneNumber(),
+                        AuditService.UNKNOWN,
+                        txmaAuditEncoded);
+        return AuthDeleteAccount.create(
+                auditContext,
+                userProfile.getPublicSubjectID(),
+                userProfile.getLegacySubjectID(),
+                reason.name(),
+                Clock.systemUTC());
+    }
+
+    private static AuthDeleteAccount createAuditEvent(
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            String txmaAuditEncoded,
+            AccountDeletionReason reason,
+            Subject internalCommonSubjectIdentifier) {
+        String ipAddress = StructuredAuditService.UNKNOWN;
+        String persistentSessionID =
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
+        attachLogFieldToLogs(PERSISTENT_SESSION_ID, ipAddress);
+        ipAddress = IpAddressHelper.extractIpAddress(input);
+        var clientId =
+                input.getRequestContext()
+                        .getAuthorizer()
+                        .getOrDefault("clientId", StructuredAuditService.UNKNOWN)
+                        .toString();
+        var clientSessionId = ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders());
+        var sessionId =
+                RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
+        var auditContext =
+                new AuditContext(
+                        clientId,
+                        clientSessionId,
+                        sessionId,
+                        internalCommonSubjectIdentifier.getValue(),
+                        userProfile.getEmail(),
+                        ipAddress,
+                        userProfile.getPhoneNumber(),
+                        persistentSessionID,
+                        txmaAuditEncoded);
+        return AuthDeleteAccount.create(
+                auditContext,
+                userProfile.getPublicSubjectID(),
+                userProfile.getLegacySubjectID(),
+                reason.name(),
+                Clock.systemUTC());
     }
 
     private Subject calculateICS(UserProfile userProfile) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -69,14 +69,38 @@ public class ManualAccountDeletionService {
                         userProfile.getPublicSubjectID(),
                         userProfile.getLegacySubjectID(),
                         getCommonSubjectId(userProfile));
+
         try {
-            accountDeletionService.removeAccount(
-                    Optional.empty(),
-                    userProfile,
-                    AuditService.UNKNOWN,
-                    accountDeletionReason,
-                    sendNotification,
-                    getAccountDataApiToken(userProfile));
+            if (accountDeletionTokenService == null
+                    || !configurationService.isAccountDeletionDataApiEnabled()) {
+                accountDeletionService.removeAccount(
+                        Optional.empty(),
+                        userProfile,
+                        AuditService.UNKNOWN,
+                        accountDeletionReason,
+                        sendNotification);
+
+            } else {
+                Result<JwtFailureReason, BearerAccessToken> adapiTokenResult =
+                        accountDeletionTokenService.createAccountDataApiAccessToken(
+                                userProfile.getPublicSubjectID(), clientId);
+
+                if (adapiTokenResult.isFailure()) {
+                    throw new RuntimeException(
+                            "Failed to mint account-delete token for publicSubjectId: "
+                                    + userProfile.getPublicSubjectID()
+                                    + ". Reason: "
+                                    + adapiTokenResult.getFailure());
+                }
+
+                accountDeletionService.removeAccount(
+                        Optional.empty(),
+                        userProfile,
+                        AuditService.UNKNOWN,
+                        accountDeletionReason,
+                        sendNotification,
+                        adapiTokenResult.getSuccess().getValue());
+            }
         } catch (RuntimeException e) {
             LOG.error(
                     "Error while deleting account: {}. Identifiers: {}",
@@ -84,29 +108,11 @@ public class ManualAccountDeletionService {
                     accountIdentifiers);
             throw e;
         }
+
         var deletedAccountPayload =
                 SerializationService.getInstance().writeValueAsString(legacyAccountDeletionMessage);
         legacyAccountDeletionSnsClient.publish(deletedAccountPayload);
         return accountIdentifiers;
-    }
-
-    private Optional<String> getAccountDataApiToken(UserProfile userProfile) {
-        if (accountDeletionTokenService == null
-                || !configurationService.isAccountDeletionDataApiEnabled()) {
-            return Optional.empty();
-        }
-        Result<JwtFailureReason, BearerAccessToken> tokenResult =
-                accountDeletionTokenService.createAccountDataApiAccessToken(
-                        userProfile.getPublicSubjectID(), clientId);
-        return tokenResult.fold(
-                failure -> {
-                    throw new RuntimeException(
-                            "Failed to mint account-delete token for publicSubjectId: "
-                                    + userProfile.getPublicSubjectID()
-                                    + ". Reason: "
-                                    + failure);
-                },
-                token -> Optional.of(token.getValue()));
     }
 
     private String getCommonSubjectId(UserProfile userProfile) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.URI;
-import java.util.Optional;
 
 public class ManualAccountDeletionService {
     private final AccountDeletionService accountDeletionService;
@@ -74,11 +73,7 @@ public class ManualAccountDeletionService {
             if (accountDeletionTokenService == null
                     || !configurationService.isAccountDeletionDataApiEnabled()) {
                 accountDeletionService.removeAccount(
-                        Optional.empty(),
-                        userProfile,
-                        AuditService.UNKNOWN,
-                        accountDeletionReason,
-                        sendNotification);
+                        userProfile, AuditService.UNKNOWN, accountDeletionReason, sendNotification);
 
             } else {
                 Result<JwtFailureReason, BearerAccessToken> adapiTokenResult =
@@ -94,7 +89,6 @@ public class ManualAccountDeletionService {
                 }
 
                 accountDeletionService.removeAccount(
-                        Optional.empty(),
                         userProfile,
                         AuditService.UNKNOWN,
                         accountDeletionReason,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -91,7 +91,7 @@ class RemoveAccountHandlerTest {
         assertThat(result, hasStatus(204));
         verify(accountDeletionService)
                 .removeAccount(
-                        Optional.of(event),
+                        event,
                         userProfile,
                         TXMA_ENCODED_HEADER_VALUE,
                         AccountDeletionReason.USER_INITIATED,
@@ -116,7 +116,7 @@ class RemoveAccountHandlerTest {
         assertThat(result, hasStatus(204));
         verify(accountDeletionService)
                 .removeAccount(
-                        Optional.of(event),
+                        event,
                         userProfile,
                         TXMA_ENCODED_HEADER_VALUE,
                         AccountDeletionReason.USER_INITIATED,
@@ -140,7 +140,7 @@ class RemoveAccountHandlerTest {
         assertThat(result, hasStatus(204));
         verify(accountDeletionService)
                 .removeAccount(
-                        Optional.of(event),
+                        event,
                         userProfile,
                         StructuredAuditService.UNKNOWN,
                         AccountDeletionReason.USER_INITIATED,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -95,8 +95,7 @@ class RemoveAccountHandlerTest {
                         userProfile,
                         TXMA_ENCODED_HEADER_VALUE,
                         AccountDeletionReason.USER_INITIATED,
-                        true,
-                        Optional.empty());
+                        true);
     }
 
     @Test
@@ -122,7 +121,7 @@ class RemoveAccountHandlerTest {
                         TXMA_ENCODED_HEADER_VALUE,
                         AccountDeletionReason.USER_INITIATED,
                         true,
-                        Optional.of("some-access-token"));
+                        "some-access-token");
     }
 
     @Test
@@ -145,8 +144,7 @@ class RemoveAccountHandlerTest {
                         userProfile,
                         StructuredAuditService.UNKNOWN,
                         AccountDeletionReason.USER_INITIATED,
-                        true,
-                        Optional.empty());
+                        true);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -117,10 +116,11 @@ class AccountDeletionServiceTest {
         when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
         // when
         underTest.removeAccount(
-                Optional.of(input),
+                input,
                 userProfile,
                 StructuredAuditService.UNKNOWN,
-                AccountDeletionReason.USER_INITIATED);
+                AccountDeletionReason.USER_INITIATED,
+                true);
         // then
         verify(dynamoDeleteService)
                 .deleteAccount(eq(expectedEmail), any(), eq(TEST_PUBLIC_SUBJECT_ID));
@@ -139,10 +139,11 @@ class AccountDeletionServiceTest {
                 expectedException.getClass(),
                 () ->
                         underTest.removeAccount(
-                                Optional.of(input),
+                                input,
                                 userProfile,
                                 StructuredAuditService.UNKNOWN,
-                                AccountDeletionReason.USER_INITIATED));
+                                AccountDeletionReason.USER_INITIATED,
+                                true));
     }
 
     @Test
@@ -154,10 +155,11 @@ class AccountDeletionServiceTest {
 
         // when
         underTest.removeAccount(
-                Optional.of(input),
+                input,
                 userProfile,
                 StructuredAuditService.UNKNOWN,
-                AccountDeletionReason.USER_INITIATED);
+                AccountDeletionReason.USER_INITIATED,
+                true);
 
         // then
         var captor = ArgumentCaptor.forClass(String.class);
@@ -180,10 +182,11 @@ class AccountDeletionServiceTest {
         assertDoesNotThrow(
                 () ->
                         underTest.removeAccount(
-                                Optional.of(input),
+                                input,
                                 userProfile,
                                 StructuredAuditService.UNKNOWN,
-                                AccountDeletionReason.USER_INITIATED));
+                                AccountDeletionReason.USER_INITIATED,
+                                true));
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining("Failed to send account deletion email")));
@@ -212,8 +215,7 @@ class AccountDeletionServiceTest {
                 .when(() -> IpAddressHelper.extractIpAddress(input))
                 .thenReturn(TEST_IP_ADDRESS);
 
-        underTest.removeAccount(
-                Optional.of(input), userProfile, StructuredAuditService.UNKNOWN, reason);
+        underTest.removeAccount(input, userProfile, StructuredAuditService.UNKNOWN, reason, true);
 
         var captor = ArgumentCaptor.forClass(AuthDeleteAccount.class);
         verify(structuredAuditService).submitAuditEvent(captor.capture());
@@ -248,10 +250,11 @@ class AccountDeletionServiceTest {
                 .thenReturn(TEST_IP_ADDRESS);
 
         underTest.removeAccount(
-                Optional.of(input),
+                input,
                 userProfile,
                 StructuredAuditService.UNKNOWN,
-                AccountDeletionReason.USER_INITIATED);
+                AccountDeletionReason.USER_INITIATED,
+                true);
 
         var captor = ArgumentCaptor.forClass(AuthDeleteAccount.class);
         verify(structuredAuditService).submitAuditEvent(captor.capture());
@@ -271,10 +274,11 @@ class AccountDeletionServiceTest {
         assertDoesNotThrow(
                 () ->
                         underTest.removeAccount(
-                                Optional.of(input),
+                                input,
                                 userProfile,
                                 StructuredAuditService.UNKNOWN,
-                                AccountDeletionReason.USER_INITIATED));
+                                AccountDeletionReason.USER_INITIATED,
+                                true));
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining("Failed to audit account deletion")));
@@ -304,7 +308,7 @@ class AccountDeletionServiceTest {
             when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
 
             underTestWithDataApi.removeAccount(
-                    Optional.of(input),
+                    input,
                     userProfile,
                     StructuredAuditService.UNKNOWN,
                     AccountDeletionReason.USER_INITIATED,
@@ -330,7 +334,7 @@ class AccountDeletionServiceTest {
             when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
 
             underTestWithDataApi.removeAccount(
-                    Optional.of(input),
+                    input,
                     userProfile,
                     StructuredAuditService.UNKNOWN,
                     AccountDeletionReason.USER_INITIATED,
@@ -355,7 +359,7 @@ class AccountDeletionServiceTest {
                     RuntimeException.class,
                     () ->
                             underTestWithDataApi.removeAccount(
-                                    Optional.of(input),
+                                    input,
                                     userProfile,
                                     StructuredAuditService.UNKNOWN,
                                     AccountDeletionReason.USER_INITIATED,
@@ -378,7 +382,7 @@ class AccountDeletionServiceTest {
                     RuntimeException.class,
                     () ->
                             underTestWithDataApi.removeAccount(
-                                    Optional.of(input),
+                                    input,
                                     userProfile,
                                     StructuredAuditService.UNKNOWN,
                                     AccountDeletionReason.USER_INITIATED,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -309,7 +309,7 @@ class AccountDeletionServiceTest {
                     StructuredAuditService.UNKNOWN,
                     AccountDeletionReason.USER_INITIATED,
                     true,
-                    Optional.of(TEST_ADAPI_TOKEN));
+                    TEST_ADAPI_TOKEN);
 
             verify(accountDataApiService)
                     .deleteAccount(eq(TEST_PUBLIC_SUBJECT_ID), eq(TEST_ADAPI_TOKEN));
@@ -334,8 +334,7 @@ class AccountDeletionServiceTest {
                     userProfile,
                     StructuredAuditService.UNKNOWN,
                     AccountDeletionReason.USER_INITIATED,
-                    true,
-                    Optional.empty());
+                    true);
 
             verify(dynamoDeleteService)
                     .deleteAccount(eq(TEST_EMAIL), any(), eq(TEST_PUBLIC_SUBJECT_ID));
@@ -361,7 +360,7 @@ class AccountDeletionServiceTest {
                                     StructuredAuditService.UNKNOWN,
                                     AccountDeletionReason.USER_INITIATED,
                                     true,
-                                    Optional.of(TEST_ADAPI_TOKEN)));
+                                    TEST_ADAPI_TOKEN));
         }
 
         @Test
@@ -384,7 +383,7 @@ class AccountDeletionServiceTest {
                                     StructuredAuditService.UNKNOWN,
                                     AccountDeletionReason.USER_INITIATED,
                                     true,
-                                    Optional.of(TEST_ADAPI_TOKEN)));
+                                    TEST_ADAPI_TOKEN));
         }
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -83,8 +83,7 @@ class ManualAccountDeletionServiceTest {
                         USER_PROFILE,
                         AuditService.UNKNOWN,
                         AccountDeletionReason.SUPPORT_INITIATED,
-                        true,
-                        Optional.empty());
+                        true);
     }
 
     @Test
@@ -140,7 +139,7 @@ class ManualAccountDeletionServiceTest {
         // given
         doThrow(new RuntimeException("error"))
                 .when(accountDeletionService)
-                .removeAccount(any(), any(), any(), any(), anyBoolean(), any());
+                .removeAccount(any(), any(), any(), any(), anyBoolean());
 
         // then
         assertThrows(RuntimeException.class, () -> underTest.manuallyDeleteAccount(USER_PROFILE));
@@ -181,7 +180,7 @@ class ManualAccountDeletionServiceTest {
                             AuditService.UNKNOWN,
                             AccountDeletionReason.SUPPORT_INITIATED,
                             true,
-                            Optional.of(TOKEN_VALUE));
+                            TOKEN_VALUE);
         }
 
         @Test
@@ -199,8 +198,7 @@ class ManualAccountDeletionServiceTest {
                             USER_PROFILE,
                             AuditService.UNKNOWN,
                             AccountDeletionReason.SUPPORT_INITIATED,
-                            true,
-                            Optional.empty());
+                            true);
             verifyNoInteractions(accountDeletionTokenService);
         }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -79,7 +78,6 @@ class ManualAccountDeletionServiceTest {
         // then
         verify(accountDeletionService)
                 .removeAccount(
-                        Optional.empty(),
                         USER_PROFILE,
                         AuditService.UNKNOWN,
                         AccountDeletionReason.SUPPORT_INITIATED,
@@ -139,7 +137,7 @@ class ManualAccountDeletionServiceTest {
         // given
         doThrow(new RuntimeException("error"))
                 .when(accountDeletionService)
-                .removeAccount(any(), any(), any(), any(), anyBoolean());
+                .removeAccount(any(), any(), any(), anyBoolean());
 
         // then
         assertThrows(RuntimeException.class, () -> underTest.manuallyDeleteAccount(USER_PROFILE));
@@ -175,7 +173,6 @@ class ManualAccountDeletionServiceTest {
             // then
             verify(accountDeletionService)
                     .removeAccount(
-                            Optional.empty(),
                             USER_PROFILE,
                             AuditService.UNKNOWN,
                             AccountDeletionReason.SUPPORT_INITIATED,
@@ -194,7 +191,6 @@ class ManualAccountDeletionServiceTest {
             // then
             verify(accountDeletionService)
                     .removeAccount(
-                            Optional.empty(),
                             USER_PROFILE,
                             AuditService.UNKNOWN,
                             AccountDeletionReason.SUPPORT_INITIATED,


### PR DESCRIPTION
## What

- Don't pass in `Optional` tokens or inputs to methods, overloading methods to make clearer what is happening at each call site, rather than relying on understanding conditional logic inside
- Also adds javadoc to AccountDeletionService
- Would like to follow this up with transition to `Result` pattern in this service, forcing errors to be bubbles up and handled at the lambda handler level for clarity

## How to review

1. Code Review commit-by-commit

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
