### PR TITLE
Aut 5809/allow retrieval of session with previous session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartHandlerIntegrationTest.java
@@ -100,8 +100,7 @@ class StartHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             CredentialTrustLevel requestedCredentialTrustLevel,
             boolean identityRequired,
             boolean isAuthenticated,
-            boolean isMfaRequired)
-            throws Json.JsonException {
+            boolean isMfaRequired) {
         String sessionId = IdGenerator.generate();
         userStore.signUp(EMAIL, "password");
         authSessionExtension.addSession(PREVIOUS_SESSION_ID);
@@ -353,7 +352,7 @@ class StartHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldReturn400WhenRedirectURIIsInvalid() throws Exception {
+    void shouldReturn400WhenRedirectURIIsInvalid() {
         String sessionId = IdGenerator.generate();
         userStore.signUp(EMAIL, "password");
         authSessionExtension.addSession(sessionId);
@@ -426,7 +425,7 @@ class StartHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         Scope scope;
 
         @BeforeEach
-        void setup() throws Json.JsonException {
+        void setup() {
             handler = new StartHandler(new TestConfigurationService());
             txmaAuditQueue.clear();
             sessionId = IdGenerator.generate();
@@ -514,7 +513,7 @@ class StartHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         Scope scope = new Scope();
 
         @BeforeEach
-        void setup() throws Json.JsonException {
+        void setup() {
             handler = new StartHandler(new TestConfigurationService());
             txmaAuditQueue.clear();
             sessionId = IdGenerator.generate();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartHandlerIntegrationTest.java
@@ -50,7 +50,7 @@ import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+class StartHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String CLIENT_ID = "test-client-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -283,6 +283,66 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
+    void shouldHandleMultipleDuplicateRequestsWhenThereIsAnExistingPreviousSession()
+            throws Json.JsonException {
+        var userEmail = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+        var isAuthenticated = true;
+        var sessionId = IdGenerator.generate();
+        authSessionExtension.addSession(PREVIOUS_SESSION_ID);
+        authSessionExtension.addEmailToSession(PREVIOUS_SESSION_ID, userEmail);
+
+        userStore.signUp(userEmail, "rubbbishPassword");
+        userStore.addVerifiedPhoneNumber(userEmail, "+447316763843");
+
+        var state = new State();
+        var scope = new Scope(OIDCScopeValue.OPENID);
+
+        KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+
+        var requestBody =
+                makeRequestBody(
+                        isAuthenticated,
+                        WITH_PREVIOUS_SESSION,
+                        state.getValue(),
+                        scope.toString(),
+                        REDIRECT_URI.toString(),
+                        Optional.empty(),
+                        MEDIUM_LEVEL,
+                        false);
+
+        var firstResponse =
+                makeRequest(
+                        Optional.of(requestBody),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
+        var firstStartResponse =
+                objectMapper.readValue(firstResponse.getBody(), StartResponse.class);
+        var sessionAfterFirstResponse = authSessionExtension.getSession(sessionId);
+
+        var secondResponse =
+                makeRequest(
+                        Optional.of(requestBody),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
+        var secondStartResponse =
+                objectMapper.readValue(secondResponse.getBody(), StartResponse.class);
+
+        var sessionAfterSecondResponse = authSessionExtension.getSession(sessionId);
+
+        assertThat(firstResponse, hasStatus(200));
+        assertThat(secondResponse, hasStatus(200));
+
+        assertThat(firstStartResponse.user().isAuthenticated(), equalTo(true));
+        assertThat(secondStartResponse.user().isAuthenticated(), equalTo(true));
+
+        assertThat(sessionAfterFirstResponse.isPresent(), equalTo(true));
+        assertThat(sessionAfterSecondResponse.isPresent(), equalTo(true));
+
+        assertThat(sessionAfterFirstResponse.get().getEmailAddress(), equalTo(userEmail));
+        assertThat(sessionAfterSecondResponse.get().getEmailAddress(), equalTo(userEmail));
+    }
+
+    @Test
     void shouldReturn400WhenClientSessionIdMissing() {
         var headers = Map.of("X-API-Key", FRONTEND_API_KEY);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -49,13 +49,13 @@ class AuthSessionServiceIntegrationTest {
     void shouldReturnUpdatedSessionWhenItExistsAndDeletePrevious() {
         withStoredSession(PREVIOUS_SESSION_ID);
 
-        AuthSessionItem previousSession =
+        var newSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
                         Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
         var previousSessionItem = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
         assertTrue(previousSessionItem.isEmpty());
-        assertThat(previousSession.getSessionId(), is(SESSION_ID));
+        assertThat(newSession.getSessionId(), is(SESSION_ID));
     }
 
     @Test
@@ -64,10 +64,10 @@ class AuthSessionServiceIntegrationTest {
 
         assertTrue(previousSessionItem.isEmpty());
 
-        AuthSessionItem previousSession =
+        var newSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
                         Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
-        assertThat(previousSession.getSessionId(), is(SESSION_ID));
+        assertThat(newSession.getSessionId(), is(SESSION_ID));
     }
 
     @Test
@@ -98,7 +98,7 @@ class AuthSessionServiceIntegrationTest {
         previousSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         authSessionExtension.updateSession(previousSession);
 
-        AuthSessionItem retrievedSession =
+        var retrievedSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
                         Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
         var retrievedPreviousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.services;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -14,11 +16,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
@@ -68,6 +72,7 @@ class AuthSessionServiceIntegrationTest {
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)
                         .withPreviousSessionId(PREVIOUS_SESSION_ID)
+                        .withCreatedAt(Instant.now().toString())
                         .withEmailAddress(emailAddressWhichWouldntExistOnGeneratedSession)
                         .withTimeToLive(Instant.now().plus(10L, ChronoUnit.HOURS).toEpochMilli());
         authSessionExtension.addSession(existingSessionItem);
@@ -89,6 +94,37 @@ class AuthSessionServiceIntegrationTest {
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)
                         .withPreviousSessionId("foo")
+                        .withCreatedAt(Instant.now().toString())
+                        .withEmailAddress(emailAddressWhichWouldNotExistOnGeneratedSession)
+                        .withTimeToLive(Instant.now().plus(10L, ChronoUnit.HOURS).toEpochMilli());
+        authSessionExtension.addSession(existingSessionItem);
+
+        var newSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
+
+        assertThat(newSession.getSessionId(), is(SESSION_ID));
+        assertNull(newSession.getPreviousSessionId());
+        assertNull(newSession.getEmailAddress());
+    }
+
+    private static Stream<AuthSessionItem> authSessionItemsWithIneligibleCreatedAts() {
+        return Stream.of(
+                new AuthSessionItem()
+                        .withCreatedAt(Instant.now().minus(1001, ChronoUnit.MILLIS).toString()),
+                new AuthSessionItem(), // no created at
+                new AuthSessionItem().withCreatedAt("Not a parseable localdate time"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("authSessionItemsWithIneligibleCreatedAts")
+    void shouldGenerateANewSessionWhenExistingSessionIsMoreThanOneSecondOldOrCreationDateNotPresent(
+            AuthSessionItem blankAuthSessionItemWithIneligibleCreatedAt) {
+        var emailAddressWhichWouldNotExistOnGeneratedSession = "test@example.com";
+        var existingSessionItem =
+                blankAuthSessionItemWithIneligibleCreatedAt
+                        .withSessionId(SESSION_ID)
+                        .withPreviousSessionId(PREVIOUS_SESSION_ID)
                         .withEmailAddress(emailAddressWhichWouldNotExistOnGeneratedSession)
                         .withTimeToLive(Instant.now().plus(10L, ChronoUnit.HOURS).toEpochMilli());
         authSessionExtension.addSession(existingSessionItem);
@@ -152,6 +188,7 @@ class AuthSessionServiceIntegrationTest {
         assertThat(
                 retrievedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
         assertThat(retrievedSession.getPreviousSessionId(), equalTo(PREVIOUS_SESSION_ID));
+        assertNotNull(retrievedSession.getCreatedAt());
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -92,7 +92,7 @@ class AuthSessionServiceIntegrationTest {
     }
 
     @Test
-    void shouldReturnAPreviousSessionWithRetainedValues() {
+    void shouldReturnAPreviousSessionWithRetainedValuesAndPreviousSessionId() {
         var previousSession = withStoredSession(PREVIOUS_SESSION_ID);
 
         previousSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
@@ -107,6 +107,7 @@ class AuthSessionServiceIntegrationTest {
         assertThat(retrievedSession.getSessionId(), equalTo(SESSION_ID));
         assertThat(
                 retrievedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
+        assertThat(retrievedSession.getPreviousSessionId(), equalTo(PREVIOUS_SESSION_ID));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -9,6 +9,8 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 
@@ -56,6 +59,47 @@ class AuthSessionServiceIntegrationTest {
 
         assertTrue(previousSessionItem.isEmpty());
         assertThat(newSession.getSessionId(), is(SESSION_ID));
+    }
+
+    @Test
+    void shouldReturnExistingSessionWhenItMatchesTheSessionIdAndPreviousSessionId() {
+        var emailAddressWhichWouldntExistOnGeneratedSession = "test@example.com";
+        var existingSessionItem =
+                new AuthSessionItem()
+                        .withSessionId(SESSION_ID)
+                        .withPreviousSessionId(PREVIOUS_SESSION_ID)
+                        .withEmailAddress(emailAddressWhichWouldntExistOnGeneratedSession)
+                        .withTimeToLive(Instant.now().plus(10L, ChronoUnit.HOURS).toEpochMilli());
+        authSessionExtension.addSession(existingSessionItem);
+
+        var newSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
+
+        assertThat(newSession.getSessionId(), is(SESSION_ID));
+        assertThat(newSession.getPreviousSessionId(), is(PREVIOUS_SESSION_ID));
+        assertThat(
+                newSession.getEmailAddress(), is(emailAddressWhichWouldntExistOnGeneratedSession));
+    }
+
+    @Test
+    void shouldGenerateANewSessionWhenExistingSessionDoesNotMatchPreviousSessionId() {
+        var emailAddressWhichWouldNotExistOnGeneratedSession = "test@example.com";
+        var existingSessionItem =
+                new AuthSessionItem()
+                        .withSessionId(SESSION_ID)
+                        .withPreviousSessionId("foo")
+                        .withEmailAddress(emailAddressWhichWouldNotExistOnGeneratedSession)
+                        .withTimeToLive(Instant.now().plus(10L, ChronoUnit.HOURS).toEpochMilli());
+        authSessionExtension.addSession(existingSessionItem);
+
+        var newSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
+
+        assertThat(newSession.getSessionId(), is(SESSION_ID));
+        assertNull(newSession.getPreviousSessionId());
+        assertNull(newSession.getEmailAddress());
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -78,6 +78,10 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
         authSessionService.addSession(authSessionService.generateNewAuthSession(sessionId));
     }
 
+    public void addSession(AuthSessionItem sessionItem) {
+        authSessionService.addSession(sessionItem);
+    }
+
     public void addEmailToSession(String sessionId, String email) {
         updateSession(getSession(sessionId).orElseThrow().withEmailAddress(email));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -49,6 +49,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY = "HasVerifiedWithPasskey";
     public static final String ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT = "IsPartiallyCreatedAccount";
     public static final String ATTRIBUTE_PREVIOUS_SESSION_ID = "PreviousSessionId";
+    public static final String ATTRIBUTE_CREATED_AT = "CreatedAt";
 
     public enum AccountState {
         NEW,
@@ -97,6 +98,7 @@ public class AuthSessionItem {
     private boolean hasVerifiedWithPasskey;
     private boolean isPartiallyCreatedAccount;
     private String previousSessionId;
+    private String createdAt;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -569,6 +571,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withPreviousSessionId(String previousSessionId) {
         this.previousSessionId = previousSessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CREATED_AT)
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public AuthSessionItem withCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -48,6 +48,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_MFA = "HasVerifiedWithMfa";
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY = "HasVerifiedWithPasskey";
     public static final String ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT = "IsPartiallyCreatedAccount";
+    public static final String ATTRIBUTE_PREVIOUS_SESSION_ID = "PreviousSessionId";
 
     public enum AccountState {
         NEW,
@@ -95,6 +96,7 @@ public class AuthSessionItem {
     private boolean hasVerifiedWithMfa;
     private boolean hasVerifiedWithPasskey;
     private boolean isPartiallyCreatedAccount;
+    private String previousSessionId;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -556,6 +558,20 @@ public class AuthSessionItem {
         return this;
     }
 
+    @DynamoDbAttribute(ATTRIBUTE_PREVIOUS_SESSION_ID)
+    public String getPreviousSessionId() {
+        return previousSessionId;
+    }
+
+    public void setPreviousSessionId(String previousSessionId) {
+        this.previousSessionId = previousSessionId;
+    }
+
+    public AuthSessionItem withPreviousSessionId(String previousSessionId) {
+        this.previousSessionId = previousSessionId;
+        return this;
+    }
+
     /**
      * Return a string representation of the instance that is safe to record in logs (e.g. does not
      * contain PII)
@@ -575,6 +591,8 @@ public class AuthSessionItem {
                 + resetMfaState
                 + "', upliftRequired = '"
                 + upliftRequired
+                + "', previousSessionId = '"
+                + previousSessionId
                 + "', hasVerifiedWithPassword = '"
                 + hasVerifiedWithPassword
                 + "', hasVerifiedWithMfa = '"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -66,41 +66,43 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
     }
 
     public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
-            Optional<String> previousSessionId, String newSessionId) {
+            Optional<String> maybePreviousSessionId, String newSessionId) {
 
         try {
             Optional<AuthSessionItem> previousAuthSession = Optional.empty();
-            if (previousSessionId.isPresent()) {
-                previousAuthSession = getSession(previousSessionId.get());
+            if (maybePreviousSessionId.isPresent()) {
+                previousAuthSession = getSession(maybePreviousSessionId.get());
             }
 
             if (previousAuthSession.isPresent()) {
+                var previousSessionId = maybePreviousSessionId.get();
                 var updatedSession =
                         previousAuthSession
                                 .get()
                                 .withSessionId(newSessionId)
                                 .withResetPasswordState(AuthSessionItem.ResetPasswordState.NONE)
                                 .withResetMfaState(AuthSessionItem.ResetMfaState.NONE)
+                                .withPreviousSessionId(previousSessionId)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
                                                 .getEpochSecond());
 
-                delete(previousSessionId.get());
+                delete(previousSessionId);
                 LOG.info(
                         "Existing Auth session updated from previousSessionId: {}, sessionId: {}",
-                        previousSessionId,
+                        maybePreviousSessionId,
                         newSessionId);
 
                 return updatedSession;
             } else {
-                if (previousSessionId.isPresent()) {
+                if (maybePreviousSessionId.isPresent()) {
                     var existingSessionWithNewSessionId = getSession(newSessionId);
                     if (existingSessionWithNewSessionId.isPresent()) {
                         LOG.info(
                                 "Session already exists with newSessionId {} for previousSessionId {} may cause problems",
                                 newSessionId,
-                                previousSessionId);
+                                maybePreviousSessionId);
                     }
                 }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
@@ -97,12 +98,19 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 return updatedSession;
             } else {
                 if (maybePreviousSessionId.isPresent()) {
-                    var existingSessionWithNewSessionId = getSession(newSessionId);
+                    var existingSessionWithNewSessionId =
+                            getSession(newSessionId)
+                                    .filter(
+                                            session ->
+                                                    Objects.equals(
+                                                            session.getPreviousSessionId(),
+                                                            maybePreviousSessionId.get()));
                     if (existingSessionWithNewSessionId.isPresent()) {
                         LOG.info(
-                                "Session already exists with newSessionId {} for previousSessionId {} may cause problems",
+                                "Session already exists with newSessionId {} and previousSessionId {}, reusing",
                                 newSessionId,
                                 maybePreviousSessionId);
+                        return existingSessionWithNewSessionId.get();
                     }
                 }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -11,6 +11,8 @@ import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +24,8 @@ import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOpt
 public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
 
     private static final Logger LOG = LogManager.getLogger(AuthSessionService.class);
+
+    private static final int SESSION_REUSE_TOLERANCE_SECONDS = 1;
 
     private final ConfigurationService configurationService;
 
@@ -51,6 +55,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         return new AuthSessionItem()
                 .withSessionId(sessionId)
                 .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
+                .withCreatedAt(Instant.now().toString())
                 .withTimeToLive(
                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                 .toInstant()
@@ -84,6 +89,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                                 .withResetPasswordState(AuthSessionItem.ResetPasswordState.NONE)
                                 .withResetMfaState(AuthSessionItem.ResetMfaState.NONE)
                                 .withPreviousSessionId(previousSessionId)
+                                .withCreatedAt(Instant.now().toString())
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
@@ -102,9 +108,8 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                             getSession(newSessionId)
                                     .filter(
                                             session ->
-                                                    Objects.equals(
-                                                            session.getPreviousSessionId(),
-                                                            maybePreviousSessionId.get()));
+                                                    sessionIsEligibleToBeReused(
+                                                            session, maybePreviousSessionId.get()));
                     if (existingSessionWithNewSessionId.isPresent()) {
                         LOG.info(
                                 "Session already exists with newSessionId {} and previousSessionId {}, reusing",
@@ -123,6 +128,35 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                     newSessionId,
                     e.getMessage());
             throw new AuthSessionException(e.getMessage());
+        }
+    }
+
+    private boolean sessionIsEligibleToBeReused(
+            AuthSessionItem retrievedSession, String previousSessionId) {
+        if (!Objects.equals(retrievedSession.getPreviousSessionId(), previousSessionId)) {
+            return false;
+        }
+
+        return parseCreatedAt(retrievedSession.getCreatedAt())
+                .map(
+                        createdAt ->
+                                createdAt.isAfter(
+                                        Instant.now()
+                                                .minus(
+                                                        SESSION_REUSE_TOLERANCE_SECONDS,
+                                                        ChronoUnit.SECONDS)))
+                .orElse(false);
+    }
+
+    private Optional<Instant> parseCreatedAt(String createdAt) {
+        if (createdAt == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Instant.parse(createdAt));
+        } catch (DateTimeParseException e) {
+            LOG.warn("Could not parse created at {} as instant, not reusing session", createdAt);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
## What

If we receive a double request for an authenticated user to the start handler in quick succession, this often means the user is not silently logged in.

This happens because our logic for handling requests for sessions with previous sessions is to look up the previous session from the database. If it exists, we copy it over to the new session and delete the previous session. If it doesn't exist, we create a new session.

In the double request scenario this plays out as follows:

* Two requests are received for session `b` with previous authenticatied session `a`
* In the first request, we look up session `a` from the database. It exists, so we create a new session `b` and copy over the details from `a`. `a` is no longer needed, so we delete it.
* In the second request, we look up session `a` from the database. It no longer exists. We then create an entirely new session `b`, overwriting what we did in the first request.
* This means that the first request will return authenticated = false to the frontend, since the session `b` does not have an email address on it, meaning we need to make the user fully log in.

This PR fixes this, by allowing the second request to see if session `b` can be retrieved from the database already, before creating a new one.

We allow reuse of session `b` if:
* it has a previous session `a`; and
* it was created less than 1 second ago

These measures provide additional assurance that we are dealing with duplicate requests. The time limit may be reviewed in future as it's possible we can be more flexible.

