### PR TITLE
AUT-5797: return authenticated=false on auth code protection

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -205,6 +205,15 @@ public class StartHandler
                             internalSubjectId);
         }
 
+        var authenticated = isUserAuthenticatedWithValidProfile;
+        if (authenticated
+                && !reauthenticate
+                && !upliftRequired
+                && !permissionDecisionManager.canIssueAuthCode(authSession)) {
+            authenticated = false;
+            emitAuthenticatedOverrideObservability();
+        }
+
         var userStartInfo =
                 startService.buildUserStartInfo(
                         userContext,
@@ -214,17 +223,9 @@ public class StartHandler
                         startRequest.isIdentityVerificationRequired(),
                         reauthenticate,
                         isBlockedForReauth,
-                        isUserAuthenticatedWithValidProfile,
+                        authenticated,
                         upliftRequired,
                         mfaRequired(requestedCredentialTrustLevel));
-
-        if (userStartInfo.isAuthenticated() && !userStartInfo.isUpliftRequired()) {
-            var canIssueAuthCode = permissionDecisionManager.canIssueAuthCode(authSession);
-            if (!canIssueAuthCode) {
-                LOG.warn(
-                        "Orch and auth disagree on whether user is authenticated: problems will likely arise in this journey");
-            }
-        }
 
         StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
 
@@ -370,6 +371,14 @@ public class StartHandler
                             failureReason == null ? "unknown" : failureReason.getValue()));
         }
         return true;
