### PR TITLE
ATO-2860: remove OIDC api gateway and lambdas in dev

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -1,10 +1,15 @@
 resource "aws_api_gateway_rest_api" "di_authentication_api" {
+  count          = var.deploy_orch_lambda_and_api ? 1 : 0
   name           = "${var.environment}-di-authentication-api"
   api_key_source = "HEADER"
 }
+moved {
+  from = aws_api_gateway_rest_api.di_authentication_api
+  to   = aws_api_gateway_rest_api.di_authentication_api[0]
+}
 
 resource "random_password" "client_registry_api_key" {
-  count   = var.client_registry_api_enabled ? 1 : 0
+  count   = var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   length  = 40
   special = false
 
@@ -14,47 +19,67 @@ resource "random_password" "client_registry_api_key" {
 }
 
 resource "aws_api_gateway_api_key" "client_registry_api_key" {
-  count = var.client_registry_api_enabled ? 1 : 0
+  count = var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   name  = "${var.environment}-client-registry-api-key"
   value = random_password.client_registry_api_key[0].result
 }
 
 resource "aws_api_gateway_usage_plan_key" "client_registry_usage_plan_key" {
-  count         = var.client_registry_api_enabled ? 1 : 0
+  count         = var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   key_id        = aws_api_gateway_api_key.client_registry_api_key[0].id
   key_type      = "API_KEY"
-  usage_plan_id = aws_api_gateway_usage_plan.di_auth_usage_plan.id
+  usage_plan_id = aws_api_gateway_usage_plan.di_auth_usage_plan[0].id
 }
 
 resource "aws_api_gateway_usage_plan" "di_auth_usage_plan" {
-  name = "${var.environment}-di-auth-usage-plan"
+  count = var.deploy_orch_lambda_and_api ? 1 : 0
+  name  = "${var.environment}-di-auth-usage-plan"
 
   api_stages {
-    api_id = aws_api_gateway_rest_api.di_authentication_api.id
-    stage  = aws_api_gateway_stage.endpoint_stage.stage_name
+    api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+    stage  = aws_api_gateway_stage.endpoint_stage[0].stage_name
   }
   depends_on = [
     aws_api_gateway_stage.endpoint_stage,
     aws_api_gateway_rest_api.di_authentication_api,
   ]
 }
+moved {
+  from = aws_api_gateway_usage_plan.di_auth_usage_plan
+  to   = aws_api_gateway_usage_plan.di_auth_usage_plan[0]
+}
 
 resource "aws_api_gateway_resource" "wellknown_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = ".well-known"
+}
+moved {
+  from = aws_api_gateway_resource.wellknown_resource
+  to   = aws_api_gateway_resource.wellknown_resource[0]
 }
 
 resource "aws_api_gateway_resource" "connect_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "connect"
+}
+moved {
+  from = aws_api_gateway_resource.connect_resource
+  to   = aws_api_gateway_resource.connect_resource[0]
 }
 
 resource "aws_api_gateway_resource" "register_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.connect_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.connect_resource[0].id
   path_part   = var.orch_register_enabled ? "register-auth" : "register"
+}
+moved {
+  from = aws_api_gateway_resource.register_resource
+  to   = aws_api_gateway_resource.register_resource[0]
 }
 
 locals {
@@ -64,39 +89,40 @@ locals {
 }
 
 resource "aws_api_gateway_deployment" "deployment" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
 
   triggers = {
     redeployment = sha1(jsonencode([
-      module.auth-code.integration_trigger_value,
-      module.auth-code.method_trigger_value,
-      module.authorize.integration_trigger_value,
-      module.authorize.method_trigger_value,
-      module.jwks.integration_trigger_value,
-      module.jwks.method_trigger_value,
-      module.storage_token_jwk.integration_trigger_value,
-      module.storage_token_jwk.method_trigger_value,
-      module.logout.integration_trigger_value,
-      module.logout.method_trigger_value,
-      module.openid_configuration_discovery.integration_trigger_value,
-      module.openid_configuration_discovery.method_trigger_value,
-      var.client_registry_api_enabled ? module.register[0].integration_trigger_value : null,
-      var.client_registry_api_enabled ? module.register[0].method_trigger_value : null,
-      module.token.integration_trigger_value,
-      module.token.method_trigger_value,
-      var.client_registry_api_enabled ? module.update[0].integration_trigger_value : null,
-      var.client_registry_api_enabled ? module.update[0].method_trigger_value : null,
-      module.userinfo.integration_trigger_value,
-      module.userinfo.method_trigger_value,
-      module.ipv-callback.integration_trigger_value,
-      module.ipv-callback.method_trigger_value,
-      module.ipv-capacity.integration_trigger_value,
-      module.ipv-capacity.method_trigger_value,
-      module.doc-app-callback.integration_trigger_value,
-      module.doc-app-callback.method_trigger_value,
-      module.authentication_callback.integration_trigger_value,
-      module.authentication_callback.method_trigger_value,
-      var.use_robots_txt ? aws_api_gateway_integration_response.robots_txt_integration_response[0].response_templates : null,
+      module.auth-code[0].integration_trigger_value,
+      module.auth-code[0].method_trigger_value,
+      module.authorize[0].integration_trigger_value,
+      module.authorize[0].method_trigger_value,
+      module.jwks[0].integration_trigger_value,
+      module.jwks[0].method_trigger_value,
+      module.storage_token_jwk[0].integration_trigger_value,
+      module.storage_token_jwk[0].method_trigger_value,
+      module.logout[0].integration_trigger_value,
+      module.logout[0].method_trigger_value,
+      module.openid_configuration_discovery[0].integration_trigger_value,
+      module.openid_configuration_discovery[0].method_trigger_value,
+      var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? module.register[0].integration_trigger_value : null,
+      var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? module.register[0].method_trigger_value : null,
+      module.token[0].integration_trigger_value,
+      module.token[0].method_trigger_value,
+      var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? module.update[0].integration_trigger_value : null,
+      var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? module.update[0].method_trigger_value : null,
+      module.userinfo[0].integration_trigger_value,
+      module.userinfo[0].method_trigger_value,
+      module.ipv-callback[0].integration_trigger_value,
+      module.ipv-callback[0].method_trigger_value,
+      module.ipv-capacity[0].integration_trigger_value,
+      module.ipv-capacity[0].method_trigger_value,
+      module.doc-app-callback[0].integration_trigger_value,
+      module.doc-app-callback[0].method_trigger_value,
+      module.authentication_callback[0].integration_trigger_value,
+      module.authentication_callback[0].method_trigger_value,
+      var.use_robots_txt && var.deploy_orch_lambda_and_api ? aws_api_gateway_integration_response.robots_txt_integration_response[0].response_templates : null,
       var.orch_openid_configuration_enabled,
       var.orch_doc_app_callback_enabled,
       var.orch_token_enabled,
@@ -109,10 +135,10 @@ resource "aws_api_gateway_deployment" "deployment" {
       var.orch_auth_code_enabled,
       var.orch_userinfo_enabled,
       var.orch_storage_token_jwk_enabled,
-      jsonencode(aws_api_gateway_integration.orch_ipv_jwks_integration),
-      jsonencode(aws_api_gateway_method.orch_ipv_jwks_method),
-      jsonencode(aws_api_gateway_method.orch_auth_jwks_method),
-      jsonencode(aws_api_gateway_method.orch_sis_jwks_method)
+      jsonencode(aws_api_gateway_integration.orch_ipv_jwks_integration[0]),
+      jsonencode(aws_api_gateway_method.orch_ipv_jwks_method[0]),
+      jsonencode(aws_api_gateway_method.orch_auth_jwks_method[0]),
+      jsonencode(aws_api_gateway_method.orch_sis_jwks_method[0])
     ]))
   }
 
@@ -120,49 +146,58 @@ resource "aws_api_gateway_deployment" "deployment" {
     create_before_destroy = true
   }
   depends_on = [
-    module.auth-code,
-    module.authorize,
-    module.jwks,
-    module.storage_token_jwk,
-    module.logout,
-    module.openid_configuration_discovery,
-    module.register,
-    module.token,
-    module.update,
-    module.userinfo,
-    module.ipv-callback,
-    module.ipv-capacity,
-    module.doc-app-callback,
-    aws_api_gateway_integration.orch_openid_configuration_integration,
-    aws_api_gateway_integration.orch_trustmark_integration,
-    aws_api_gateway_integration.orch_doc_app_callback_integration,
-    aws_api_gateway_integration.orch_token_integration,
-    aws_api_gateway_integration.orch_jwks_integration,
-    aws_api_gateway_integration.orch_authorisation_integration,
-    aws_api_gateway_integration.orch_logout_integration,
-    aws_api_gateway_integration.orch_ipv_callback_integration,
-    aws_api_gateway_integration.orch_register_integration,
-    aws_api_gateway_integration.orch_authentication_callback_integration,
-    aws_api_gateway_integration.orch_auth_code_integration,
-    aws_api_gateway_integration.orch_userinfo_integration,
-    aws_api_gateway_integration.orch_update_client_integration,
-    aws_api_gateway_integration.orch_storage_token_jwk_integration,
-    aws_api_gateway_integration.orch_ipv_jwks_integration,
-    aws_api_gateway_method.orch_ipv_jwks_method
+    module.auth-code[0],
+    module.authorize[0],
+    module.jwks[0],
+    module.storage_token_jwk[0],
+    module.logout[0],
+    module.openid_configuration_discovery[0],
+    module.register[0],
+    module.token[0],
+    module.update[0],
+    module.userinfo[0],
+    module.ipv-callback[0],
+    module.ipv-capacity[0],
+    module.doc-app-callback[0],
+    aws_api_gateway_integration.orch_openid_configuration_integration[0],
+    aws_api_gateway_integration.orch_trustmark_integration[0],
+    aws_api_gateway_integration.orch_doc_app_callback_integration[0],
+    aws_api_gateway_integration.orch_token_integration[0],
+    aws_api_gateway_integration.orch_jwks_integration[0],
+    aws_api_gateway_integration.orch_authorisation_integration[0],
+    aws_api_gateway_integration.orch_logout_integration[0],
+    aws_api_gateway_integration.orch_ipv_callback_integration[0],
+    aws_api_gateway_integration.orch_register_integration[0],
+    aws_api_gateway_integration.orch_authentication_callback_integration[0],
+    aws_api_gateway_integration.orch_auth_code_integration[0],
+    aws_api_gateway_integration.orch_userinfo_integration[0],
+    aws_api_gateway_integration.orch_update_client_integration[0],
+    aws_api_gateway_integration.orch_storage_token_jwk_integration[0],
+    aws_api_gateway_integration.orch_ipv_jwks_integration[0],
+    aws_api_gateway_method.orch_ipv_jwks_method[0]
   ]
+}
+moved {
+  from = aws_api_gateway_deployment.deployment
+  to   = aws_api_gateway_deployment.deployment[0]
 }
 
 resource "aws_cloudwatch_log_group" "oidc_stage_execution_logs" {
-  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}"
+  count             = var.deploy_orch_lambda_and_api ? 1 : 0
+  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.di_authentication_api[0].id}/${var.environment}"
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+moved {
+  from = aws_cloudwatch_log_group.oidc_stage_execution_logs
+  to   = aws_cloudwatch_log_group.oidc_stage_execution_logs[0]
 }
 
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_api_execution_log_subscription" {
-  count           = length(var.logging_endpoint_arns)
+  count           = var.deploy_orch_lambda_and_api ? length(var.logging_endpoint_arns) : 0
   name            = "${var.environment}-oidc-api-execution-log-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.oidc_stage_execution_logs.name
