### PR TITLE
BAU: add log for when there is an existing session with the new sessionId

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -94,6 +94,14 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
 
                 return updatedSession;
             } else {
+                var existingSessionWithNewSessionId = getSession(newSessionId);
+                if (existingSessionWithNewSessionId.isPresent()) {
+                    LOG.info(
+                            "Session already exists with newSessionId {} for previousSessionId {} may cause problems",
+                            newSessionId,
+                            previousSessionId);
+                }
+
                 LOG.info("New Auth session item created with sessionId: {}", newSessionId);
                 return generateNewAuthSession(newSessionId);
             }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -94,12 +94,14 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
 
                 return updatedSession;
             } else {
-                var existingSessionWithNewSessionId = getSession(newSessionId);
-                if (existingSessionWithNewSessionId.isPresent()) {
-                    LOG.info(
-                            "Session already exists with newSessionId {} for previousSessionId {} may cause problems",
-                            newSessionId,
-                            previousSessionId);
+                if (previousSessionId.isPresent()) {
+                    var existingSessionWithNewSessionId = getSession(newSessionId);
+                    if (existingSessionWithNewSessionId.isPresent()) {
+                        LOG.info(
+                                "Session already exists with newSessionId {} for previousSessionId {} may cause problems",
+                                newSessionId,
+                                previousSessionId);
+                    }
                 }
 
                 LOG.info("New Auth session item created with sessionId: {}", newSessionId);


### PR DESCRIPTION
## What

We are seeing an issue where 2 quick requests made to the StartHandler are overwriting a users session with a blank session. The following is an example of how this happens

- User has existing sessionA.
- A request to the StartHandler is made with SessionA id as previousSessionId in requestBody and SessionB ID is a header
- Get SessionA with id and copy everything from it into SessionB
- Delete SessionA
- Immediately another request is sent with SessionA id as previousSessionId and SessionB as sessionId in header
- SessionA was deleted in the first request, therefore user gets a fresh session which suggests they haven't authenticated
- User doesn't do a silent login and instead has to log in again

We want to add a log to check our theory about this issue being caused by our implementation of using the previousSessionId for the existing user

## How to review

1. Code review

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->



<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->


<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->



## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
