### PR TITLE
AUT-5255: Remove legacy oidc Api from build

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -135,3 +135,4 @@ performance_tuning = {
 
 use_strongly_consistent_reads  = true
 deploy_oidc_api_gateway_domain = false
+deploy_orch_lambda_and_api     = false


### PR DESCRIPTION
## What


AUT-5255 : Removing  legacy oidc Api from build environment

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8856
