### PR TITLE
BAU: Bump threshold for reverification result alarm

### DIFF
--- a/ci/cloudformation/auth/function/reverification-result.yaml
+++ b/ci/cloudformation/auth/function/reverification-result.yaml
@@ -142,13 +142,7 @@ Resources:
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-reverification-result-lambda function. ${RunbookLink}"
-        - AlarmThreshold:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              lambdaLogAlarmThreshold,
-              DefaultValue: 5,
-            ]
+        - AlarmThreshold: 20
           Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           RunbookLink:
             !FindInMap [
@@ -168,13 +162,7 @@ Resources:
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
-      Threshold:
-        !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          lambdaLogAlarmThreshold,
-          DefaultValue: 5,
-        ]
+      Threshold: 20
 
   ReverificationResultFunctionSubscriptionFilter:
     Condition: IsSplunkEnabled


### PR DESCRIPTION
This is currently quite noisy due to an assumed safari bug causing multiple get requests which causes issues for our OIDC token flow. When resolved we could think about bumping this back down


