### PR TITLE
AUT-5469 Remove legacy Auth internal api lambda integration

### DIFF
--- a/ci/terraform/modules/endpoint-module-v2/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module-v2/api-gateway.tf
@@ -6,9 +6,9 @@ resource "aws_api_gateway_resource" "endpoint_resource" {
 }
 
 resource "aws_api_gateway_method" "endpoint_method" {
-  for_each    = toset(var.endpoint_method)
+  for_each    = var.create_endpoint ? toset(var.endpoint_method) : toset([])
   rest_api_id = var.rest_api_id
-  resource_id = var.create_endpoint ? aws_api_gateway_resource.endpoint_resource[0].id : var.root_resource_id
+  resource_id = aws_api_gateway_resource.endpoint_resource[0].id
   http_method = each.key
 
   authorization = var.authorizer_id == null ? "NONE" : "CUSTOM"
@@ -23,9 +23,9 @@ resource "aws_api_gateway_method" "endpoint_method" {
 }
 
 resource "aws_api_gateway_integration" "endpoint_integration" {
-  for_each           = toset(var.endpoint_method)
+  for_each           = var.create_endpoint ? toset(var.endpoint_method) : toset([])
   rest_api_id        = var.rest_api_id
-  resource_id        = var.create_endpoint ? aws_api_gateway_resource.endpoint_resource[0].id : var.root_resource_id
+  resource_id        = aws_api_gateway_resource.endpoint_resource[0].id
   http_method        = aws_api_gateway_method.endpoint_method[each.key].http_method
   request_parameters = var.integration_request_parameters
 
@@ -41,6 +41,7 @@ resource "aws_api_gateway_integration" "endpoint_integration" {
 }
 
 resource "aws_lambda_permission" "endpoint_execution_permission" {
+  count         = var.create_endpoint ? 1 : 0
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = module.endpoint_lambda.endpoint_lambda_function.function_name

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -26,7 +26,8 @@ module "frontend_api_account_interventions_role" {
 module "account_interventions" {
   count = local.deploy_account_interventions_count
 
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "account-interventions"
   path_part       = "account-interventions"

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -25,7 +25,8 @@ module "frontend_api_account_recovery_role" {
 
 
 module "account_recovery" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "account-recovery"
   path_part       = "account-recovery"

--- a/ci/terraform/oidc/authdev3.tfvars
+++ b/ci/terraform/oidc/authdev3.tfvars
@@ -98,3 +98,5 @@ cmk_for_back_channel_logout_enabled = true
 
 auth_new_account_id        = "975050272416"
 deploy_orch_lambda_and_api = false
+
+deploy_frontend_api = false

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -28,7 +28,8 @@ module "frontend_api_orch_auth_code_role" {
 }
 
 module "orch_auth_code" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "orch-auth-code"
   path_part       = "orch-auth-code"

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -136,3 +136,4 @@ performance_tuning = {
 use_strongly_consistent_reads  = true
 deploy_oidc_api_gateway_domain = false
 deploy_orch_lambda_and_api     = false
+deploy_frontend_api            = false

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -22,8 +22,9 @@ module "frontend_api_check_email_fraud_block_role" {
 }
 
 module "check_email_fraud_block" {
-  count  = local.deploy_check_email_fraud_block_count
-  source = "../modules/endpoint-module-v2"
+  count           = local.deploy_check_email_fraud_block_count
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "check-email-fraud-block"
   path_part       = "check-email-fraud-block"

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -24,8 +24,9 @@ module "frontend_api_check_reauth_user_role" {
 }
 
 module "check_reauth_user" {
-  count  = local.deploy_reauth_user_count
-  source = "../modules/endpoint-module-v2"
+  count           = local.deploy_reauth_user_count
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "check-reauth-user"
   path_part       = "check-reauth-user"

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -1,5 +1,7 @@
 shared_state_bucket = "di-auth-development-tfstate"
 
+environment = "dev"
+
 # FMS
 frontend_api_fms_tag_value = "authfrontenddev"
 
@@ -111,3 +113,5 @@ use_strongly_consistent_reads  = true
 support_reauth_signout_enabled = true
 deploy_oidc_api_gateway_domain = false
 deploy_orch_lambda_and_api     = false
+
+deploy_frontend_api = false

--- a/ci/terraform/oidc/id-reverification-state.tf
+++ b/ci/terraform/oidc/id-reverification-state.tf
@@ -14,7 +14,8 @@ module "id_reverification_state_role" {
 }
 
 module "id_reverification_state" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "id-reverification-state"
   path_part       = "id-reverification-state"

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -29,8 +29,9 @@ moved {
 }
 
 module "ipv-callback" {
-  source = "../modules/endpoint-module-v2"
-  count  = var.deploy_orch_lambda_and_api ? 1 : 0
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
+  count           = var.deploy_orch_lambda_and_api ? 1 : 0
 
   endpoint_name   = "ipv-callback"
   path_part       = var.orch_ipv_callback_enabled ? "ipv-callback-auth" : "ipv-callback"
@@ -59,7 +60,6 @@ module "ipv-callback" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 
-  create_endpoint  = true
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api[0].id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api[0].root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api[0].execution_arn

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -30,7 +30,8 @@ module "frontend_api_login_role_with_combined_auth_attempts_table_policies" {
 }
 
 module "login" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "login"
   path_part       = "login"

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -23,7 +23,8 @@ module "mfa_reset_authorize_role" {
 
 
 module "mfa_reset_authorize" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "mfa-reset-authorize"
   path_part       = "mfa-reset-authorize"

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -18,7 +18,8 @@ module "mfa_reset_jar_signing_jwk_role" {
 }
 
 module "mfa_reset_jar_signing_jwk" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name           = local.reverification_jwk_json_endpoint_name
   endpoint_name_sanitized = local.reverification_jwk_json_endpoint_name_sanitized

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -13,7 +13,8 @@ module "mfa_reset_storage_token_jwk_role" {
 }
 
 module "mfa_reset_storage_token_jwk" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name           = "mfa-reset-jwk.json"
   endpoint_name_sanitized = "mfa-reset-jwkjson"

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -24,7 +24,8 @@ module "frontend_api_mfa_role" {
 }
 
 module "mfa" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "mfa"
   path_part       = "mfa"

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -49,7 +49,8 @@ module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_a
 }
 
 module "processing-identity" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "processing-identity"
   path_part       = "processing-identity"

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -23,7 +23,8 @@ module "frontend_api_reset_password_request_role" {
 }
 
 module "reset-password-request" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "reset-password-request"
   path_part       = "reset-password-request"

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -28,7 +28,8 @@ module "frontend_api_reset_password_role" {
 }
 
 module "reset_password" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "reset-password"
   path_part       = "reset-password"

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -20,7 +20,8 @@ module "reverification_result_role" {
 }
 
 module "reverification_result" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "reverification-result"
   path_part       = "reverification-result"

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -27,7 +27,8 @@ module "frontend_api_send_notification_role" {
 }
 
 module "send_notification" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "send-notification"
   path_part       = "send-notification"

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -26,7 +26,8 @@ module "frontend_api_signup_role" {
 }
 
 module "signup" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "signup"
   path_part       = "signup"

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -25,7 +25,8 @@ module "frontend_api_start_role" {
 }
 
 module "start" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "start"
   path_part       = "start"

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -23,7 +23,8 @@ module "frontend_api_update_profile_role" {
 }
 
 module "update_profile" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "update-profile"
   path_part       = "update-profile"

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -23,7 +23,8 @@ module "frontend_api_user_exists_role" {
 }
 
 module "userexists" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "user-exists"
   path_part       = "user-exists"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -747,3 +747,8 @@ variable "deploy_orch_lambda_and_api" {
   type    = bool
   default = true
 }
+
+variable "deploy_frontend_api" {
+  type    = bool
+  default = true
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -28,7 +28,8 @@ module "frontend_api_verify_code_role_with_combined_auth_attempts_policy" {
 
 
 module "verify_code" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "verify-code"
   path_part       = "verify-code"

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -26,7 +26,8 @@ module "frontend_api_verify_mfa_code_role_with_combined_auth_attempts_policy" {
 }
 
 module "verify_mfa_code" {
-  source = "../modules/endpoint-module-v2"
+  source          = "../modules/endpoint-module-v2"
+  create_endpoint = var.deploy_frontend_api
 
   endpoint_name   = "verify-mfa-code"
   path_part       = "verify-mfa-code"


### PR DESCRIPTION
## What

[AUT-5469] removing legacy api lambda integration form Auth Internal Api  in Dev & build , stage 1 PR of Deleting legacy Frontend Api resource 

## How to review


1. Code Review
1. Deploy to a Authdevs  environment using  ./deploy-authdevs.sh -o -p 

check the Auth Api integration on AWS console should show no endpoints

[AUT-5469]: https://govukverify.atlassian.net/browse/AUT-5469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<img width="809" height="404" alt="image" src="https://github.com/user-attachments/assets/41ed3ef8-49bb-4f43-9c72-cfc8aaba9b1e" />
