### PR TITLE
AUT-5615: Add IAD inactivity failsafe guard

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/RecentlyActiveAccountException.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/RecentlyActiveAccountException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.accountmanagement.exceptions;
+
+public class RecentlyActiveAccountException extends RuntimeException {
+    public RecentlyActiveAccountException(String message) {
+        super(message);
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -9,13 +9,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.InactiveAccountDeletionMessage;
+import uk.gov.di.accountmanagement.exceptions.RecentlyActiveAccountException;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.InactiveAccountDeletionTokenService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.InactiveAccountFailsafeCheckHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
@@ -40,6 +43,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
     private final DynamoService dynamoService;
     private final StructuredAuditService structuredAuditService;
     private final ConfigurationService configurationService;
+    private final Clock clock;
 
     public InactiveAccountDeletionHandler() {
         this(ConfigurationService.getInstance());
@@ -54,6 +58,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
         this.dynamoService = new DynamoService(configurationService);
         this.structuredAuditService = new StructuredAuditService(configurationService);
         this.configurationService = configurationService;
+        this.clock = Clock.systemUTC();
     }
 
     public InactiveAccountDeletionHandler(
@@ -61,12 +66,14 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
             AccountDeletionService accountDeletionService,
             DynamoService dynamoService,
             StructuredAuditService structuredAuditService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            Clock clock) {
         this.tokenService = tokenService;
         this.accountDeletionService = accountDeletionService;
         this.dynamoService = dynamoService;
         this.structuredAuditService = structuredAuditService;
         this.configurationService = configurationService;
+        this.clock = clock;
     }
 
     @Override
@@ -90,15 +97,10 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
 
         for (SQSMessage msg : event.getRecords()) {
             try {
-                var message = parseMessage(msg);
-                LOG.info(
-                        "Processing inactive account deletion for publicSubjectId: {}",
-                        message.publicSubjectId());
-
-                var userProfile = getUserProfile(message.publicSubjectId());
-
-                deleteAccount(message.publicSubjectId());
-                emitAuditEvent(userProfile);
+                processAccountDeletion(msg);
+            } catch (RecentlyActiveAccountException e) {
+                LOG.warn(e.getMessage());
+                failures.add(new SQSBatchResponse.BatchItemFailure(msg.getMessageId()));
             } catch (Exception e) {
                 LOG.error(
                         "Failed to process inactive account deletion message with id: {}",
@@ -115,13 +117,47 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
         return new SQSBatchResponse(failures);
     }
 
-    private UserProfile getUserProfile(String publicSubjectId) {
-        Optional<UserProfile> maybeUserProfile =
-                dynamoService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
-        return maybeUserProfile.orElseThrow(
-                () ->
-                        new RuntimeException(
-                                "UserProfile not found for publicSubjectId: " + publicSubjectId));
+    private void processAccountDeletion(SQSMessage msg) throws JsonException {
+        var message = parseMessage(msg);
+        var publicSubjectId = message.publicSubjectId();
+        LOG.info("Processing inactive account deletion for publicSubjectId: {}", publicSubjectId);
+
+        var maybeUserProfile = getUserProfile(publicSubjectId);
+        if (maybeUserProfile.isEmpty()) {
+            LOG.warn(
+                    "User profile not found for publicSubjectId: {}. Account may have already been deleted. Skipping.",
+                    publicSubjectId);
+            return;
+        }
+        var userProfile = maybeUserProfile.get();
+
+        var userCredentials = getUserCredentials(userProfile.getEmail());
+
+        var activityCheck =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, clock);
+        if (activityCheck.recentlyActive()) {
+            throw new RecentlyActiveAccountException(
+                    String.format(
+                            "Skipping deletion for publicSubjectId: %s. Account has recent activity on attribute: %s",
+                            publicSubjectId, activityCheck.triggeringAttribute()));
+        }
+
+        deleteAccount(publicSubjectId);
+        emitAuditEvent(userProfile);
+    }
+
+    private Optional<UserProfile> getUserProfile(String publicSubjectId) {
+        return dynamoService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
+    }
+
+    private UserCredentials getUserCredentials(String email) {
+        var userCredentials = dynamoService.getUserCredentialsFromEmail(email);
+        if (userCredentials == null) {
+            LOG.info(
+                    "User credentials not found for email. Proceeding with user profile fields only.");
+        }
+        return userCredentials;
     }
 
     private void deleteAccount(String publicSubjectId) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
@@ -15,10 +16,15 @@ import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +38,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -44,6 +51,12 @@ class InactiveAccountDeletionHandlerTest {
     private static final String EMAIL = "test@example.com";
     private static final String TOKEN_VALUE = "test-bearer-token";
     private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-09-04T14:00:00Z"), ZoneOffset.UTC);
+
+    private static final String OLD_TIMESTAMP = "2019-01-01T10:00:00.000000";
+    private static final String RECENT_TIMESTAMP = "2025-06-15T10:00:00.000000";
 
     private final Context context = mock(Context.class);
     private final InactiveAccountDeletionTokenService tokenService =
@@ -64,11 +77,14 @@ class InactiveAccountDeletionHandlerTest {
                         accountDeletionService,
                         dynamoService,
                         structuredAuditService,
-                        configurationService);
+                        configurationService,
+                        FIXED_CLOCK);
         when(tokenService.createAccountDataApiAccessToken(any()))
                 .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
         when(dynamoService.getOptionalUserProfileFromPublicSubject(any()))
-                .thenReturn(Optional.of(userProfileWithPublicSubjectId(PUBLIC_SUBJECT_ID)));
+                .thenReturn(Optional.of(inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL)));
+        when(dynamoService.getUserCredentialsFromEmail(any()))
+                .thenReturn(inactiveUserCredentials());
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(dynamoService.getOrGenerateSalt(any())).thenReturn(new byte[] {0x1});
     }
@@ -155,20 +171,6 @@ class InactiveAccountDeletionHandlerTest {
     }
 
     @Test
-    void shouldReportFailureWhenUserProfileNotFound() {
-        when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
-                .thenReturn(Optional.empty());
-        var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
-
-        SQSBatchResponse response = handler.handleRequest(event, context);
-
-        assertThat(response.getBatchItemFailures(), hasSize(1));
-        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
-        verifyNoInteractions(accountDeletionService);
-        verifyNoInteractions(structuredAuditService);
-    }
-
-    @Test
     void shouldProceedToDeletionWhenUserProfileFound() {
         var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
 
@@ -181,9 +183,8 @@ class InactiveAccountDeletionHandlerTest {
 
     @Test
     void shouldEmitAuthDeleteAccountAuditEventOnSuccessfulDeletion() {
-        var userProfile = userProfileWithPublicSubjectId(PUBLIC_SUBJECT_ID);
+        var userProfile = inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL);
         userProfile.setLegacySubjectID(LEGACY_SUBJECT_ID);
-        userProfile.setEmail(EMAIL);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
                 .thenReturn(Optional.of(userProfile));
         var event = createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
@@ -235,9 +236,9 @@ class InactiveAccountDeletionHandlerTest {
         var failingMessage = createSQSMessage("msg-fail", "{\"publicSubjectId\": \"sub-2\"}");
 
         when(dynamoService.getOptionalUserProfileFromPublicSubject("sub-1"))
-                .thenReturn(Optional.of(userProfileWithPublicSubjectId("sub-1")));
+                .thenReturn(Optional.of(inactiveUserProfile("sub-1", "sub1@example.com")));
         when(dynamoService.getOptionalUserProfileFromPublicSubject("sub-2"))
-                .thenReturn(Optional.of(userProfileWithPublicSubjectId("sub-2")));
+                .thenReturn(Optional.of(inactiveUserProfile("sub-2", "sub2@example.com")));
         doNothing().when(accountDeletionService).deleteAccountViaDataApi(eq("sub-1"), any());
         doThrow(new RuntimeException("5xx"))
                 .when(accountDeletionService)
@@ -254,11 +255,184 @@ class InactiveAccountDeletionHandlerTest {
         verify(structuredAuditService, times(1)).submitAuditEvent(any());
     }
 
-    private UserProfile userProfileWithPublicSubjectId(String publicSubjectId) {
+    @Nested
+    class UserProfileNotFoundTest {
+
+        @Test
+        void shouldSkipWithNoFailureWhenUserProfileNotFound() {
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.empty());
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), is(empty()));
+            verifyNoInteractions(accountDeletionService);
+            verifyNoInteractions(structuredAuditService);
+        }
+    }
+
+    @Nested
+    class InactivityFailsafeCheckTest {
+
+        @Test
+        void shouldReportFailureWhenAccountHasRecentActivity() {
+            var recentProfile = new UserProfile();
+            recentProfile.setPublicSubjectID(PUBLIC_SUBJECT_ID);
+            recentProfile.setSubjectID(PUBLIC_SUBJECT_ID);
+            recentProfile.setEmail(EMAIL);
+            recentProfile.setCreated(OLD_TIMESTAMP);
+            recentProfile.setUpdated(RECENT_TIMESTAMP);
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.of(recentProfile));
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+            verifyNoInteractions(accountDeletionService);
+            verifyNoInteractions(structuredAuditService);
+        }
+
+        @Test
+        void shouldProceedWithDeletionWhenAllTimestampsOld() {
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), is(empty()));
+            verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+            verify(structuredAuditService).submitAuditEvent(any());
+        }
+
+        @Test
+        void shouldProceedWithDeletionWhenUserCredentialsNotFound() {
+            when(dynamoService.getUserCredentialsFromEmail(any())).thenReturn(null);
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), is(empty()));
+            verify(accountDeletionService).deleteAccountViaDataApi(PUBLIC_SUBJECT_ID, TOKEN_VALUE);
+        }
+
+        @Test
+        void shouldReportFailureWhenCredentialsHaveRecentActivity() {
+            var recentCredentials = new UserCredentials();
+            recentCredentials.setCreated(OLD_TIMESTAMP);
+            recentCredentials.setUpdated(RECENT_TIMESTAMP);
+            when(dynamoService.getUserCredentialsFromEmail(any())).thenReturn(recentCredentials);
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+            verifyNoInteractions(accountDeletionService);
+            verifyNoInteractions(structuredAuditService);
+        }
+
+        @Test
+        void shouldReportFailureWhenTermsAndConditionsTimestampIsRecent() {
+            var userProfile = inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL);
+            userProfile.setTermsAndConditions(new TermsAndConditions("1.0", RECENT_TIMESTAMP));
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.of(userProfile));
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            verifyNoInteractions(accountDeletionService);
+        }
+
+        @Test
+        void shouldReportFailureWhenLastSignedInIsRecent() {
+            var userProfile = inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL);
+            userProfile.setLastSignedIn(RECENT_TIMESTAMP);
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.of(userProfile));
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            verifyNoInteractions(accountDeletionService);
+        }
+
+        @Test
+        void shouldLookUpCredentialsByEmailFromUserProfile() {
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            handler.handleRequest(event, context);
+
+            verify(dynamoService).getUserCredentialsFromEmail(EMAIL);
+        }
+
+        @Test
+        void shouldHandleBatchWithMixOfActiveAndInactiveAccounts() {
+            var inactiveMessage =
+                    createSQSMessage("msg-inactive", "{\"publicSubjectId\": \"inactive-sub\"}");
+            var activeMessage =
+                    createSQSMessage("msg-active", "{\"publicSubjectId\": \"active-sub\"}");
+
+            var inactiveProfile = inactiveUserProfile("inactive-sub", "inactive@example.com");
+            var activeProfile = new UserProfile();
+            activeProfile.setPublicSubjectID("active-sub");
+            activeProfile.setSubjectID("active-sub");
+            activeProfile.setEmail("active@example.com");
+            activeProfile.setCreated(RECENT_TIMESTAMP);
+            activeProfile.setUpdated(RECENT_TIMESTAMP);
+
+            when(dynamoService.getOptionalUserProfileFromPublicSubject("inactive-sub"))
+                    .thenReturn(Optional.of(inactiveProfile));
+            when(dynamoService.getOptionalUserProfileFromPublicSubject("active-sub"))
+                    .thenReturn(Optional.of(activeProfile));
+            doNothing()
+                    .when(accountDeletionService)
+                    .deleteAccountViaDataApi(eq("inactive-sub"), any());
+
+            var event = new SQSEvent();
+            event.setRecords(List.of(inactiveMessage, activeMessage));
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            assertEquals("msg-active", response.getBatchItemFailures().get(0).getItemIdentifier());
+            verify(accountDeletionService).deleteAccountViaDataApi(eq("inactive-sub"), any());
+            verify(accountDeletionService, never())
+                    .deleteAccountViaDataApi(eq("active-sub"), any());
+        }
+    }
+
+    private UserProfile inactiveUserProfile(String publicSubjectId, String email) {
         var userProfile = new UserProfile();
         userProfile.setPublicSubjectID(publicSubjectId);
         userProfile.setSubjectID(publicSubjectId);
+        userProfile.setEmail(email);
+        userProfile.setCreated(OLD_TIMESTAMP);
+        userProfile.setUpdated(OLD_TIMESTAMP);
         return userProfile;
+    }
+
+    private UserCredentials inactiveUserCredentials() {
+        var userCredentials = new UserCredentials();
+        userCredentials.setCreated(OLD_TIMESTAMP);
+        userCredentials.setUpdated(OLD_TIMESTAMP);
+        return userCredentials;
     }
 
     private SQSEvent createSQSEventWithBody(String body) {

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/InactiveAccountDeletionHandlerIntegrationTest.java
@@ -12,8 +12,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.accountmanagement.lambda.InactiveAccountDeletionHandler;
+import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
@@ -22,6 +28,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.List;
+import java.util.Locale;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
@@ -33,6 +40,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_DELETE_ACCOUNT;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -43,6 +51,7 @@ class InactiveAccountDeletionHandlerIntegrationTest
     private static final String TEST_PASSWORD = "password-1";
     private static final String IAD_CLIENT_ID = "inactive-account-deletion-client";
     private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
+    private static final String OLD_TIMESTAMP = "2019-01-01T10:00:00.000000";
 
     private WireMockServer accountDataApiWireMockServer;
     private String publicSubjectId;
@@ -85,7 +94,8 @@ class InactiveAccountDeletionHandlerIntegrationTest
     }
 
     @Test