+  log_group_name  = aws_cloudwatch_log_group.oidc_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
@@ -172,16 +207,21 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_api_execution_log_subscr
 }
 
 resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
+  count             = var.deploy_orch_lambda_and_api ? 1 : 0
   name              = "${var.environment}-oidc-api-access-logs"
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 }
+moved {
+  from = aws_cloudwatch_log_group.oidc_stage_access_logs
+  to   = aws_cloudwatch_log_group.oidc_stage_access_logs[0]
+}
 
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription" {
-  count           = length(var.logging_endpoint_arns)
+  count           = var.deploy_orch_lambda_and_api ? length(var.logging_endpoint_arns) : 0
   name            = "${var.environment}-oidc-api-access-logs-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs.name
+  log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
@@ -191,16 +231,21 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription"
 }
 
 resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
+  count             = var.deploy_orch_lambda_and_api ? 1 : 0
   name              = "aws-waf-logs-oidc-${var.environment}"
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 }
+moved {
+  from = aws_cloudwatch_log_group.oidc_waf_logs
+  to   = aws_cloudwatch_log_group.oidc_waf_logs[0]
+}
 
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
-  count           = length(var.logging_endpoint_arns)
+  count           = var.deploy_orch_lambda_and_api ? length(var.logging_endpoint_arns) : 0
   name            = "${var.environment}-oidc-api-waf-logs-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs.name
+  log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
@@ -210,14 +255,15 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
 }
 
 resource "aws_api_gateway_stage" "endpoint_stage" {
-  deployment_id = aws_api_gateway_deployment.deployment.id
-  rest_api_id   = aws_api_gateway_rest_api.di_authentication_api.id
+  count         = var.deploy_orch_lambda_and_api ? 1 : 0
+  deployment_id = aws_api_gateway_deployment.deployment[0].id
+  rest_api_id   = aws_api_gateway_rest_api.di_authentication_api[0].id
   stage_name    = var.environment
 
   xray_tracing_enabled = true
 
   access_log_settings {
-    destination_arn = aws_cloudwatch_log_group.oidc_stage_access_logs.arn
+    destination_arn = aws_cloudwatch_log_group.oidc_stage_access_logs[0].arn
     format          = local.access_logging_template
   }
 
@@ -243,12 +289,16 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
     "FMSRegionalPolicy" = "false"
   }
 }
+moved {
+  from = aws_api_gateway_stage.endpoint_stage
+  to   = aws_api_gateway_stage.endpoint_stage[0]
+}
 
 resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
-  count = var.enable_api_gateway_execution_logging ? 1 : 0
+  count = var.enable_api_gateway_execution_logging && var.deploy_orch_lambda_and_api ? 1 : 0
 
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  stage_name  = aws_api_gateway_stage.endpoint_stage[0].stage_name
   method_path = "*/*"
 
   settings {
@@ -262,19 +312,25 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
 }
 
 resource "aws_api_gateway_base_path_mapping" "api" {
-  count       = var.deploy_oidc_api_gateway_domain ? 1 : 0
-  api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
+  count       = var.deploy_oidc_api_gateway_domain && var.deploy_orch_lambda_and_api ? 1 : 0
+  api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  stage_name  = aws_api_gateway_stage.endpoint_stage[0].stage_name
   domain_name = local.oidc_api_fqdn
 }
 
 
 module "dashboard" {
+  count            = var.deploy_orch_lambda_and_api ? 1 : 0
   source           = "../modules/dashboards"
-  api_gateway_name = aws_api_gateway_rest_api.di_authentication_api.name
+  api_gateway_name = aws_api_gateway_rest_api.di_authentication_api[0].name
+}
+moved {
+  from = module.dashboard
+  to   = module.dashboard[0]
 }
 
 resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
+  count = var.deploy_orch_lambda_and_api ? 1 : 0
   name  = "${var.environment}-oidc-waf-web-acl"
   scope = "REGIONAL"
 
@@ -570,22 +626,27 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     sampled_requests_enabled   = true
   }
 }
