### PR TITLE
AUT-5698: Remove legacy account deletion IAM policies and mock SNS resources

### DIFF
--- a/ci/cloudformation/account-management/function/bulk-remove-account.yaml
+++ b/ci/cloudformation/account-management/function/bulk-remove-account.yaml
@@ -274,68 +274,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref BulkRemoveAccountFunctionLogGroup
 
-  MockAccountDeletionTopic:
-    Condition: IsNotProduction
-    Type: AWS::SNS::Topic
-    Properties:
-      TopicName: !Sub
-        - ${Env}-mock-account-deletion-topic
-        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-      KmsMasterKeyId: !GetAtt MainKmsKey.Arn
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-MockAccountDeletionTopic"
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Source
-          Value: govuk-one-login/authentication-api/ci/cloudformation/account-management/function/bulk-remove-account.yaml
-
-  LegacyAccountDeletionTopicPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: !Sub
-        - ${Env}-legacy-account-deletion-topic-policy
-        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: AllowAccessToSNS
-            Effect: Allow
-            Action:
-              - sns:Publish
-            Resource:
-              - !If
-                - IsHigherEnv
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    legacyAccountDeletionTopicArn,
-                    DefaultValue: "",
-                  ]
-                - !Ref MockAccountDeletionTopic
-          - Sid: AllowDecryption
-            Effect: Allow
-            Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey
-            Resource:
-              - !GetAtt MainKmsKey.Arn
-          - !If
-            - IsHigherEnv
-            - Sid: AllowDecryptionHomeSnsTopicKmsKey
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey
-              Resource:
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    legacyAccountDeletionTopicKmsKeyArn,
-                    DefaultValue: "",
-                  ]
-            - !Ref AWS::NoValue
-
   BulkRemoveAccountInvokePolicy:
     Type: AWS::IAM::ManagedPolicy
     Condition: ShouldCreateBulkRemoveAccountPolicy

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -545,8 +545,6 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
-      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:539729775994:UserAccountDeletion
-      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:539729775994:key/d33e9077-8d66-4f63-99a1-f90e29b4aabe
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 7xgl7lexy4
       inactiveAccountDeletionClientId: inactive-account-deletion
@@ -598,8 +596,6 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: false
-      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:666500506359:UserAccountDeletion
-      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:666500506359:key/c54f60d4-122d-44d8-a5d6-d9e984df9f49
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
       inactiveAccountDeletionClientId: inactive-account-deletion
@@ -651,8 +647,6 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: false
-      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:026991849909:UserAccountDeletion
-      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:026991849909:key/80c5c2c9-4ff0-4fba-92de-5189957490e9
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0218o1p9tj
       inactiveAccountDeletionClientId: inactive-account-deletion

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -2323,27 +2323,13 @@ Resources:
   ManuallyDeleteAccountFunctionSQSPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Description: "IAM policy for permission to send SQS message and sns mock account SNS topic"
+      Description: "IAM policy for permission to send SQS message"
       Path: !Sub
         - /${Env}/am-shared/
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: AllowAccessToSNS
-            Effect: Allow
-            Action:
-              - sns:Publish
-            Resource:
-              - !If
-                - IsHigherEnv
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    legacyAccountDeletionTopicArn,
-                    DefaultValue: "",
-                  ]
-                - !Ref MockAccountDeletionTopic
           - Sid: AllowSendSQS
             Effect: Allow
             Action:
@@ -2357,21 +2343,6 @@ Resources:
               - kms:GenerateDataKey
             Resource:
               - !GetAtt MainKmsKey.Arn
-          - !If
-            - IsHigherEnv
-            - Sid: AllowDecryptionHomeSnsTopicKmsKey
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey
-              Resource:
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    legacyAccountDeletionTopicKmsKeyArn,
-                    DefaultValue: "",
-                  ]
-            - !Ref AWS::NoValue
 
   DynamoAuthSessionStoreReadWriteDeleteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
~~NOTE: Dependent on #8831 being merged~~ - merged

## What

<!-- Describe what you have changed and why -->

The IAM policies and mock SNS topic CloudFormation resources for the legacy account deletion path are removed here as a safe follow-up, now that the Lambda code no longer references them.

This was deferred from the previous PR to avoid a window where the old Lambda code could still be live but the underlying permissions and topic had already been destroyed.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env and check that stack is deployed OK (no rollbacks etc)

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [x] PR is canary deploy safe **- application code usages removed already**

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- application code usages removed already**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

https://github.com/govuk-one-login/authentication-api/pull/8831