### PR TITLE
AUT-5796: Move count alarms to authentication-notifications channel

### DIFF
--- a/ci/cloudformation/auth/function/account-recovery.yaml
+++ b/ci/cloudformation/auth/function/account-recovery.yaml
@@ -107,7 +107,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-account-recovery-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/amc-callback.yaml
+++ b/ci/cloudformation/auth/function/amc-callback.yaml
@@ -126,7 +126,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-amc-callback-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/check-email-fraud-block.yaml
+++ b/ci/cloudformation/auth/function/check-email-fraud-block.yaml
@@ -123,7 +123,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-check-email-fraud-block-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -129,7 +129,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-check-reauth-user-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -143,7 +143,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-finish-passkey-assertion-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/id-reverification-state.yaml
+++ b/ci/cloudformation/auth/function/id-reverification-state.yaml
@@ -85,7 +85,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-id-reverification-state-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
@@ -180,7 +180,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-mfa-reset-authorize-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
@@ -91,7 +91,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-mfa-reset-jar-jwk-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
@@ -110,7 +110,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-mfa-reset-storage-token-jwk-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/mfa.yaml
+++ b/ci/cloudformation/auth/function/mfa.yaml
@@ -160,7 +160,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-mfa-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/notify-callback.yaml
+++ b/ci/cloudformation/auth/function/notify-callback.yaml
@@ -412,7 +412,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-notify-callback-lambda function. ${RunbookLink}"
@@ -455,7 +458,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "Lambda error rate of ${ErrorRateThreshold}% has been reached in the ${Env}-notify-callback-lambda. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -111,7 +111,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-orch-auth-code-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/processing-identity.yaml
+++ b/ci/cloudformation/auth/function/processing-identity.yaml
@@ -193,7 +193,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-processing-identity-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/reset-password-request.yaml
+++ b/ci/cloudformation/auth/function/reset-password-request.yaml
@@ -149,7 +149,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-reset-password-request-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/reset-password.yaml
+++ b/ci/cloudformation/auth/function/reset-password.yaml
@@ -177,7 +177,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-reset-password-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/send-notification.yaml
+++ b/ci/cloudformation/auth/function/send-notification.yaml
@@ -184,7 +184,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-send-notification-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/start-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/start-passkey-assertion.yaml
@@ -151,7 +151,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-start-passkey-assertion-lambda function. ${RunbookLink}"

--- a/ci/cloudformation/auth/function/ticf-cri.yaml
+++ b/ci/cloudformation/auth/function/ticf-cri.yaml
@@ -121,7 +121,10 @@ Resources:
     Properties:
       AlarmActions: !If
         - UseAlarmActions
-        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
         - []
       AlarmDescription: !Sub
         - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-ticf-cri-lambda function. ${RunbookLink}"


### PR DESCRIPTION
## What

Count alarms are causing a lot of unnecessary noise in the di-2nd-line channel. To remediate this, have moved count alarms to the #di-authentication-notifications-channel. This will give us visibility of issues in lambdas as they are beginning to arise without involving TSD; inherently involving TSD at low/no levels of user impact isn't necessary.

The notify-callback-handler has had both count and rate alarms moved to di-authentication-notifications as these alarms do not indicate any issue with a journey.

There are no other existing count alarms in
ci/cloudformation/auth/function. Many were removed in dd800dce74 - "AUT-5226: Remove count-based alarms from high-traffic lambdas, keep rate-based alarms only" to get around the AWS stack resource limits.

The MFA reset with IPV journey is not covered by smoke tests, so have left the reverification result count alarm going to 2nd line. There is also not an error rate alarm for this On the ticket there was a goal to bump the reverification result lambda count alarm. This has already been done in 67598e6ffe8c3409448e7d8415eb0c0e1b0075c2 - "BAU: Bump threshold for reverification result alarm". Cannot see the alarm going off in 2nd line since then. This was associated with a safari browser bug, so maybe should be brought down, but not to the previous threshold of 5 as this was too noisy.

## How to review

1. Code Review
2. Check that there is always at least one alarm going to `slack_alert_notification_topic_arn`

When deployed, going to bump associated metrics to above the given threshold to test slack integration is working to #di-authentication-notifications


## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [ ] PR is canary deploy safe

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
4. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