+moved {
+  from = aws_wafv2_web_acl.wafregional_web_acl_oidc_api
+  to   = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[0]
+}
 
 
 data "aws_cloudformation_export" "oidc_origin_cloaking_waf_arn" {
-  count = var.oidc_cloudfront_enabled ? 1 : 0
+  count = var.oidc_cloudfront_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   name  = "${local.secure_pipelines_environment}-oidc-cloudfront-CloakingOriginWebACLArn"
 }
 
 resource "aws_wafv2_web_acl_association" "oidc_origin_cloaking_waf" {
-  count        = var.oidc_cloudfront_enabled ? 1 : 0
-  resource_arn = aws_api_gateway_stage.endpoint_stage.arn
+  count        = var.oidc_cloudfront_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  resource_arn = aws_api_gateway_stage.endpoint_stage[0].arn
   web_acl_arn  = data.aws_cloudformation_export.oidc_origin_cloaking_waf_arn[0].value
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_oidc_api" {
-  log_destination_configs = [aws_cloudwatch_log_group.oidc_waf_logs.arn]
-  resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_oidc_api.arn
+  count                   = var.deploy_orch_lambda_and_api ? 1 : 0
+  log_destination_configs = [aws_cloudwatch_log_group.oidc_waf_logs[0].arn]
+  resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[0].arn
   logging_filter {
     default_behavior = "KEEP"
 
@@ -605,18 +666,22 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_oidc_api"
     aws_cloudwatch_log_group.oidc_waf_logs
   ]
 }