+    }
+
+    private void emitAuthenticatedOverrideObservability() {
+        LOG.warn(
+                "Auth code protection did not pass for this session, overriding authenticated to false");
+        cloudwatchMetricsService.incrementCounter(
+                CloudwatchMetrics.AUTH_START_OVERRIDDEN_AUTHENTICATED.getValue(),
+                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 
     private void emitReauthRequestedObservability(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.StartRequest;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
@@ -151,185 +152,8 @@ public class StartHandler
                 startRequest.previousSessionId(),
                 sessionId);
 
-        boolean isUserAuthenticatedWithValidProfile;
         try {
-            var authSession =
-                    authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                            Optional.ofNullable(startRequest.previousSessionId())
-                                    .filter(s -> !s.isBlank()),
-                            sessionId);
-            LOG.info("Start session retrieved");
-            var requestedCredentialTrustLevel =
-                    retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength());
-            authSession.setRequestedCredentialStrength(requestedCredentialTrustLevel);
-            if (startRequest.requestedLevelOfConfidence() != null) {
-                authSession.setRequestedLevelOfConfidence(
-                        retrieveLevelOfConfidence(startRequest.requestedLevelOfConfidence()));
-            }
-            authSession.setClientId(startRequest.clientId());
-            authSession.setClientName(startRequest.clientName());
-            authSession.setIsSmokeTest(startRequest.isSmokeTest());
-            authSession.setIsOneLoginService(startRequest.isOneLoginService());
-            authSession.setSubjectType(startRequest.subjectType());
-            authSession.setRpSectorIdentifierHost(startRequest.rpSectorIdentifierHost());
-
-            if (startRequest.authenticated()) {
-                var isUserProfileEmpty = startService.isUserProfileEmpty(authSession);
-                if (isUserProfileEmpty) {
-                    LOG.warn("User profile for authenticated session is empty");
-                }
-                isUserAuthenticatedWithValidProfile = !isUserProfileEmpty;
-            } else {
-                isUserAuthenticatedWithValidProfile = false;
-            }
-
-            var upliftRequired =
-                    startService.isUpliftRequired(
-                            requestedCredentialTrustLevel,
-                            authSession.getAchievedCredentialStrength());
-
-            authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
-
-            var userContext = startService.buildUserContext(authSession);
-
-            var scopes = List.of(startRequest.scope().split(" "));
-            var redirectURI = new URI(startRequest.redirectUri());
-            var state = new State(startRequest.state());
-            attachLogFieldToLogs(CLIENT_ID, authSession.getClientId());
-            var clientStartInfo =
-                    startService.buildClientStartInfo(
-                            startRequest.serviceType(),
-                            authSession.getClientName(),
-                            scopes,
-                            redirectURI,
-                            state,
-                            startRequest.isCookieConsentShared(),
-                            startRequest.isOneLoginService());
-
-            var cookieConsent =
-                    startService.getCookieConsentValue(
-                            startRequest.cookieConsent(), startRequest.isCookieConsentShared());
-            var gaTrackingId = startRequest.ga();
-            var reauthenticateHeader =
-                    getHeaderValueFromHeaders(
-                            input.getHeaders(),
-                            REAUTHENTICATE_HEADER,
-                            configurationService.getHeadersCaseInsensitive());
-            var reauthenticate =
-                    reauthenticateHeader != null && reauthenticateHeader.equals("true");
-
-            LOG.info(
-                    "reauthenticateHeader: {} reauthenticate: {}",
-                    reauthenticateHeader,
-                    reauthenticate);
-
-            if (reauthenticate) {
-                LOG.info(
-                        "Reauthentication - Setting hasVerifiedWithPassword, hasVerifiedWithMfa & hasVerifiedWithPasskey to false");
-                authSession.setHasVerifiedWithPassword(false);
-                authSession.setHasVerifiedWithMfa(false);
-                authSession.setHasVerifiedWithPasskey(false);
-            }
-
-            Optional<String> maybeInternalSubject =
-                    Optional.ofNullable(authSession.getInternalCommonSubjectId());
-
-            var clientSessionId =
-                    getHeaderValueFromHeaders(
-                            input.getHeaders(),
-                            CLIENT_SESSION_ID_HEADER,
-                            configurationService.getHeadersCaseInsensitive());
-            var txmaAuditHeader = getTxmaAuditEncodedHeaderOrUnknown(input);
-            String phoneNumber = AuditService.UNKNOWN;
-
-            var auditContext =
-                    new AuditContext(
-                            authSession.getClientId(),
-                            clientSessionId,
-                            sessionId,
-                            maybeInternalSubject.orElse(AuditService.UNKNOWN),
-                            userContext
-                                    .getUserProfile()
-                                    .map(UserProfile::getEmail)
-                                    .orElse(AuditService.UNKNOWN),
-                            IpAddressHelper.extractIpAddress(input),
-                            phoneNumber,
-                            extractPersistentIdFromHeaders(input.getHeaders()),
-                            txmaAuditHeader);
-
-            if (reauthenticate) {
-                emitReauthRequestedObservability(startRequest, auditContext);
-            }
-
-            boolean isBlockedForReauth = false;
-            if (reauthenticate) {
-                var permissionContext =
-                        buildPermissionContext(authSession, startRequest, userContext);
-                var permissionResult =
-                        permissionDecisionManager.canStartJourney(
-                                JourneyType.REAUTHENTICATION, permissionContext);
-
-                if (permissionResult.isSuccess()
-                        && permissionResult.getSuccess()
-                                instanceof
-                                uk.gov.di.authentication.userpermissions.entity.Decision
-                                        .ReauthLockedOut
-                                lockedOut) {
-                    isBlockedForReauth = true;
-                    if (maybeInternalSubject.isPresent()) {
-                        var reauthCountTypesToCounts = lockedOut.detailedCounts();
-                        var blockedCountTypes = lockedOut.blockedCountTypes();
-                        ReauthFailureReasons failureReason =
-                                getReauthFailureReasonFromCountTypes(blockedCountTypes);
-                        auditService.submitAuditEvent(
-                                FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                                auditContext,
-                                ReauthMetadataBuilder.builder(startRequest.rpPairwiseIdForReauth())
-                                        .withAllIncorrectAttemptCounts(reauthCountTypesToCounts)
-                                        .withFailureReason(failureReason)
-                                        .build());
-                        cloudwatchMetricsService.incrementCounter(
-                                CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                                Map.of(
-                                        ENVIRONMENT.getValue(),
-                                        configurationService.getEnvironment(),
-                                        FAILURE_REASON.getValue(),
-                                        failureReason == null
-                                                ? "unknown"
-                                                : failureReason.getValue()));
-                    }
-                }
-            }
-
-            var userStartInfo =
-                    startService.buildUserStartInfo(
-                            userContext,
-                            cookieConsent,
-                            gaTrackingId,
-                            startRequest.isIdentityVerificationRequired(),
-                            reauthenticate,
-                            isBlockedForReauth,
-                            isUserAuthenticatedWithValidProfile,
-                            upliftRequired,
-                            mfaRequired(requestedCredentialTrustLevel));
-
-            if (userStartInfo.isAuthenticated() && !userStartInfo.isUpliftRequired()) {
-                var canIssueAuthCode = permissionDecisionManager.canIssueAuthCode(authSession);
-                if (!canIssueAuthCode) {
-                    LOG.warn(
-                            "Orch and auth disagree on whether user is authenticated: problems will likely arise in this journey");
-                }
-            }
-
-            StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
-
-            auditService.submitAuditEvent(
-                    FrontendAuditableEvent.AUTH_START_INFO_FOUND,
-                    auditContext,
-                    pair("internalSubjectId", maybeInternalSubject.orElse(AuditService.UNKNOWN)));
-
-            return generateApiGatewayProxyResponse(200, startResponse);
-
+            return buildStartResponse(input, sessionId, startRequest);
         } catch (JsonException e) {
             var errorMessage = "Unable to serialize start response";
             LOG.error(errorMessage, e);
@@ -339,6 +163,213 @@ public class StartHandler
             LOG.error(errorMessage, e);
             return generateApiGatewayProxyResponse(400, errorMessage);
         }
