### PR TITLE
AUT-5607: Enable Data API deletion in staging, integration and production

### DIFF
--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -553,7 +553,7 @@ Mappings:
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:851725205974:key/ecfc81ec-546e-478d-ae04-5ed5d1b375a9
       manualAccountDeletionClientId: manual-account-deletion
       bulkAccountDeletionClientId: bulk-account-deletion
-      accountDeletionDataApiEnabled: false
+      accountDeletionDataApiEnabled: true
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
@@ -605,7 +605,7 @@ Mappings:
       inactiveAccountDeletionClientId: inactive-account-deletion
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125600642:key/f0e0c444-b70e-4d2f-9d5a-9f0bcf1d6540
       manualAccountDeletionClientId: manual-account-deletion
-      accountDeletionDataApiEnabled: false
+      accountDeletionDataApiEnabled: true
       bulkAccountDeletionClientId: bulk-account-deletion
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
@@ -659,7 +659,7 @@ Mappings:
       authToAccountDataSigningKeyArn: arn:aws:kms:eu-west-2:211125303002:key/29d156dd-c893-4221-8fe1-f24882e0e401
       manualAccountDeletionClientId: manual-account-deletion
       bulkAccountDeletionClientId: bulk-account-deletion
-      accountDeletionDataApiEnabled: false
+      accountDeletionDataApiEnabled: true
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"


### PR DESCRIPTION
## What
  
  Enables the Data API deletion path in staging, integration and production. Both lambdas already default to this path when the flag is on (delivered in AUT-5607, #8821); this only flips the environment config. Following senior approval to release.
  
  ## How to review
  
  1. Code review, this is a one-line config change per environment.
  2. No deploy or manual testing required beyond the pipeline, the underlying feature was already verified on dev.
  
  ## Checklist
  
  - [x] PR is canary deploy safe, config-only change, no lambda code changed
  - [x] Assessed the impact on active user sessions and confirmed no breaking changes, this only affects the account deletion path, not session handling
  - [x] A UCD review has been performed (or no review required), no user-facing or frontend change
  
  ## Related PRs
  
  Builds on #8821 (AUT-5607), which added the feature flag this PR turns on.