### PR TITLE
BAU: Fix finish passkey assertion alarm threshold to match description

### DIFF
--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -178,7 +178,7 @@ Resources:
           EnvironmentConfiguration,
           !Ref Environment,
           lambdaLogAlarmThreshold,
-          DefaultValue: 5,
+          DefaultValue: 15,
         ]
 
   FinishPasskeyAssertionFunctionErrorRateCloudwatchAlarm:


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

When this was bumped to 15 previously, the bump was only applied to the description and not the threshold itself.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
    - Ensuring that the value used in the description and the threshold are the same (15).