+    }
+
+    private APIGatewayProxyResponseEvent buildStartResponse(
+            APIGatewayProxyRequestEvent input, String sessionId, StartRequest startRequest)
+            throws JsonException, URISyntaxException {
+        var authSession = setUpAuthSession(startRequest, sessionId);
+        var requestedCredentialTrustLevel = authSession.getRequestedCredentialStrength();
+        var isUserAuthenticatedWithValidProfile =
+                isUserAuthenticatedWithValidProfile(startRequest, authSession);
+        var upliftRequired =
+                startService.isUpliftRequired(
+                        requestedCredentialTrustLevel, authSession.getAchievedCredentialStrength());
+        authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
+
+        var userContext = startService.buildUserContext(authSession);
+        var clientStartInfo = buildClientStartInfo(startRequest, authSession);
+
+        var reauthenticate = isReauthenticateRequest(input);
+        if (reauthenticate) {
+            LOG.info(
+                    "Reauthentication - Setting hasVerifiedWithPassword, hasVerifiedWithMfa & hasVerifiedWithPasskey to false");
+            authSession.setHasVerifiedWithPassword(false);
+            authSession.setHasVerifiedWithMfa(false);
+            authSession.setHasVerifiedWithPasskey(false);
+        }
+
+        var internalSubjectId = authSession.getInternalCommonSubjectId();
+        var auditContext =
+                buildAuditContext(input, sessionId, authSession, userContext, internalSubjectId);
+
+        var isBlockedForReauth = false;
+        if (reauthenticate) {
+            emitReauthRequestedObservability(startRequest, auditContext);
+            isBlockedForReauth =
+                    handleReauthLockout(
+                            authSession,
+                            startRequest,
+                            userContext,
+                            auditContext,
+                            internalSubjectId);
+        }
+
+        var userStartInfo =
+                startService.buildUserStartInfo(
+                        userContext,
+                        startService.getCookieConsentValue(
+                                startRequest.cookieConsent(), startRequest.isCookieConsentShared()),
+                        startRequest.ga(),
+                        startRequest.isIdentityVerificationRequired(),
+                        reauthenticate,
+                        isBlockedForReauth,
+                        isUserAuthenticatedWithValidProfile,
+                        upliftRequired,
+                        mfaRequired(requestedCredentialTrustLevel));
+
+        if (userStartInfo.isAuthenticated() && !userStartInfo.isUpliftRequired()) {
+            var canIssueAuthCode = permissionDecisionManager.canIssueAuthCode(authSession);
+            if (!canIssueAuthCode) {
+                LOG.warn(
+                        "Orch and auth disagree on whether user is authenticated: problems will likely arise in this journey");
+            }
+        }
+
+        StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
+
+        auditService.submitAuditEvent(
+                FrontendAuditableEvent.AUTH_START_INFO_FOUND,
+                auditContext,
+                pair(
+                        "internalSubjectId",
+                        internalSubjectId == null ? AuditService.UNKNOWN : internalSubjectId));
+
+        return generateApiGatewayProxyResponse(200, startResponse);
+    }
+
+    private AuthSessionItem setUpAuthSession(StartRequest startRequest, String sessionId) {
+        var authSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.ofNullable(startRequest.previousSessionId())
+                                .filter(s -> !s.isBlank()),
+                        sessionId);
+        LOG.info("Start session retrieved");
+        var requestedCredentialTrustLevel =
+                retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength());
+        authSession.setRequestedCredentialStrength(requestedCredentialTrustLevel);
+        if (startRequest.requestedLevelOfConfidence() != null) {
+            authSession.setRequestedLevelOfConfidence(
+                    retrieveLevelOfConfidence(startRequest.requestedLevelOfConfidence()));
+        }
+        authSession.setClientId(startRequest.clientId());
+        authSession.setClientName(startRequest.clientName());
+        authSession.setIsSmokeTest(startRequest.isSmokeTest());
+        authSession.setIsOneLoginService(startRequest.isOneLoginService());
+        authSession.setSubjectType(startRequest.subjectType());
+        authSession.setRpSectorIdentifierHost(startRequest.rpSectorIdentifierHost());
+        return authSession;
+    }
+
+    private boolean isUserAuthenticatedWithValidProfile(
+            StartRequest startRequest, AuthSessionItem authSession) {
+        if (!startRequest.authenticated()) {
+            return false;
+        }
+        var isUserProfileEmpty = startService.isUserProfileEmpty(authSession);
+        if (isUserProfileEmpty) {
+            LOG.warn("User profile for authenticated session is empty");
+        }
+        return !isUserProfileEmpty;
+    }
+
+    private ClientStartInfo buildClientStartInfo(
+            StartRequest startRequest, AuthSessionItem authSession) throws URISyntaxException {
+        var scopes = List.of(startRequest.scope().split(" "));
+        var redirectURI = new URI(startRequest.redirectUri());
+        var state = new State(startRequest.state());
+        attachLogFieldToLogs(CLIENT_ID, authSession.getClientId());
+        return startService.buildClientStartInfo(
+                startRequest.serviceType(),
+                authSession.getClientName(),
+                scopes,
+                redirectURI,
+                state,
+                startRequest.isCookieConsentShared(),
+                startRequest.isOneLoginService());
+    }
+
+    private boolean isReauthenticateRequest(APIGatewayProxyRequestEvent input) {
+        var reauthenticateHeader =
+                getHeaderValueFromHeaders(
+                        input.getHeaders(),
+                        REAUTHENTICATE_HEADER,
+                        configurationService.getHeadersCaseInsensitive());
+        var reauthenticate = reauthenticateHeader != null && reauthenticateHeader.equals("true");
+        LOG.info(
+                "reauthenticateHeader: {} reauthenticate: {}",
+                reauthenticateHeader,
+                reauthenticate);
+        return reauthenticate;
+    }
+
+    private AuditContext buildAuditContext(
+            APIGatewayProxyRequestEvent input,
+            String sessionId,
+            AuthSessionItem authSession,
+            UserContext userContext,
+            String internalSubjectId) {
+        var clientSessionId =
+                getHeaderValueFromHeaders(
+                        input.getHeaders(),
+                        CLIENT_SESSION_ID_HEADER,
+                        configurationService.getHeadersCaseInsensitive());
+        var txmaAuditHeader = getTxmaAuditEncodedHeaderOrUnknown(input);
+        return new AuditContext(
+                authSession.getClientId(),
+                clientSessionId,
+                sessionId,
+                internalSubjectId == null ? AuditService.UNKNOWN : internalSubjectId,
+                userContext
+                        .getUserProfile()
+                        .map(UserProfile::getEmail)
+                        .orElse(AuditService.UNKNOWN),
+                IpAddressHelper.extractIpAddress(input),
+                AuditService.UNKNOWN,
+                extractPersistentIdFromHeaders(input.getHeaders()),
+                txmaAuditHeader);
+    }
+
+    private boolean handleReauthLockout(
+            AuthSessionItem authSession,
+            StartRequest startRequest,
+            UserContext userContext,
+            AuditContext auditContext,
+            String internalSubjectId) {
+        var permissionContext = buildPermissionContext(authSession, startRequest, userContext);
+        var permissionResult =
+                permissionDecisionManager.canStartJourney(
+                        JourneyType.REAUTHENTICATION, permissionContext);
+
+        if (!(permissionResult.isSuccess()
+                && permissionResult.getSuccess()
+                        instanceof
+                        uk.gov.di.authentication.userpermissions.entity.Decision.ReauthLockedOut
+                        lockedOut)) {
+            return false;
+        }
+
+        if (internalSubjectId != null) {
+            var reauthCountTypesToCounts = lockedOut.detailedCounts();
+            var blockedCountTypes = lockedOut.blockedCountTypes();
+            ReauthFailureReasons failureReason =
+                    getReauthFailureReasonFromCountTypes(blockedCountTypes);
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                    auditContext,
+                    ReauthMetadataBuilder.builder(startRequest.rpPairwiseIdForReauth())
+                            .withAllIncorrectAttemptCounts(reauthCountTypesToCounts)
+                            .withFailureReason(failureReason)
+                            .build());
+            cloudwatchMetricsService.incrementCounter(
+                    CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            FAILURE_REASON.getValue(),
+                            failureReason == null ? "unknown" : failureReason.getValue()));
+        }
+        return true;
     }
 
     private void emitReauthRequestedObservability(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -166,6 +166,8 @@ class StartHandlerTest {
         var userStartInfo = getUserStartInfo(cookieConsentValue, gaTrackingId);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
+        when(permissionDecisionManager.canIssueAuthCode(any(AuthSessionItem.class)))
+                .thenReturn(true);
 
         var event =
                 apiRequestEventWithHeadersAndBody(
@@ -293,6 +295,8 @@ class StartHandlerTest {
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
+        when(permissionDecisionManager.canIssueAuthCode(any(AuthSessionItem.class)))
+                .thenReturn(true);
 
         var event =
                 apiRequestEventWithHeadersAndBody(
@@ -315,7 +319,7 @@ class StartHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void considersUserAuthenticatedButLogsWhenCannotIssueAuthCode(boolean canIssueAuthCode)
+    void overridesAuthenticatedToFalseWhenOrchAndAuthDisagree(boolean canIssueAuthCode)
             throws Json.JsonException {
         withUserProfilePresent();
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false, false);
@@ -329,21 +333,37 @@ class StartHandlerTest {
                 apiRequestEventWithHeadersAndBody(
                         VALID_HEADERS, makeRequestBodyWithAuthenticatedField(true));
 
-        var result = handler.handleRequest(event, context);
+        handler.handleRequest(event, context);
 
-        StartResponse response = objectMapper.readValue(result.getBody(), StartResponse.class);
-        assertTrue(response.user().isAuthenticated());
+        verify(startService)
+                .buildUserStartInfo(
+                        any(),
+                        any(),
+                        any(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        eq(canIssueAuthCode),
+                        anyBoolean(),
+                        anyBoolean());
 
-        var expectedLogIfCannotIssueAuthCode =
-                "Orch and auth disagree on whether user is authenticated";
+        var expectedLogIfCannotIssueAuthCode = "Auth code protection did not pass for this session";
         if (canIssueAuthCode) {
             assertThat(
                     logging.events(),
                     not(hasItem(withMessageContaining(expectedLogIfCannotIssueAuthCode))));
+            verify(cloudwatchMetricsService, never())
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.AUTH_START_OVERRIDDEN_AUTHENTICATED.getValue()),
+                            any());
         } else {
             assertThat(
                     logging.events(),
                     hasItem(withMessageContaining(expectedLogIfCannotIssueAuthCode)));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            CloudwatchMetrics.AUTH_START_OVERRIDDEN_AUTHENTICATED.getValue(),
+                            Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
         }
     }
 
@@ -356,6 +376,8 @@ class StartHandlerTest {
         var userStartInfo =
                 new UserStartInfo(false, false, isAuthenticated, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        when(permissionDecisionManager.canIssueAuthCode(any(AuthSessionItem.class)))
+                .thenReturn(true);
 
         var event =
                 apiRequestEventWithHeadersAndBody(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -106,6 +106,15 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(EMAIL, "password");
         authSessionExtension.addSession(PREVIOUS_SESSION_ID);
         authSessionExtension.addEmailToSession(PREVIOUS_SESSION_ID, EMAIL);
+        if (isAuthenticated) {
+            authSessionExtension.addAchievedCredentialTrustToSession(
+                    PREVIOUS_SESSION_ID, requestedCredentialTrustLevel);
+            var previousSession =
+                    authSessionExtension.getSession(PREVIOUS_SESSION_ID).orElseThrow();
+            previousSession.setHasVerifiedWithPassword(true);
+            previousSession.setHasVerifiedWithMfa(true);
+            authSessionExtension.updateSession(previousSession);
+        }
         authSessionExtension.addSession(sessionId);
         var state = new State();
         Scope scope = new Scope();
@@ -238,6 +247,11 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         authSessionExtension.addSession(PREVIOUS_SESSION_ID);
         authSessionExtension.addEmailToSession(PREVIOUS_SESSION_ID, userEmail);
+        authSessionExtension.addAchievedCredentialTrustToSession(PREVIOUS_SESSION_ID, MEDIUM_LEVEL);
+        var previousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID).orElseThrow();
+        previousSession.setHasVerifiedWithPassword(true);
+        previousSession.setHasVerifiedWithMfa(true);
+        authSessionExtension.updateSession(previousSession);
         authSessionExtension.addSession(sessionId);
 
         userStore.signUp(userEmail, "rubbbishPassword");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -45,7 +45,8 @@ public enum CloudwatchMetrics {
     PASSKEY_DELETION_FAILED("PasskeyDeletionFailed"),
     PASSWORD_REHASH_COMPLETED("PasswordRehashCompleted"),
     AUTH_CODE_ISSUED("AuthCodeIssued"),
-    ENHANCED_AUTH_CODE_BLOCKED("EnhancedAuthCodeBlocked");
+    ENHANCED_AUTH_CODE_BLOCKED("EnhancedAuthCodeBlocked"),
+    AUTH_START_OVERRIDDEN_AUTHENTICATED("AuthStartOverriddenAuthenticated");
 
     private String value;
 


### PR DESCRIPTION
  ## What
  
  When orch reports a user as authenticated but auth's own session state disagrees (`canIssueAuthCode` returns false), `StartHandler` previously only logged a warning and returned `authenticated=true` anyway. This sent users into a
  silent login that failed later with an auth code protection 500, no way back to the RP.
  
  Override `authenticated` to `false` in the Start response instead, so the user is sent to log in again rather than hitting that failure. Uplift journeys remain excluded via the existing `isUpliftRequired` guard.
  
  Replaced the existing disagreement log with one that says the override fired. It does not repeat the credential strengths or the `hasVerifiedWithX` flags, because `PermissionDecisionManager.canIssueAuthCode` already logs all five of those, plus the specific reason it blocked, on the lines immediately before.
  
  Added a new `CloudwatchMetrics` entry, emitted when the override fires, to track how often this happens in production.
  
  Split `handleRequest` into named methods per phase (session setup, audit context, reauth lockout, the new override). It was already over the cognitive complexity and method length thresholds the Sonar quality gate enforces before this change, and adding the override made it worse.
  
  Also fixed two `StartIntegrationTest` cases that built sessions with no verification state and asserted `authenticated=true` came back regardless, an assumption that only held because of this bug. Gave both a genuinely verified session instead of changing what they assert, since neither test is actually about the disagreement fix.
  
  Out of scope for this PR: a wipe of `hasVerifiedWithX` fields on the persisted session, and suppressing `PermissionDecisionManager.canIssueAuthCode`'s diagnostic logging.
  
  ## How to review
  
  1. Code review.
  1. Deploy to a dev environment using the appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions) (Deploy Internal API, External API, IPV API and Delivery Receipts API, since
  `StartHandler` lives in `frontend-api`).
  1. Reproduce the ticket's manual simulation: log in once, clear the verified fields on that session (or use the orch stub's "authenticated" option if testing against an orch stub rather than an RP stub, since silent login only
  fires automatically with an RP stub), start a new journey marked as authenticated.
  1. Confirm you're sent to log in again instead of hitting an auth code failure.
  1. Check the new `AuthStartOverriddenAuthenticated` CloudWatch metric fires, and the new log line (`"Auth code protection did not pass for this session..."`) appears, along with `canIssueAuthCode`'s own log lines just before it.
  
  ## Checklist

  - [x] Assessed the impact on active user sessions and confirmed no breaking changes
