### PR TITLE
BAU: Add logging for when orch and auth disagree on authenticated state

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -301,6 +301,14 @@ public class StartHandler
                             upliftRequired,
                             mfaRequired(requestedCredentialTrustLevel));
 
+            if (userStartInfo.isAuthenticated()) {
+                var canIssueAuthCode = permissionDecisionManager.canIssueAuthCode(authSession);
+                if (!canIssueAuthCode) {
+                    LOG.warn(
+                            "Orch and auth disagree on whether user is authenticated: problems will likely arise in this journey");
+                }
+            }
+
             StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
 
             auditService.submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -7,9 +7,11 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
@@ -35,6 +37,7 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 
 import java.net.URI;
@@ -45,6 +48,8 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,6 +77,7 @@ import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.ENCODED_DEVICE_DETAILS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -117,6 +123,9 @@ class StartHandlerTest {
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
                     ENCODED_DEVICE_DETAILS);
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging = new CaptureLoggingExtension(StartHandler.class);
 
     @BeforeEach
     void beforeEach() {
@@ -302,6 +311,40 @@ class StartHandlerTest {
                         eq(true),
                         anyBoolean(),
                         anyBoolean());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void considersUserAuthenticatedButLogsWhenCannotIssueAuthCode(boolean canIssueAuthCode)
+            throws Json.JsonException {
+        withUserProfilePresent();
+        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false, false);
+        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        useValidSession();
+
+        when(permissionDecisionManager.canIssueAuthCode(any(AuthSessionItem.class)))
+                .thenReturn(canIssueAuthCode);
+
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(true));
+
+        var result = handler.handleRequest(event, context);
+
+        StartResponse response = objectMapper.readValue(result.getBody(), StartResponse.class);
+        assertTrue(response.user().isAuthenticated());
+
+        var expectedLogIfCannotIssueAuthCode =
+                "Orch and auth disagree on whether user is authenticated";
+        if (canIssueAuthCode) {
+            assertThat(
+                    logging.events(),
+                    not(hasItem(withMessageContaining(expectedLogIfCannotIssueAuthCode))));
+        } else {
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining(expectedLogIfCannotIssueAuthCode)));
+        }
     }
 
     @Test


### PR DESCRIPTION
Journeys where orch tell us the session is authenticated, but our auth session does not agree, are likely to result in failures.

These cases have been seen where a double request to a lambda (possibly caused by double clicking or the assumed safari bug) result in the auth session being created from new, meaning that we lose all the context of the user being authenticated.

We could fix this by not returning authenticated from the start handler when we don't think the user is authenticated. Adding this log will allow us to better identify journeys where this happens, to determine the cause and consider solutions

