### PR TITLE
BAU: Removed reference to old Pager duty sns and SSM client id

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
   statistic           = "Sum"
   threshold           = var.account_interventions_p1_alarm_error_threshold
   alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/x/GwCXEwE"
-  alarm_actions       = [local.isP1Alarm ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
+  alarm_actions       = [local.slack_event_sns_topic_arn]
 
   tags = {
     Service = "account-interventions"

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "spot_request_sqs_cloudwatch_p1_alarm" {
     QueueName = aws_sqs_queue.spot_request_queue.name
   }
   alarm_description = "Age of the oldest message on ${aws_sqs_queue.spot_request_queue.name} exceeds 60 seconds. ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/x/VIFoCAE"
-  alarm_actions     = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
+  alarm_actions     = [local.slack_event_sns_topic_arn]
 }
 
 # Turning WAF blocked alerts off until we figure out how best to utilise them

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -429,53 +429,6 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     }
   }
 
-  dynamic "rule" {
-    for_each = var.environment == "production" || var.environment == "sandpit" ? ["1"] : []
-    content {
-      action {
-        block {}
-      }
-      priority = 4
-      name     = "${var.environment}-smoke-test-client-exception"
-
-      statement {
-        and_statement {
-          statement {
-            label_match_statement {
-              key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_QueryArguments"
-              scope = "LABEL"
-            }
-          }
-          statement {
-            not_statement {
-              statement {
-                byte_match_statement {
-                  text_transformation {
-                    priority = 0
-                    type     = "NONE"
-                  }
-                  positional_constraint = "EXACTLY"
-                  search_string         = data.aws_ssm_parameter.smoke_test_client_id[0].value
-                  field_to_match {
-                    single_query_argument {
-                      name = "client_id"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      visibility_config {
-        cloudwatch_metrics_enabled = true
-        metric_name                = "${replace(var.environment, "-", "")}SmokeTestClientExceptionRule"
-        sampled_requests_enabled   = true
-      }
-    }
-  }
-
   rule {
     name     = "default_query_param_limit"
     priority = 5

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -73,6 +73,6 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   statistic           = "Sum"
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handback errors have occurred in ${var.environment}.ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/spaces/Orch/pages/5761204264/Runbook+IPV+handback+alarm"
-  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : local.slack_event_sns_topic_arn]
+  alarm_actions       = [local.slack_event_sns_topic_arn]
   treat_missing_data  = "notBreaching"
 }

--- a/ci/terraform/oidc/sns.tf
+++ b/ci/terraform/oidc/sns.tf
@@ -1,4 +1,0 @@
-data "aws_sns_topic" "pagerduty_p1_alerts" {
-  count = var.environment == "production" ? 1 : 0
-  name  = "${var.environment}-pagerduty-p1-alerts"
-}

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -166,8 +166,3 @@ resource "aws_iam_policy" "doc_app_rp_client_id_parameter_policy" {
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "doc-app-rp-client-id-parameter-store-policy"
 }
-
-data "aws_ssm_parameter" "smoke_test_client_id" {
-  count = var.environment == "production" || var.environment == "sandpit" ? 1 : 0
-  name  = "${var.environment}-smoke-test-client-id"
-}


### PR DESCRIPTION
## What

BAU: Removed reference to old Pager duty sns and SSM client id

OIDC code is not functional so removing alerting and reference to  SSM parameter , we have a tidy PR to follow to remove Legacy resource 

## How to review

Code review