### PR TITLE
BAU: Auto-start Docker Desktop when running composeUp locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,16 @@ spotless {
     }
 }
 
+if (!System.getenv('CI') && !System.getenv('GITHUB_ACTIONS') && !System.getenv('CODEBUILD_BUILD_ID')) {
+    tasks.register('ensureDockerRunning', Exec) {
+        group = 'docker'
+        description = 'Checks if Docker daemon is running and attempts to start Docker Desktop if not (macOS only)'
+        commandLine 'bash', "${rootDir}/scripts/ensure-docker-running.sh"
+    }
+
+    tasks.named('composeUp') { dependsOn 'ensureDockerRunning' }
+}
+
 dockerCompose {
     buildBeforeUp = true
     forceRecreate = true

--- a/scripts/ensure-docker-running.sh
+++ b/scripts/ensure-docker-running.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eu
+
+# Guard: only run locally, not in CI or deployed environments
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${CODEBUILD_BUILD_ID:-}" ]; then
+  echo "CI environment detected, skipping Docker check."
+  exit 0
+fi
+
+if docker info > /dev/null 2>&1; then
+  echo "Docker daemon is already running."
+  exit 0
+fi
+
+echo "Docker daemon is not running. Attempting to start Docker Desktop..."
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Error: Docker is not running. Please start Docker manually." >&2
+  exit 1
+fi
+
+open -a Docker
+
+DOCKER_STARTUP_TIMEOUT=60
+DOCKER_POLL_INTERVAL=3
+elapsed=0
+
+echo "Waiting for Docker to start..."
+while ! docker info > /dev/null 2>&1; do
+  sleep ${DOCKER_POLL_INTERVAL}
+  elapsed=$((elapsed + DOCKER_POLL_INTERVAL))
+
+  if [ ${elapsed} -ge ${DOCKER_STARTUP_TIMEOUT} ]; then
+    echo "Error: Docker failed to start within ${DOCKER_STARTUP_TIMEOUT}s" >&2
+    exit 1
+  fi
+done
+
+echo "Docker is now running (took ~${elapsed}s)."


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Dev quality-of-life improvement. Checks if Docker is running before running composeUp locally (e.g., when running integration tests), and attempts to start Docker Desktop (via the bash script added in this PR) if not.

Mirrors existing pattern added in the frontend - https://github.com/govuk-one-login/authentication-frontend/pull/3442

Tried to add guards to stop this ever running in CI / GitHub workflows/actions / CodeBuild jobs as a safeguard, my current understanding of each "env" is:
- Locally: composeUp runs as a dependency of integration tests. This is where I want the new "Docker running check" to run.
- GitHub Actions:
    - In pre-merge-checks integration tests are run with `-x composeUp` to skip `composeUp`.
    - Deployment workflows only run buildZip or assemble, which have no dependencies on composeUp
- CodeBuild: These only deal with the artifact uploaded in GHA

<details>

<summary>Before</summary>

<img width="840" height="136" alt="Before" src="https://github.com/user-attachments/assets/8e230e0b-5a7b-4b7d-9797-c494076dce10" />

</details>

<details>

<summary>After</summary>

<img width="816" height="197" alt="After" src="https://github.com/user-attachments/assets/06c5eb27-98b1-405f-9003-2a1ec0bc954a" />

</details>

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Checkout main locally, quit Docker Desktop (or ensure stopped), try to run an integration test, should fail to run due to Docker not running. Checkout this branch, ensure Docker Desktop stopped, repeat prior steps, should automatically start Docker Desktop and the integration tests should pass.
    - I've ran through this - see the "Testing" section below.

## Testing

Ran through the above testing steps locally.

Also deployed this branch to dev to check everything looks OK there.

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [x] PR is canary deploy safe

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Mirrors existing pattern added in the frontend - https://github.com/govuk-one-login/authentication-frontend/pull/3442