-    void shouldSuccessfullyDeleteAccountViaDataApi() {
+    void shouldSuccessfullyDeleteInactiveAccountViaDataApi() {
+        makeAccountInactive(TEST_EMAIL);
         accountDataApiWireMockServer.stubFor(
                 delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(204)));
@@ -104,7 +114,38 @@ class InactiveAccountDeletionHandlerIntegrationTest
     }
 
     @Test
+    void shouldReportFailureWhenAccountHasRecentActivity() {
+        accountDataApiWireMockServer.stubFor(
+                delete(urlPathMatching("/accounts/" + publicSubjectId))
+                        .willReturn(aResponse().withStatus(204)));
+
+        var event = createSQSEvent(publicSubjectId);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertEquals("msg-1", response.getBatchItemFailures().get(0).getItemIdentifier());
+        accountDataApiWireMockServer.verify(0, deleteRequestedFor(urlPathMatching("/accounts/.*")));
+        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+
+    @Test
+    void shouldSkipWithNoFailureWhenUserProfileAlreadyDeleted() {
+        userStore.deleteUserProfile(TEST_EMAIL);
+        userStore.deleteUserCredentials(TEST_EMAIL);
+
+        var event = createSQSEvent(publicSubjectId);
+
+        SQSBatchResponse response = handler.handleRequest(event, context);
+
+        assertThat(response.getBatchItemFailures(), is(empty()));
+        accountDataApiWireMockServer.verify(0, deleteRequestedFor(urlPathMatching("/accounts/.*")));
+        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+
+    @Test
     void shouldReportFailureWhenDataApiReturns404() {
+        makeAccountInactive(TEST_EMAIL);
         accountDataApiWireMockServer.stubFor(
                 delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(404)));
@@ -118,6 +159,7 @@ class InactiveAccountDeletionHandlerIntegrationTest
 
     @Test
     void shouldReportFailureWhenDataApiReturns500() {
+        makeAccountInactive(TEST_EMAIL);
         accountDataApiWireMockServer.stubFor(
                 delete(urlPathMatching("/accounts/" + publicSubjectId))
                         .willReturn(aResponse().withStatus(500)));
@@ -150,34 +192,68 @@ class InactiveAccountDeletionHandlerIntegrationTest
     }
 
     @Test
-    void shouldProcessBatchWithMixedSuccessAndFailure() {
-        var successPublicSubjectId = userStore.signUp("success-user@example.com", TEST_PASSWORD);
-        var failPublicSubjectId = userStore.signUp("fail-user@example.com", TEST_PASSWORD);
+    void shouldProcessBatchWithMixedInactiveActiveAndFailure() {
+        var inactiveEmail = "inactive-user@example.com";
+        var activeEmail = "active-user@example.com";
+        var inactivePublicSubjectId = userStore.signUp(inactiveEmail, TEST_PASSWORD);
+        var activePublicSubjectId = userStore.signUp(activeEmail, TEST_PASSWORD);
+        makeAccountInactive(inactiveEmail);
 
         accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + successPublicSubjectId))
+                delete(urlPathMatching("/accounts/" + inactivePublicSubjectId))
                         .willReturn(aResponse().withStatus(204)));
-        accountDataApiWireMockServer.stubFor(
-                delete(urlPathMatching("/accounts/" + failPublicSubjectId))
-                        .willReturn(aResponse().withStatus(500)));
 
-        var goodMessage = createSQSMessage("msg-good", successPublicSubjectId);
+        var inactiveMessage = createSQSMessage("msg-inactive", inactivePublicSubjectId);
+        var activeMessage = createSQSMessage("msg-active", activePublicSubjectId);
         var badMessage = createRawSQSMessage("msg-bad", "invalid json");
-        var failMessage = createSQSMessage("msg-fail", failPublicSubjectId);
 
         var event = new SQSEvent();
-        event.setRecords(List.of(goodMessage, badMessage, failMessage));
+        event.setRecords(List.of(inactiveMessage, activeMessage, badMessage));
 
         SQSBatchResponse response = handler.handleRequest(event, context);
 
         assertThat(response.getBatchItemFailures(), hasSize(2));
-        assertEquals("msg-bad", response.getBatchItemFailures().get(0).getItemIdentifier());
-        assertEquals("msg-fail", response.getBatchItemFailures().get(1).getItemIdentifier());
+        assertEquals("msg-active", response.getBatchItemFailures().get(0).getItemIdentifier());
+        assertEquals("msg-bad", response.getBatchItemFailures().get(1).getItemIdentifier());
 
         accountDataApiWireMockServer.verify(
-                1, deleteRequestedFor(urlPathMatching("/accounts/" + successPublicSubjectId)));
+                1, deleteRequestedFor(urlPathMatching("/accounts/" + inactivePublicSubjectId)));
         accountDataApiWireMockServer.verify(
-                1, deleteRequestedFor(urlPathMatching("/accounts/" + failPublicSubjectId)));
+                0, deleteRequestedFor(urlPathMatching("/accounts/" + activePublicSubjectId)));
+    }
+
+    private void makeAccountInactive(String email) {
+        var configService = ConfigurationService.getInstance();
+        var dynamoDbEnhancedClient = DynamoClientHelper.createDynamoEnhancedClient(configService);
+
+        var userProfileTableName = TableNameHelper.getFullTableName("user-profile", configService);
+        var userProfileTable =
+                dynamoDbEnhancedClient.table(
+                        userProfileTableName, TableSchema.fromBean(UserProfile.class));
+        var userProfile =
+                userProfileTable.getItem(
+                        Key.builder().partitionValue(email.toLowerCase(Locale.ROOT)).build());
+        if (userProfile != null) {
+            userProfile.setCreated(OLD_TIMESTAMP);
+            userProfile.setUpdated(OLD_TIMESTAMP);
+            userProfile.setTermsAndConditions(null);
+            userProfile.setLastSignedIn(null);
+            userProfileTable.updateItem(userProfile);
+        }
+
+        var userCredentialsTableName =
+                TableNameHelper.getFullTableName("user-credentials", configService);
+        var userCredentialsTable =
+                dynamoDbEnhancedClient.table(
+                        userCredentialsTableName, TableSchema.fromBean(UserCredentials.class));
+        var userCredentials =
+                userCredentialsTable.getItem(
+                        Key.builder().partitionValue(email.toLowerCase(Locale.ROOT)).build());
+        if (userCredentials != null) {
+            userCredentials.setCreated(OLD_TIMESTAMP);
+            userCredentials.setUpdated(OLD_TIMESTAMP);
+            userCredentialsTable.updateItem(userCredentials);
+        }
     }
 
     private SQSEvent createSQSEvent(String publicSubjectId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelper.java
@@ -1,0 +1,93 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InactiveAccountFailsafeCheckHelper {
+
+    private static final Logger LOG =
+            LogManager.getLogger(InactiveAccountFailsafeCheckHelper.class);
+
+    static final long INACTIVITY_THRESHOLD_YEARS = 5;
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    .optionalStart()
+                    .appendOffsetId()
+                    .optionalEnd()
+                    .toFormatter();
+
+    public record ActivityCheckResult(boolean recentlyActive, String triggeringAttribute) {}
+
+    private record TimestampCandidate(String timestamp, String label) {}
+
+    private InactiveAccountFailsafeCheckHelper() {}
+
+    public static ActivityCheckResult checkForRecentActivity(
+            UserProfile userProfile, UserCredentials userCredentials, Clock clock) {
+        var threshold = LocalDateTime.now(clock).minusYears(INACTIVITY_THRESHOLD_YEARS);
+
+        return buildTimestampCandidates(userProfile, userCredentials).stream()
+                .filter(candidate -> candidate.timestamp() != null)
+                .filter(
+                        candidate ->
+                                isWithinActivityThreshold(
+                                        candidate.timestamp(), candidate.label(), threshold))
+                .findFirst()
+                .map(candidate -> new ActivityCheckResult(true, candidate.label()))
+                .orElse(new ActivityCheckResult(false, null));
+    }
+
+    private static boolean isWithinActivityThreshold(
+            String timestamp, String label, LocalDateTime threshold) {
+        try {
+            return LocalDateTime.parse(timestamp, DATE_TIME_FORMATTER).isAfter(threshold);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to parse timestamp '{}' from source '{}': {}",
+                    timestamp,
+                    label,
+                    e.getMessage());
+            return false;
+        }
+    }
+
+    private static List<TimestampCandidate> buildTimestampCandidates(
+            UserProfile userProfile, UserCredentials userCredentials) {
+        var candidates = new ArrayList<TimestampCandidate>();
+
+        candidates.add(new TimestampCandidate(userProfile.getCreated(), "UserProfile.Created"));
+        candidates.add(new TimestampCandidate(userProfile.getUpdated(), "UserProfile.Updated"));
+
+        TermsAndConditions tc = userProfile.getTermsAndConditions();
+        candidates.add(
+                new TimestampCandidate(
+                        tc != null ? tc.getTimestamp() : null,
+                        "UserProfile.termsAndConditions.timestamp"));
+
+        candidates.add(
+                new TimestampCandidate(userProfile.getLastSignedIn(), "UserProfile.LastSignedIn"));
+
+        if (userCredentials != null) {
+            candidates.add(
+                    new TimestampCandidate(
+                            userCredentials.getCreated(), "UserCredentials.Created"));
+            candidates.add(
+                    new TimestampCandidate(
+                            userCredentials.getUpdated(), "UserCredentials.Updated"));
+        }
+
+        return candidates;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelper.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -36,7 +37,7 @@ public class InactiveAccountFailsafeCheckHelper {
 
     public static ActivityCheckResult checkForRecentActivity(
             UserProfile userProfile, UserCredentials userCredentials, Clock clock) {
-        var threshold = LocalDateTime.now(clock).minusYears(INACTIVITY_THRESHOLD_YEARS);
+        var threshold = LocalDate.now(clock).minusYears(INACTIVITY_THRESHOLD_YEARS);
 
         return buildTimestampCandidates(userProfile, userCredentials).stream()
                 .filter(candidate -> candidate.timestamp() != null)
@@ -50,9 +51,10 @@ public class InactiveAccountFailsafeCheckHelper {
     }
 
     private static boolean isWithinActivityThreshold(
-            String timestamp, String label, LocalDateTime threshold) {
+            String timestamp, String label, LocalDate threshold) {
         try {
-            return LocalDateTime.parse(timestamp, DATE_TIME_FORMATTER).isAfter(threshold);
+            var candidateDate = LocalDateTime.parse(timestamp, DATE_TIME_FORMATTER).toLocalDate();
+            return candidateDate.isAfter(threshold);
         } catch (Exception e) {
             LOG.warn(
                     "Failed to parse timestamp '{}' from source '{}': {}",

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelperTest.java
@@ -243,8 +243,22 @@ class InactiveAccountFailsafeCheckHelperTest {
     }
 
     @Test
+    void shouldReturnNotRecentlyActiveWhenTimestampOnSameDateAsThresholdButDifferentTime() {
+        var sameDateLaterTime = "2021-09-04T23:59:59.999999";
+        var userProfile = createUserProfile(sameDateLaterTime, null, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
     void shouldReturnRecentlyActiveWhenTimestampJustInsideThreshold() {
-        var justInsideTimestamp = "2021-09-04T14:00:01";
+        var justInsideTimestamp = "2021-09-05T00:00:00";
         var userProfile = createUserProfile(justInsideTimestamp, null, null, null);
         var userCredentials = createUserCredentials(null, null);
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/InactiveAccountFailsafeCheckHelperTest.java
@@ -1,0 +1,314 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+class InactiveAccountFailsafeCheckHelperTest {
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-09-04T14:00:00Z"), ZoneOffset.UTC);
+
+    private static final String OLD_TIMESTAMP = "2019-01-01T10:00:00.000000";
+    private static final String RECENT_TIMESTAMP = "2025-06-15T10:00:00.000000";
+
+    @Test
+    void shouldReturnNotRecentlyActiveWhenAllTimestampsOlderThanFiveYears() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenUserProfileCreatedWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        RECENT_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Created"));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenUserProfileUpdatedWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        RECENT_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Updated"));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenTermsAndConditionsTimestampWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", RECENT_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.termsAndConditions.timestamp"));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenLastSignedInWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        RECENT_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.LastSignedIn"));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenUserCredentialsCreatedWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(RECENT_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserCredentials.Created"));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenUserCredentialsUpdatedWithinThreshold() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", OLD_TIMESTAMP),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, RECENT_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserCredentials.Updated"));
+    }
+
+    @Test
+    void shouldReturnNotRecentlyActiveWhenAllTimestampsNull() {
+        var userProfile = createUserProfile(null, null, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldReturnNotRecentlyActiveWhenUserCredentialsNull() {
+        var userProfile = createUserProfile(null, null, null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, null, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldSkipUnparseableTimestampAndAllowDeletionWhenNoOtherRecentTimestamps() {
+        var userProfile = createUserProfile("not-a-date", OLD_TIMESTAMP, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldSkipUnparseableTimestampAndStillDetectRecentActivityOnLaterField() {
+        var userProfile = createUserProfile("not-a-date", RECENT_TIMESTAMP, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Updated"));
+    }
+
+    @Test
+    void shouldSafelySkipNullTermsAndConditionsObject() {
+        var userProfile = createUserProfile(OLD_TIMESTAMP, OLD_TIMESTAMP, null, OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldSafelySkipNullTermsAndConditionsTimestamp() {
+        var userProfile =
+                createUserProfile(
+                        OLD_TIMESTAMP,
+                        OLD_TIMESTAMP,
+                        new TermsAndConditions("1.0", null),
+                        OLD_TIMESTAMP);
+        var userCredentials = createUserCredentials(OLD_TIMESTAMP, OLD_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldReturnNotRecentlyActiveWhenTimestampExactlyAtThresholdBoundary() {
+        var boundaryTimestamp = "2021-09-04T14:00:00";
+        var userProfile = createUserProfile(boundaryTimestamp, null, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(false));
+        assertThat(result.triggeringAttribute(), is((String) null));
+    }
+
+    @Test
+    void shouldReturnRecentlyActiveWhenTimestampJustInsideThreshold() {
+        var justInsideTimestamp = "2021-09-04T14:00:01";
+        var userProfile = createUserProfile(justInsideTimestamp, null, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Created"));
+    }
+
+    @Test
+    void shouldHandleTimestampWithUtcOffsetSuffix() {
+        var timestampWithOffset = "2025-01-15T10:30:00.000Z";
+        var userProfile = createUserProfile(timestampWithOffset, null, null, null);
+        var userCredentials = createUserCredentials(null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Created"));
+    }
+
+    @Test
+    void shouldCheckUserProfileFieldsBeforeCredentialsFields() {
+        var userProfile = createUserProfile(RECENT_TIMESTAMP, null, null, null);
+        var userCredentials = createUserCredentials(null, RECENT_TIMESTAMP);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, userCredentials, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Created"));
+    }
+
+    @Test
+    void shouldOnlyCheckUserProfileFieldsWhenCredentialsNull() {
+        var userProfile = createUserProfile(null, RECENT_TIMESTAMP, null, null);
+
+        var result =
+                InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
+                        userProfile, null, FIXED_CLOCK);
+
+        assertThat(result.recentlyActive(), is(true));
+        assertThat(result.triggeringAttribute(), is("UserProfile.Updated"));
+    }
+
+    private UserProfile createUserProfile(
+            String created, String updated, TermsAndConditions tc, String lastSignedIn) {
+        var userProfile = new UserProfile();
+        userProfile.setCreated(created);
+        userProfile.setUpdated(updated);
+        userProfile.setTermsAndConditions(tc);
+        userProfile.setLastSignedIn(lastSignedIn);
+        return userProfile;
+    }
+
+    private UserCredentials createUserCredentials(String created, String updated) {
+        var userCredentials = new UserCredentials();
+        userCredentials.setCreated(created);
+        userCredentials.setUpdated(updated);
+        return userCredentials;
+    }
+}


### PR DESCRIPTION
## What

Added failsafe checks to IAD deletion handler.

Guards deletion of an account by checking the timestamps on that accounts UserProfile and UserCredentials items. If any one of these timestamps is within a threshold, marks that message as a failure. Only dates are being compared (all times are ignored) - see commit e02d6445f5c588f54ca77737b936cecdd7e0b3b3 description for more info.

A subsequent ticket (AUT-5729) will add a metric here which the home team will monitor.

## How to review

1. Code review, including (but not limited to):
    - Reviewing the logic in the helper to ensure all relevant timestamp fields are checked.
1. Optionally, deploy to a dev env and locate the stub queue (not the DLQ!):
    - Determine a public subject ID for an account which would be a valid deletion (last activity >5y) and add a message of the format {"publicSubjectId": "ID_HERE"} to the stub queue and send. This should be deleted successfully and the Lambda logs should confirm this.
    - Repeat the above, BUT the other account should have a timestamp within the last 5y. Once the message has been sent to the queue, review the Lambda logs and confirm that deletion of this account was prevented and that it is still present.

## Testing

I deployed to a dev environment then:
1. Found a public subject ID for an account which would be a valid deletion (last activity >5y) and added a message of the format {"publicSubjectId": "ID_HERE"} to the stub queue and sent. Account **deleted** successfully - confirmed through Lambda logs and DyanmoDB query (on dev DB).
2. Found a public subject ID for an account with a timestamp in the last 5y and added a message of the format {"publicSubjectId": "ID_HERE"} to the stub queue and sent. Account deletion **prevented** (expected behaviour) - confirmed through Lambda logs and DyanmoDB query (on dev DB). Lambda logs indicated the correct timestamp which prevented the deletion.
3. Found an account and set all but one timestamp >5y away and one exactly 5y ago but a time at night (eg 23:30). Added a message of the format {"publicSubjectId": "ID_HERE"} to the stub queue and sent. Account **deleted** successfully (expected due to times being ignored) - confirmed through Lambda logs and DyanmoDB query (on dev DB).
    - Prior to the final commit, this scenario would've resulted in the deletion being prevented due to it being within the 5y window (when considering both date and time) even though this was <24h.

## Checklist

- [x] PR is canary deploy safe **- changes confined to the background SQS queue processor**

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- should only affect async account deletions for inactive accounts**

- [ ] A UCD review has been performed (or no review required) **- N/A, backend only**