### PR TITLE
AUT-5698: Temporarily add the legacy AD topic ARNs back

### DIFF
--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -545,6 +545,8 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
+      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:539729775994:UserAccountDeletion
+      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:539729775994:key/d33e9077-8d66-4f63-99a1-f90e29b4aabe
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 7xgl7lexy4
       inactiveAccountDeletionClientId: inactive-account-deletion
@@ -596,6 +598,8 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: false
+      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:666500506359:UserAccountDeletion
+      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:666500506359:key/c54f60d4-122d-44d8-a5d6-d9e984df9f49
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
       inactiveAccountDeletionClientId: inactive-account-deletion
@@ -647,6 +651,8 @@ Mappings:
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: false
+      legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:026991849909:UserAccountDeletion
+      legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:026991849909:key/80c5c2c9-4ff0-4fba-92de-5189957490e9
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0218o1p9tj
       inactiveAccountDeletionClientId: inactive-account-deletion


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Temporarily add the legacy AD topic ARNs back

These are required by the policies and topic that #8846 `AUT-5698/teardown-legacy-account-deletion-topic` will remove.

Failing job: https://github.com/govuk-one-login/authentication-api/actions/runs/33733566824/job/100578819599

Error from that failing job:
`
[[W1034: Validate the values that come from a Fn::FindInMap function] ({'Fn::FindInMap': ['EnvironmentConfiguration', {'Ref': 'Environment'}, 'legacyAccountDeletionTopicArn', {'DefaultValue': ''}]} does not match '^(arn:(aws[A-Za-z\\-]*?|\\*):[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$' when 'Fn::FindInMap' is resolved) matched 4354, [W1034: Validate the values that come from a Fn::FindInMap function] ({'Fn::FindInMap': ['EnvironmentConfiguration', {'Ref': 'Environment'}, 'legacyAccountDeletionTopicKmsKeyArn', {'DefaultValue': ''}]} does not match '^(arn:(aws[A-Za-z\\-]*?|\\*):[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$' when 'Fn::FindInMap' is resolved) matched 4377, [W1034: Validate the values that come from a Fn::FindInMap function] ({'Fn::FindInMap': ['EnvironmentConfiguration', {'Ref': 'Environment'}, 'legacyAccountDeletionTopicArn', {'DefaultValue': ''}]} does not match '^(arn:(aws[A-Za-z\\-]*?|\\*):[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$' when 'Fn::FindInMap' is resolved) matched 4593, [W1034: Validate the values that come from a Fn::FindInMap function] ({'Fn::FindInMap': ['EnvironmentConfiguration', {'Ref': 'Environment'}, 'legacyAccountDeletionTopicKmsKeyArn', {'DefaultValue': ''}]} does not match '^(arn:(aws[A-Za-z\\-]*?|\\*):[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$' when 'Fn::FindInMap' is resolved) matched 4622]
Error: Linting failed. At least one linting rule was matched to the provided template.
`

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [x] PR is canary deploy safe

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Prior: https://github.com/govuk-one-login/authentication-api/pull/8831
- Subsequent: https://github.com/govuk-one-login/authentication-api/pull/8846