+moved {
+  from = aws_wafv2_web_acl_logging_configuration.waf_logging_config_oidc_api
+  to   = aws_wafv2_web_acl_logging_configuration.waf_logging_config_oidc_api[0]
+}
 
 
 resource "aws_api_gateway_resource" "robots_txt_resource" {
-  count       = var.use_robots_txt ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.use_robots_txt && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "robots.txt"
 }
 
 resource "aws_api_gateway_method" "robots_txt_method" {
-  count       = var.use_robots_txt ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.use_robots_txt && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.robots_txt_resource[0].id
   http_method = "GET"
 
@@ -627,8 +692,8 @@ resource "aws_api_gateway_method" "robots_txt_method" {
 }
 
 resource "aws_api_gateway_integration" "robots_txt_integration" {
-  count       = var.use_robots_txt ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.use_robots_txt && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.robots_txt_resource[0].id
   http_method = aws_api_gateway_method.robots_txt_method[0].http_method
 
@@ -649,8 +714,8 @@ resource "aws_api_gateway_integration" "robots_txt_integration" {
 }
 
 resource "aws_api_gateway_method_response" "robots_txt_method_response" {
-  count       = var.use_robots_txt ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.use_robots_txt && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.robots_txt_resource[0].id
   http_method = aws_api_gateway_method.robots_txt_method[0].http_method
   status_code = 200
@@ -664,8 +729,8 @@ resource "aws_api_gateway_method_response" "robots_txt_method_response" {
 }
 
 resource "aws_api_gateway_integration_response" "robots_txt_integration_response" {
-  count       = var.use_robots_txt ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.use_robots_txt && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.robots_txt_resource[0].id
   http_method = aws_api_gateway_method.robots_txt_method[0].http_method
 
@@ -685,19 +750,18 @@ EOF
 }
 
 resource "aws_api_gateway_resource" "orch_openid_configuration_resource" {
-  count       = var.orch_openid_configuration_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.orch_openid_configuration_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "openid-configuration"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource,
-    module.openid_configuration_discovery
   ]
 }
 
 resource "aws_api_gateway_method" "orch_openid_configuration_method" {
-  count       = var.orch_openid_configuration_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_openid_configuration_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_openid_configuration_resource[0].id
   http_method = "GET"
 
@@ -708,8 +772,8 @@ resource "aws_api_gateway_method" "orch_openid_configuration_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_openid_configuration_integration" {
-  count       = var.orch_openid_configuration_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_openid_configuration_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_openid_configuration_resource[0].id
   http_method = aws_api_gateway_method.orch_openid_configuration_method[0].http_method
   depends_on = [
@@ -721,14 +785,20 @@ resource "aws_api_gateway_integration" "orch_openid_configuration_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_trustmark_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "trustmark"
+}
+moved {
+  from = aws_api_gateway_resource.orch_trustmark_resource
+  to   = aws_api_gateway_resource.orch_trustmark_resource[0]
 }
 
 resource "aws_api_gateway_method" "orch_trustmark_method" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_trustmark_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_trustmark_resource[0].id
   http_method = "GET"
 
   depends_on = [
@@ -736,11 +806,16 @@ resource "aws_api_gateway_method" "orch_trustmark_method" {
   ]
   authorization = "NONE"
 }
+moved {
+  from = aws_api_gateway_method.orch_trustmark_method
+  to   = aws_api_gateway_method.orch_trustmark_method[0]
+}
 
 resource "aws_api_gateway_integration" "orch_trustmark_integration" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_trustmark_resource.id
-  http_method = aws_api_gateway_method.orch_trustmark_method.http_method
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_trustmark_resource[0].id
+  http_method = aws_api_gateway_method.orch_trustmark_method[0].http_method
   depends_on = [
     aws_api_gateway_resource.orch_trustmark_resource
   ]
@@ -750,18 +825,15 @@ resource "aws_api_gateway_integration" "orch_trustmark_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_doc_app_callback_resource" {
-  count       = var.orch_doc_app_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_doc_app_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "doc-app-callback"
-  depends_on = [
-    module.doc-app-callback
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_doc_app_callback_method" {
-  count       = var.orch_doc_app_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_doc_app_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_doc_app_callback_resource[0].id
   http_method = "GET"
 
@@ -772,8 +844,8 @@ resource "aws_api_gateway_method" "orch_doc_app_callback_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_doc_app_callback_integration" {
-  count       = var.orch_doc_app_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_doc_app_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_doc_app_callback_resource[0].id
   http_method = aws_api_gateway_method.orch_doc_app_callback_method[0].http_method
   depends_on = [
@@ -785,18 +857,15 @@ resource "aws_api_gateway_integration" "orch_doc_app_callback_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_token_resource" {
-  count       = var.orch_token_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_token_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "token"
-  depends_on = [
-    module.token
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_token_method" {
-  count       = var.orch_token_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_token_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_token_resource[0].id
   http_method = "POST"
 
@@ -807,8 +876,8 @@ resource "aws_api_gateway_method" "orch_token_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_token_integration" {
-  count       = var.orch_token_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_token_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_token_resource[0].id
   http_method = aws_api_gateway_method.orch_token_method[0].http_method
   depends_on = [
@@ -820,19 +889,18 @@ resource "aws_api_gateway_integration" "orch_token_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_jwks_resource" {
-  count       = var.orch_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.orch_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "jwks.json"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource,
-    module.jwks
   ]
 }
 
 resource "aws_api_gateway_method" "orch_jwks_method" {
-  count       = var.orch_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_jwks_resource[0].id
   http_method = "GET"
 
@@ -843,8 +911,8 @@ resource "aws_api_gateway_method" "orch_jwks_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_jwks_integration" {
-  count       = var.orch_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_jwks_resource[0].id
   http_method = aws_api_gateway_method.orch_jwks_method[0].http_method
   depends_on = [
@@ -856,18 +924,15 @@ resource "aws_api_gateway_integration" "orch_jwks_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_authorisation_resource" {
-  count       = var.orch_authorisation_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_authorisation_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "authorize"
-  depends_on = [
-    module.authorize
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_authorisation_method" {
-  for_each    = var.orch_authorisation_enabled ? toset(["GET"]) : []
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  for_each    = var.orch_authorisation_enabled && var.deploy_orch_lambda_and_api ? toset(["GET"]) : []
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_authorisation_resource[0].id
   http_method = each.key
 
@@ -878,18 +943,15 @@ resource "aws_api_gateway_method" "orch_authorisation_method" {
 }
 
 resource "aws_api_gateway_resource" "orch_auth_code_resource" {
-  count       = var.orch_auth_code_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_auth_code_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "auth-code"
-  depends_on = [
-    module.auth-code
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_auth_code_method" {
-  count       = var.orch_auth_code_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_auth_code_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_auth_code_resource[0].id
   http_method = "GET"
 
@@ -900,8 +962,8 @@ resource "aws_api_gateway_method" "orch_auth_code_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_authorisation_integration" {
-  for_each    = var.orch_authorisation_enabled ? toset(["GET"]) : []
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  for_each    = var.orch_authorisation_enabled && var.deploy_orch_lambda_and_api ? toset(["GET"]) : []
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_authorisation_resource[0].id
   http_method = aws_api_gateway_method.orch_authorisation_method[each.key].http_method
   depends_on = [
@@ -913,18 +975,15 @@ resource "aws_api_gateway_integration" "orch_authorisation_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_logout_resource" {
-  count       = var.orch_logout_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_logout_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "logout"
-  depends_on = [
-    module.logout
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_logout_method" {
-  count       = var.orch_logout_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_logout_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_logout_resource[0].id
   http_method = "GET"
 
@@ -935,8 +994,8 @@ resource "aws_api_gateway_method" "orch_logout_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_logout_integration" {
-  count       = var.orch_logout_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_logout_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_logout_resource[0].id
   http_method = aws_api_gateway_method.orch_logout_method[0].http_method
   depends_on = [
@@ -948,18 +1007,15 @@ resource "aws_api_gateway_integration" "orch_logout_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_ipv_callback_resource" {
-  count       = var.orch_ipv_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_ipv_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "ipv-callback"
-  depends_on = [
-    module.ipv-callback
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_ipv_callback_method" {
-  count       = var.orch_ipv_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_ipv_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_ipv_callback_resource[0].id
   http_method = "GET"
 
@@ -970,8 +1026,8 @@ resource "aws_api_gateway_method" "orch_ipv_callback_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_ipv_callback_integration" {
-  count       = var.orch_ipv_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_ipv_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_ipv_callback_resource[0].id
   http_method = aws_api_gateway_method.orch_ipv_callback_method[0].http_method
   depends_on = [
@@ -983,18 +1039,15 @@ resource "aws_api_gateway_integration" "orch_ipv_callback_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_register_resource" {
-  count       = var.orch_register_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.connect_resource.id
+  count       = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.connect_resource[0].id
   path_part   = "register"
-  depends_on = [
-    module.register
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_register_method" {
-  count            = var.orch_register_enabled ? 1 : 0
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  count            = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id      = aws_api_gateway_resource.orch_register_resource[0].id
   http_method      = "POST"
   api_key_required = true
@@ -1006,8 +1059,8 @@ resource "aws_api_gateway_method" "orch_register_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_register_integration" {
-  count       = var.orch_register_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_register_resource[0].id
   http_method = aws_api_gateway_method.orch_register_method[0].http_method
   depends_on = [
@@ -1019,18 +1072,15 @@ resource "aws_api_gateway_integration" "orch_register_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_update_client_resource" {
-  count       = var.orch_register_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   parent_id   = aws_api_gateway_resource.orch_register_resource[0].id
   path_part   = "{clientId}"
-  depends_on = [
-    module.update
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_update_client_method" {
-  count              = var.orch_register_enabled ? 1 : 0
-  rest_api_id        = aws_api_gateway_rest_api.di_authentication_api.id
+  count              = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id        = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id        = aws_api_gateway_resource.orch_update_client_resource[0].id
   http_method        = "PUT"
   api_key_required   = true
@@ -1043,8 +1093,8 @@ resource "aws_api_gateway_method" "orch_update_client_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_update_client_integration" {
-  count       = var.orch_register_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_register_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_update_client_resource[0].id
   http_method = aws_api_gateway_method.orch_update_client_method[0].http_method
   depends_on = [
@@ -1057,18 +1107,15 @@ resource "aws_api_gateway_integration" "orch_update_client_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_authentication_callback_resource" {
-  count       = var.orch_authentication_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_authentication_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "orchestration-redirect"
-  depends_on = [
-    module.authentication_callback
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_authentication_callback_method" {
-  count       = var.orch_authentication_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_authentication_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_authentication_callback_resource[0].id
   http_method = "GET"
 
@@ -1079,8 +1126,8 @@ resource "aws_api_gateway_method" "orch_authentication_callback_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_authentication_callback_integration" {
-  count       = var.orch_authentication_callback_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_authentication_callback_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_authentication_callback_resource[0].id
   http_method = aws_api_gateway_method.orch_authentication_callback_method[0].http_method
   depends_on = [
@@ -1092,8 +1139,8 @@ resource "aws_api_gateway_integration" "orch_authentication_callback_integration
 }
 
 resource "aws_api_gateway_integration" "orch_auth_code_integration" {
-  count       = var.orch_auth_code_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_auth_code_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_auth_code_resource[0].id
   http_method = aws_api_gateway_method.orch_auth_code_method[0].http_method
   depends_on = [
@@ -1106,18 +1153,15 @@ resource "aws_api_gateway_integration" "orch_auth_code_integration" {
 
 
 resource "aws_api_gateway_resource" "orch_userinfo_resource" {
-  count       = var.orch_userinfo_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  count       = var.orch_userinfo_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   path_part   = "userinfo"
-  depends_on = [
-    module.userinfo
-  ]
 }
 
 resource "aws_api_gateway_method" "orch_userinfo_method" {
-  count       = var.orch_userinfo_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_userinfo_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_userinfo_resource[0].id
   http_method = "GET"
 
@@ -1128,8 +1172,8 @@ resource "aws_api_gateway_method" "orch_userinfo_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_userinfo_integration" {
-  count       = var.orch_userinfo_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_userinfo_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_userinfo_resource[0].id
   http_method = aws_api_gateway_method.orch_userinfo_method[0].http_method
   depends_on = [
@@ -1141,19 +1185,18 @@ resource "aws_api_gateway_integration" "orch_userinfo_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_storage_token_jwk_resource" {
-  count       = var.orch_storage_token_jwk_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.orch_storage_token_jwk_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "storage-token-jwk.json"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource,
-    module.storage_token_jwk
   ]
 }
 
 resource "aws_api_gateway_method" "orch_storage_token_jwk_method" {
-  count       = var.orch_storage_token_jwk_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_storage_token_jwk_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_storage_token_jwk_resource[0].id
   http_method = "GET"
 
@@ -1164,8 +1207,8 @@ resource "aws_api_gateway_method" "orch_storage_token_jwk_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_storage_token_jwk_integration" {
-  count       = var.orch_storage_token_jwk_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_storage_token_jwk_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_storage_token_jwk_resource[0].id
   http_method = aws_api_gateway_method.orch_storage_token_jwk_method[0].http_method
   depends_on = [
@@ -1177,9 +1220,9 @@ resource "aws_api_gateway_integration" "orch_storage_token_jwk_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_ipv_jwks_resource" {
-  count       = var.orch_ipv_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.orch_ipv_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "ipv-jwks.json"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource
@@ -1187,8 +1230,8 @@ resource "aws_api_gateway_resource" "orch_ipv_jwks_resource" {
 }
 
 resource "aws_api_gateway_method" "orch_ipv_jwks_method" {
-  count       = var.orch_ipv_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_ipv_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_ipv_jwks_resource[0].id
   http_method = "GET"
 
@@ -1199,8 +1242,8 @@ resource "aws_api_gateway_method" "orch_ipv_jwks_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_ipv_jwks_integration" {
-  count       = var.orch_ipv_jwks_enabled ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  count       = var.orch_ipv_jwks_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
   resource_id = aws_api_gateway_resource.orch_ipv_jwks_resource[0].id
   http_method = aws_api_gateway_method.orch_ipv_jwks_method[0].http_method
   depends_on = [
@@ -1212,17 +1255,23 @@ resource "aws_api_gateway_integration" "orch_ipv_jwks_integration" {
 }
 
 resource "aws_api_gateway_resource" "orch_auth_jwks_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "auth-jwks.json"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource
   ]
 }
+moved {
+  from = aws_api_gateway_resource.orch_auth_jwks_resource
+  to   = aws_api_gateway_resource.orch_auth_jwks_resource[0]
+}
 
 resource "aws_api_gateway_method" "orch_auth_jwks_method" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_auth_jwks_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_auth_jwks_resource[0].id
   http_method = "GET"
 
   depends_on = [
@@ -1230,11 +1279,16 @@ resource "aws_api_gateway_method" "orch_auth_jwks_method" {
   ]
   authorization = "NONE"
 }
+moved {
+  from = aws_api_gateway_method.orch_auth_jwks_method
+  to   = aws_api_gateway_method.orch_auth_jwks_method[0]
+}
 
 resource "aws_api_gateway_integration" "orch_auth_jwks_integration" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_auth_jwks_resource.id
-  http_method = aws_api_gateway_method.orch_auth_jwks_method.http_method
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_auth_jwks_resource[0].id
+  http_method = aws_api_gateway_method.orch_auth_jwks_method[0].http_method
   depends_on = [
     aws_api_gateway_resource.orch_auth_jwks_resource
   ]
@@ -1242,19 +1296,29 @@ resource "aws_api_gateway_integration" "orch_auth_jwks_integration" {
   integration_http_method = "POST"
   uri                     = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:${var.orch_account_id}:function:${local.secure_pipelines_environment}-AuthJwksFunction:latest/invocations"
 }
+moved {
+  from = aws_api_gateway_integration.orch_auth_jwks_integration
+  to   = aws_api_gateway_integration.orch_auth_jwks_integration[0]
+}
 
 resource "aws_api_gateway_resource" "orch_sis_jwks_resource" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  parent_id   = aws_api_gateway_resource.wellknown_resource[0].id
   path_part   = "sis-jwks.json"
   depends_on = [
     aws_api_gateway_resource.wellknown_resource
   ]
 }
+moved {
+  from = aws_api_gateway_resource.orch_sis_jwks_resource
+  to   = aws_api_gateway_resource.orch_sis_jwks_resource[0]
+}
 
 resource "aws_api_gateway_method" "orch_sis_jwks_method" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource.id
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource[0].id
   http_method = "GET"
 
   depends_on = [
@@ -1262,15 +1326,25 @@ resource "aws_api_gateway_method" "orch_sis_jwks_method" {
   ]
   authorization = "NONE"
 }
+moved {
+  from = aws_api_gateway_method.orch_sis_jwks_method
+  to   = aws_api_gateway_method.orch_sis_jwks_method[0]
+}
+
 
 resource "aws_api_gateway_integration" "orch_sis_jwks_integration" {
-  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource.id
-  http_method = aws_api_gateway_method.orch_sis_jwks_method.http_method
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api[0].id
+  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource[0].id
+  http_method = aws_api_gateway_method.orch_sis_jwks_method[0].http_method
   depends_on = [
     aws_api_gateway_resource.orch_sis_jwks_resource
   ]
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
   uri                     = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:${var.orch_account_id}:function:${local.secure_pipelines_environment}-SISJwksFunction:latest/invocations"
+}
+moved {
+  from = aws_api_gateway_integration.orch_sis_jwks_integration
+  to   = aws_api_gateway_integration.orch_sis_jwks_integration[0]
 }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -44,9 +44,9 @@ module "auth-code" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -1,4 +1,5 @@
 module "oidc_auth_code_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-auth-code-role"
@@ -20,8 +21,14 @@ module "oidc_auth_code_role" {
   }
 }
 
+moved {
+  from = module.oidc_auth_code_role
+  to   = module.oidc_auth_code_role[0]
+}
+
 module "auth-code" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "auth-code"
   path_part       = var.orch_auth_code_enabled ? "auth-code-auth" : "auth-code"
@@ -52,7 +59,7 @@ module "auth-code" {
   ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
 
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_auth_code_role.arn
+  lambda_role_arn                        = module.oidc_auth_code_role[0].arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
@@ -68,4 +75,8 @@ module "auth-code" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.auth-code
+  to   = module.auth-code[0]
 }

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -83,3 +83,4 @@ oidc_cloudfront_enabled = false
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
 use_strongly_consistent_reads           = true
+deploy_orch_lambda_and_api              = false

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -81,3 +81,4 @@ oidc_cloudfront_enabled = false
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
 use_strongly_consistent_reads           = true
+deploy_orch_lambda_and_api              = false

--- a/ci/terraform/oidc/authdev3.tfvars
+++ b/ci/terraform/oidc/authdev3.tfvars
@@ -96,4 +96,5 @@ orch_client_registry_table_encryption_key_arn      = "arn:aws:kms:eu-west-2:8160
 
 cmk_for_back_channel_logout_enabled = true
 
-auth_new_account_id = "975050272416"
+auth_new_account_id        = "975050272416"
+deploy_orch_lambda_and_api = false

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -1,4 +1,5 @@
 module "oidc_api_authentication_callback_role_1" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-api-authentication-callback-role"
@@ -18,8 +19,13 @@ module "oidc_api_authentication_callback_role_1" {
     Service = "orchestration-redirect"
   }
 }
+moved {
+  from = module.oidc_api_authentication_callback_role_1
+  to   = module.oidc_api_authentication_callback_role_1[0]
+}
 
 module "authentication_callback" {
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   endpoint_name   = "orchestration-redirect"
@@ -68,7 +74,7 @@ module "authentication_callback" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_api_authentication_callback_role_1.arn
+  lambda_role_arn                        = module.oidc_api_authentication_callback_role_1[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -82,4 +88,8 @@ module "authentication_callback" {
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api
   ]
+}
+moved {
+  from = module.authentication_callback
+  to   = module.authentication_callback[0]
 }

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -59,9 +59,9 @@ module "authentication_callback" {
 
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -65,9 +65,9 @@ module "authorize" {
     USE_STRONGLY_CONSISTENT_READS        = var.use_strongly_consistent_reads
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
-  rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id           = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id      = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn         = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
 
   lambda_error_rate_alarm_disabled = true
   memory_size                      = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -1,4 +1,5 @@
 module "oidc_authorize_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-authorize-role"
@@ -23,9 +24,14 @@ module "oidc_authorize_role" {
     Service = "authorize"
   }
 }
+moved {
+  from = module.oidc_authorize_role
+  to   = module.oidc_authorize_role[0]
+}
 
 module "authorize" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "authorize"
   path_part       = var.orch_authorisation_enabled ? "authorize-auth" : "authorize"
@@ -80,7 +86,7 @@ module "authorize" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = var.authorize_protected_subnet_enabled ? local.authentication_protected_subnet_ids : local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_authorize_role.arn
+  lambda_role_arn                        = module.oidc_authorize_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -95,4 +101,8 @@ module "authorize" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.authorize
+  to   = module.authorize[0]
 }

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -1,4 +1,5 @@
 module "backchannel_logout_request_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "backchannel-logout-request-role"
@@ -11,10 +12,15 @@ module "backchannel_logout_request_role" {
     Service = "backchannel-logout-request"
   }
 }
+moved {
+  from = module.backchannel_logout_request_role
+  to   = module.backchannel_logout_request_role[0]
+}
 
 resource "aws_lambda_function" "backchannel_logout_request_lambda" {
+  count         = var.deploy_orch_lambda_and_api ? 1 : 0
   function_name = "${var.environment}-backchannel-logout-request-lambda"
-  role          = module.backchannel_logout_request_role.arn
+  role          = module.backchannel_logout_request_role[0].arn
   handler       = "uk.gov.di.authentication.oidc.lambda.BackChannelLogoutRequestHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
@@ -39,9 +45,14 @@ resource "aws_lambda_function" "backchannel_logout_request_lambda" {
     Service = "backchannel-logout-request"
   }
 }
+moved {
+  from = aws_lambda_function.backchannel_logout_request_lambda
+  to   = aws_lambda_function.backchannel_logout_request_lambda[0]
+}
 
 resource "aws_cloudwatch_log_group" "backchannel_logout_request_lambda_log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.backchannel_logout_request_lambda.function_name}"
+  count             = var.deploy_orch_lambda_and_api ? 1 : 0
+  name              = "/aws/lambda/${aws_lambda_function.backchannel_logout_request_lambda[0].function_name}"
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   retention_in_days = var.cloudwatch_log_retention
 
@@ -49,12 +60,16 @@ resource "aws_cloudwatch_log_group" "backchannel_logout_request_lambda_log_group
     aws_lambda_function.backchannel_logout_request_lambda
   ]
 }
+moved {
+  from = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group
+  to   = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group[0]
+}
 
 
 resource "aws_cloudwatch_log_subscription_filter" "backchannel_logout_request_lambda_log_subscription" {
-  count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.backchannel_logout_request_lambda.function_name}-log-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group.name
+  count           = var.deploy_orch_lambda_and_api ? length(var.logging_endpoint_arns) : 0
+  name            = "${aws_lambda_function.backchannel_logout_request_lambda[0].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
@@ -62,17 +77,27 @@ resource "aws_cloudwatch_log_subscription_filter" "backchannel_logout_request_la
     create_before_destroy = false
   }
 }
+moved {
+  from = aws_cloudwatch_log_subscription_filter.backchannel_logout_request_lambda_log_subscription
+  to   = aws_cloudwatch_log_subscription_filter.backchannel_logout_request_lambda_log_subscription[0]
+}
 
 resource "aws_lambda_alias" "backchannel_logout_request_lambda_active" {
-  name             = "${aws_lambda_function.backchannel_logout_request_lambda.function_name}-active"
+  count            = var.deploy_orch_lambda_and_api ? 1 : 0
+  name             = "${aws_lambda_function.backchannel_logout_request_lambda[0].function_name}-active"
   description      = "Alias pointing at active version of Lambda"
-  function_name    = aws_lambda_function.backchannel_logout_request_lambda.arn
-  function_version = aws_lambda_function.backchannel_logout_request_lambda.version
+  function_name    = aws_lambda_function.backchannel_logout_request_lambda[0].arn
+  function_version = aws_lambda_function.backchannel_logout_request_lambda[0].version
+}
+moved {
+  from = aws_lambda_alias.backchannel_logout_request_lambda_active
+  to   = aws_lambda_alias.backchannel_logout_request_lambda_active[0]
 }
 
 resource "aws_lambda_event_source_mapping" "backchannel_logout_lambda_sqs_mapping" {
+  count            = var.deploy_orch_lambda_and_api ? 1 : 0
   event_source_arn = aws_sqs_queue.back_channel_logout_queue.arn
-  function_name    = aws_lambda_function.backchannel_logout_request_lambda.arn
+  function_name    = aws_lambda_function.backchannel_logout_request_lambda[0].arn
 
   depends_on = [
     aws_sqs_queue.back_channel_logout_queue,
@@ -81,4 +106,8 @@ resource "aws_lambda_event_source_mapping" "backchannel_logout_lambda_sqs_mappin
   tags = {
     Service = "backchannel-logout-request"
   }
+}
+moved {
+  from = aws_lambda_event_source_mapping.backchannel_logout_lambda_sqs_mapping
+  to   = aws_lambda_event_source_mapping.backchannel_logout_lambda_sqs_mapping[0]
 }

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -110,3 +110,4 @@ performance_tuning = {
 use_strongly_consistent_reads  = true
 support_reauth_signout_enabled = true
 deploy_oidc_api_gateway_domain = false
+deploy_orch_lambda_and_api     = false

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -1,4 +1,5 @@
 module "doc_app_callback_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "doc-app-callback-role"
@@ -16,8 +17,13 @@ module "doc_app_callback_role" {
     Service = "doc-app-callback"
   }
 }
+moved {
+  from = module.doc_app_callback_role
+  to   = module.doc_app_callback_role[0]
+}
 
 module "doc-app-callback" {
+  count           = var.deploy_orch_lambda_and_api ? 1 : 0
   source          = "../modules/endpoint-module-v2"
   endpoint_name   = "doc-app-callback"
   path_part       = var.orch_doc_app_callback_enabled ? "doc-app-callback-auth" : "doc-app-callback"
@@ -60,7 +66,7 @@ module "doc-app-callback" {
     local.authentication_egress_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.doc_app_callback_role.arn
+  lambda_role_arn                        = module.doc_app_callback_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -75,4 +81,8 @@ module "doc-app-callback" {
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,
   ]
+}
+moved {
+  from = module.doc-app-callback
+  to   = module.doc-app-callback[0]
 }

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -51,9 +51,9 @@ module "doc-app-callback" {
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest"
 
   create_endpoint  = true
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -60,9 +60,9 @@ module "ipv-callback" {
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 
   create_endpoint  = true
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,4 +1,5 @@
 module "ipv_callback_role_2" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "ipv-callback-role"
@@ -22,9 +23,14 @@ module "ipv_callback_role_2" {
     Service = "ipv-callback"
   }
 }
+moved {
+  from = module.ipv_callback_role_2
+  to   = module.ipv_callback_role_2[0]
+}
 
 module "ipv-callback" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "ipv-callback"
   path_part       = var.orch_ipv_callback_enabled ? "ipv-callback-auth" : "ipv-callback"
@@ -69,7 +75,7 @@ module "ipv-callback" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.ipv_callback_role_2.arn
+  lambda_role_arn                        = module.ipv_callback_role_2[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -84,4 +90,8 @@ module "ipv-callback" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.ipv-callback
+  to   = module.ipv-callback[0]
 }

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -1,4 +1,5 @@
 module "ipv_capacity_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "ipv-capacity-role"
@@ -14,9 +15,14 @@ module "ipv_capacity_role" {
     Service = "ipv-capacity"
   }
 }
+moved {
+  from = module.ipv_capacity_role
+  to   = module.ipv_capacity_role[0]
+}
 
 module "ipv-capacity" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "ipv-capacity"
   path_part       = "ipv-capacity"
@@ -54,7 +60,7 @@ module "ipv-capacity" {
   ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
 
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.ipv_capacity_role.arn
+  lambda_role_arn                        = module.ipv_capacity_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -69,4 +75,8 @@ module "ipv-capacity" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.ipv-capacity
+  to   = module.ipv-capacity[0]
 }

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -41,9 +41,9 @@ module "ipv-capacity" {
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
 
   create_endpoint  = true
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
 
   memory_size                 = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).memory
   provisioned_concurrency     = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).concurrency

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -1,5 +1,6 @@
 data "aws_cloudwatch_log_group" "ipv_callback_lambda_log_group" {
-  name = replace("/aws/lambda/${var.environment}-ipv-callback-lambda", ".", "")
+  count = var.deploy_orch_lambda_and_api ? 1 : 0
+  name  = replace("/aws/lambda/${var.environment}-ipv-callback-lambda", ".", "")
 
   depends_on = [
     module.ipv-callback
@@ -8,7 +9,8 @@ data "aws_cloudwatch_log_group" "ipv_callback_lambda_log_group" {
 
 
 data "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
-  name = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
+  count = var.deploy_orch_lambda_and_api ? 1 : 0
+  name  = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
   depends_on = [
     module.ipv_spot_response_role_2
   ]
@@ -25,9 +27,10 @@ data "aws_cloudwatch_log_group" "processing_identity_lambda_log_group" {
 
 
 resource "aws_cloudwatch_log_metric_filter" "ipv_callback_metric_filter" {
+  count          = var.deploy_orch_lambda_and_api ? 1 : 0
   name           = replace("${var.environment}-ipv-callback-p1-errors", ".", "")
   pattern        = "{($.level = \"ERROR\")}"
-  log_group_name = data.aws_cloudwatch_log_group.ipv_callback_lambda_log_group.name
+  log_group_name = data.aws_cloudwatch_log_group.ipv_callback_lambda_log_group[0].name
 
   metric_transformation {
     name      = replace("${var.environment}-ipv-handback-error-count", ".", "")
@@ -38,9 +41,10 @@ resource "aws_cloudwatch_log_metric_filter" "ipv_callback_metric_filter" {
 
 
 resource "aws_cloudwatch_log_metric_filter" "spot_response_metric_filter" {
+  count          = var.deploy_orch_lambda_and_api ? 1 : 0
   name           = replace("${var.environment}-spot-response-p1-errors", ".", "")
   pattern        = "{($.level = \"ERROR\")}"
-  log_group_name = data.aws_cloudwatch_log_group.spot_response_lambda_log_group.name
+  log_group_name = data.aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
 
   metric_transformation {
     name      = replace("${var.environment}-ipv-handback-error-count", ".", "")

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -38,9 +38,9 @@ module "jwks" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_resource.wellknown_resource.id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_resource.wellknown_resource[0].id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -1,4 +1,5 @@
 module "oidc_jwks_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-jwks-role"
@@ -12,8 +13,13 @@ module "oidc_jwks_role" {
     Service = "jwks.json"
   }
 }
+moved {
+  from = module.oidc_jwks_role
+  to   = module.oidc_jwks_role[0]
+}
 
 module "jwks" {
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   endpoint_name           = "jwks.json"
@@ -44,7 +50,7 @@ module "jwks" {
 
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_jwks_role.arn
+  lambda_role_arn                        = module.oidc_jwks_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -59,4 +65,8 @@ module "jwks" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.jwks
+  to   = module.jwks[0]
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -48,9 +48,9 @@ module "logout" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -1,5 +1,6 @@
 module "oidc_logout_role" {
   source      = "../modules/lambda-role"
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   environment = var.environment
   role_name   = "oidc-logout-role"
   vpc_arn     = local.authentication_vpc_arn
@@ -20,9 +21,14 @@ module "oidc_logout_role" {
     Service = "logout"
   }
 }
+moved {
+  from = module.oidc_logout_role
+  to   = module.oidc_logout_role[0]
+}
 
 module "logout" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "logout"
   path_part       = var.orch_logout_enabled ? "logout-auth" : "logout"
@@ -57,7 +63,7 @@ module "logout" {
   ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
 
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_logout_role.arn
+  lambda_role_arn                        = module.oidc_logout_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -72,4 +78,8 @@ module "logout" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.logout
+  to   = module.logout[0]
 }

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -7,7 +7,7 @@ output "frontend_api_base_url" {
 }
 
 output "api_gateway_root_id" {
-  value = aws_api_gateway_rest_api.di_authentication_api.id
+  value = aws_api_gateway_rest_api.di_authentication_api[0].id
 }
 
 output "frontend_api_gateway_root_id" {

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -7,7 +7,7 @@ output "frontend_api_base_url" {
 }
 
 output "api_gateway_root_id" {
-  value = aws_api_gateway_rest_api.di_authentication_api[0].id
+  value = var.deploy_orch_lambda_and_api ? aws_api_gateway_rest_api.di_authentication_api[0].id : null
 }
 
 output "frontend_api_gateway_root_id" {

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -38,9 +38,9 @@ module "register" {
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler::handleRequest"
 
   create_endpoint  = false
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_resource.register_resource.id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_resource.register_resource[0].id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -1,4 +1,5 @@
 module "client_registry_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "client-registry-role"
@@ -16,9 +17,13 @@ module "client_registry_role" {
     Service = "register"
   }
 }
+moved {
+  from = module.client_registry_role
+  to   = module.client_registry_role[0]
+}
 
 module "register" {
-  count  = var.client_registry_api_enabled ? 1 : 0
+  count  = var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   endpoint_name   = "register"
@@ -45,7 +50,7 @@ module "register" {
 
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.client_registry_role.arn
+  lambda_role_arn                        = module.client_registry_role[0].arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,4 +1,5 @@
 module "ipv_spot_response_role_2" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "ipv-spot-response-role"
@@ -17,6 +18,10 @@ module "ipv_spot_response_role_2" {
   extra_tags = {
     Service = "spot-response"
   }
+}
+moved {
+  from = module.ipv_spot_response_role_2
+  to   = module.ipv_spot_response_role_2[0]
 }
 
 data "aws_iam_policy_document" "spot_response_policy_document" {
@@ -63,10 +68,10 @@ resource "aws_iam_policy" "spot_response_sqs_read_policy" {
 }
 
 resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
-  count            = var.spot_enabled ? 1 : 0
+  count            = var.spot_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   enabled          = !var.auth_spot_response_disabled
   event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
-  function_name    = aws_lambda_function.spot_response_lambda.arn
+  function_name    = aws_lambda_function.spot_response_lambda[0].arn
   batch_size       = 1
 
   depends_on = [
@@ -77,10 +82,15 @@ resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
     Service = "spot-response"
   }
 }
+moved {
+  from = aws_lambda_event_source_mapping.spot_response_lambda_sqs_mapping
+  to   = aws_lambda_event_source_mapping.spot_response_lambda_sqs_mapping[0]
+}
 
 resource "aws_lambda_function" "spot_response_lambda" {
+  count         = var.deploy_orch_lambda_and_api ? 1 : 0
   function_name = "${var.environment}-spot-response-lambda"
-  role          = module.ipv_spot_response_role_2.arn
+  role          = module.ipv_spot_response_role_2[0].arn
   handler       = "uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
@@ -111,9 +121,14 @@ resource "aws_lambda_function" "spot_response_lambda" {
     Service = "spot-response"
   }
 }
+moved {
+  from = aws_lambda_function.spot_response_lambda
+  to   = aws_lambda_function.spot_response_lambda[0]
+}
 
 resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.spot_response_lambda.function_name}"
+  count             = var.deploy_orch_lambda_and_api ? 1 : 0
+  name              = "/aws/lambda/${aws_lambda_function.spot_response_lambda[0].function_name}"
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   retention_in_days = var.cloudwatch_log_retention
 
@@ -121,11 +136,16 @@ resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
     aws_lambda_function.spot_response_lambda
   ]
 }
+moved {
+  from = aws_cloudwatch_log_group.spot_response_lambda_log_group
+  to   = aws_cloudwatch_log_group.spot_response_lambda_log_group[0]
+}
+
 
 resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subscription" {
-  count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.spot_response_lambda.function_name}-log-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group.name
+  count           = var.deploy_orch_lambda_and_api ? length(var.logging_endpoint_arns) : 0
+  name            = "${aws_lambda_function.spot_response_lambda[0].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
@@ -135,8 +155,13 @@ resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subs
 }
 
 resource "aws_lambda_alias" "spot_response_lambda_active" {
-  name             = "${aws_lambda_function.spot_response_lambda.function_name}-active"
+  count            = var.deploy_orch_lambda_and_api ? 1 : 0
+  name             = "${aws_lambda_function.spot_response_lambda[0].function_name}-active"
   description      = "Alias pointing at active version of Lambda"
-  function_name    = aws_lambda_function.spot_response_lambda.arn
-  function_version = aws_lambda_function.spot_response_lambda.version
+  function_name    = aws_lambda_function.spot_response_lambda[0].arn
+  function_version = aws_lambda_function.spot_response_lambda[0].version
+}
+moved {
+  from = aws_lambda_alias.spot_response_lambda_active
+  to   = aws_lambda_alias.spot_response_lambda_active[0]
 }

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -36,9 +36,9 @@ module "storage_token_jwk" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.StorageTokenJwkHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_resource.wellknown_resource.id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_resource.wellknown_resource[0].id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -1,4 +1,5 @@
 module "oidc_storage_token_jwk_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-storage-token-jwk-role"
@@ -11,9 +12,14 @@ module "oidc_storage_token_jwk_role" {
     Service = "storage-token-jwk.json"
   }
 }
+moved {
+  from = module.oidc_storage_token_jwk_role
+  to   = module.oidc_storage_token_jwk_role[0]
+}
 
 module "storage_token_jwk" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name           = "storage-token-jwk.json"
   endpoint_name_sanitized = "storage-token-jwkjson"
@@ -42,7 +48,7 @@ module "storage_token_jwk" {
 
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_storage_token_jwk_role.arn
+  lambda_role_arn                        = module.oidc_storage_token_jwk_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -57,4 +63,8 @@ module "storage_token_jwk" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.storage_token_jwk
+  to   = module.storage_token_jwk[0]
 }

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -79,9 +79,9 @@ module "token" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "oidc_token_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-token"
@@ -23,6 +24,10 @@ module "oidc_token_role" {
   extra_tags = {
     Service = local.oidc_token_endpoint_name
   }
+}
+moved {
+  from = module.oidc_token_role
+  to   = module.oidc_token_role[0]
 }
 
 data "aws_iam_policy_document" "kms_signing_policy_document" {
@@ -53,6 +58,7 @@ resource "aws_iam_policy" "oidc_token_kms_signing_policy" {
 }
 
 module "token" {
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   endpoint_name   = local.oidc_token_endpoint_name
@@ -88,7 +94,7 @@ module "token" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_token_role.arn
+  lambda_role_arn                        = module.oidc_token_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -103,4 +109,8 @@ module "token" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.token
+  to   = module.token[0]
 }

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -39,9 +39,9 @@ module "update" {
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_resource.register_resource.id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_resource.register_resource[0].id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
 
   memory_size                 = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).memory
   provisioned_concurrency     = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).concurrency

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -1,4 +1,5 @@
 module "client_update_role" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "client-update-role"
@@ -16,9 +17,13 @@ module "client_update_role" {
     Service = "update-client-info"
   }
 }
+moved {
+  from = module.client_update_role
+  to   = module.client_update_role[0]
+}
 
 module "update" {
-  count  = var.client_registry_api_enabled ? 1 : 0
+  count  = var.client_registry_api_enabled && var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   path_part                      = "{clientId}"
@@ -53,7 +58,7 @@ module "update" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.client_update_role.arn
+  lambda_role_arn                        = module.client_update_role[0].arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -48,9 +48,9 @@ module "userinfo" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,4 +1,5 @@
 module "oidc_userinfo_role_2" {
+  count       = var.deploy_orch_lambda_and_api ? 1 : 0
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-userinfo-role"
@@ -19,9 +20,15 @@ module "oidc_userinfo_role_2" {
     Service = "userinfo"
   }
 }
+moved {
+  from = module.oidc_userinfo_role_2
+  to   = module.oidc_userinfo_role_2[0]
+}
+
 
 module "userinfo" {
   source = "../modules/endpoint-module-v2"
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "userinfo"
   path_part       = var.orch_userinfo_enabled ? "userinfo-auth" : "userinfo"
@@ -56,7 +63,7 @@ module "userinfo" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_userinfo_role_2.arn
+  lambda_role_arn                        = module.oidc_userinfo_role_2[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -71,4 +78,8 @@ module "userinfo" {
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]
+}
+moved {
+  from = module.userinfo
+  to   = module.userinfo[0]
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -742,3 +742,8 @@ variable "deploy_oidc_api_gateway_domain" {
   type    = bool
   default = true
 }
+
+variable "deploy_orch_lambda_and_api" {
+  type    = bool
+  default = true
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -223,10 +223,6 @@ variable "shared_state_bucket" {
   default = "digital-identity-dev-tfstate"
 }
 
-variable "contra_state_bucket" {
-  type = string
-}
-
 variable "cloudwatch_log_retention" {
   default     = 30
   type        = number

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -35,9 +35,9 @@ module "openid_configuration_discovery" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest"
 
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id = aws_api_gateway_resource.wellknown_resource.id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
+  root_resource_id = aws_api_gateway_resource.wellknown_resource[0].id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn
   memory_size      = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "openid_configuration_role" {
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/lambda-role"
 
   role_name   = "openid-configuration"
@@ -12,8 +13,14 @@ module "openid_configuration_role" {
     Service = local.openid_configuration_endpoint_name
   }
 }
+moved {
+  from = module.openid_configuration_role
+  to   = module.openid_configuration_role[0]
+}
+
 
 module "openid_configuration_discovery" {
+  count  = var.deploy_orch_lambda_and_api ? 1 : 0
   source = "../modules/endpoint-module-v2"
 
   endpoint_name   = local.openid_configuration_endpoint_name
@@ -40,7 +47,7 @@ module "openid_configuration_discovery" {
 
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.openid_configuration_role.arn
+  lambda_role_arn                        = module.openid_configuration_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
@@ -57,4 +64,8 @@ module "openid_configuration_discovery" {
     module.openid_configuration_role,
 
   ]
+}
+moved {
+  from = module.openid_configuration_discovery
+  to   = module.openid_configuration_discovery[0]
 }

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -23,6 +23,7 @@ Options:
     -u, --utils                 deploy the utils API. (default: false)
     -s, --shared                deploy the shared Terraform configuration. (default: true)
     -t, --test-services         deploy the test services API. (default: false)
+     -o, --oidc                 deploy the OIDC API. (default: true)
 
 Arguments:
     environment                 the environment to deploy to. Valid environments are: ${environments[*]}
@@ -36,6 +37,7 @@ O_SHELL=0   # --shell
 O_REFRESH=0 # -r, --refresh-only
 
 T_ACCOUNT_MANAGEMENT=0 # -a, --account-management
+T_OIDC=0               # -o, --oidc
 T_UTILS=0              # -u, --utils
 T_SHARED=0             # -s, --shared
 T_TEST_SERVICE=0       # -t, --test-services
@@ -56,6 +58,7 @@ while (($#)); do
     -r | --refresh-only) O_REFRESH=1 ;;
 
     -a | --account-management) T_ACCOUNT_MANAGEMENT=1 NUMBER_PICKED=$((NUMBER_PICKED + 1)) ;;
+    -o | --oidc) T_OIDC=1 NUMBER_PICKED=$((NUMBER_PICKED + 1)) ;;
     -u | --utils) T_UTILS=1 NUMBER_PICKED=$((NUMBER_PICKED + 1)) ;;
     -s | --shared) T_SHARED=1 NUMBER_PICKED=$((NUMBER_PICKED + 1)) ;;
     -t | --test-services) T_TEST_SERVICE=1 NUMBER_PICKED=$((NUMBER_PICKED + 1)) ;;
@@ -102,6 +105,7 @@ if [[ ${NUMBER_PICKED} -eq 0 ]]; then
   O_BUILD=1
   T_ACCOUNT_MANAGEMENT=1
   T_SHARED=1
+  T_OIDC=1
 fi
 
 if [[ ${O_BUILD} -eq 1 ]]; then
@@ -162,4 +166,8 @@ fi
 
 if [[ ${T_TEST_SERVICE} -eq 1 ]]; then
   run_terraform "test-services"
+fi
+
+if [[ ${T_OIDC} -eq 1 ]]; then
+  run_terraform "oidc"
 fi


### PR DESCRIPTION
## What
Orchestration have moved to an API Gateway in their account, meaning the OIDC API Gateway here is now unused, alongside with all the lambdas integrated with it. We would like to clean this up, and remove the redundant resources from the old terraform. To do this, we will do it per environment to safely roll this out. We do this by adding a feature flag, defaulted to true, so the current state is preserved until actively turned off.

## How to review:
- Review commit-by-commit
- Deployed to authdev3 with the flag set to true (basically a no-op) in the relevant env to ensure the `count`s added here do not recreate any resource:
    -  Plan: 1 to add, 2 to change, 1 to destroy - only updated resources were forcing a new API Gateway deployment (expected)
- Deploy with the flag set to false (remove the lambdas and API Gateway) and observe all the lambdas and API Gateway resources are removed:
    - Plan: 0 to add, 1 to change, 469 to destroy.
    - Apply complete! Resources: 0 added, 1 changed, 469 destroyed.
- Both sides of the feature flag deploy cleanly

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [X] PR is canary deploy safe: This infra is no longer used and does not affect canaries

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Assessed the impact on active user sessions and confirmed no breaking changes: Again this infra is unused but checking that the "flag off" state should not trigger any resource changes 

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [X] A UCD review has been performed (or no review required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
