### PR TITLE
AUT-5795: Stop overwriting entire session when doing session updates in StartPasskeyAssertionHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -130,10 +130,8 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                     500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
         }
 
-        authSessionService.updateSession(
-                userContext
-                        .getAuthSession()
-                        .withPasskeyAssertionRequest(assertionRequestJsonToStore));
+        authSessionService.updateSessionPasskeyAssertionRequest(
+                userContext.getAuthSession().getSessionId(), assertionRequestJsonToStore);
 
         incrementAuthenticationGeneratedMetric();
         emitAuthPasskeyAuthenticationGeneratedAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
@@ -41,7 +41,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -155,11 +154,7 @@ class StartPasskeyAssertionHandlerTest {
             assertThat(result, hasStatus(200));
             assertThat(result.getBody(), equalTo(assertionRequest.toCredentialsGetJson()));
             verify(authSessionService)
-                    .updateSession(
-                            argThat(
-                                    session ->
-                                            session.getPasskeyAssertionRequest()
-                                                    .equals(expectedJson)));
+                    .updateSessionPasskeyAssertionRequest(authSession.getSessionId(), expectedJson);
         }
 
         @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -138,6 +138,21 @@ class AuthSessionServiceIntegrationTest {
         assertThat(updatedSession.getPreservedReauthCountsForAuditMap(), equalTo(counts));
     }
 
+    @Test
+    void shouldUpdateSessionPasskeyAssertionRequestWithoutAffectingOtherFields() {
+        withStoredSession(SESSION_ID);
+
+        var session = authSessionExtension.getSession(SESSION_ID).orElseThrow();
+        assertThat(session.getHasVerifiedWithPasskey(), equalTo(false));
+
+        authSessionExtension.updateSession(session.withHasVerifiedWithPasskey(true));
+        authSessionExtension.updateSessionPasskeyAssertionRequest(SESSION_ID, "assertion-2");
+
+        var result = authSessionExtension.getSession(SESSION_ID).orElseThrow();
+        assertThat(result.getHasVerifiedWithPasskey(), equalTo(true));
+        assertThat(result.getPasskeyAssertionRequest(), equalTo("assertion-2"));
+    }
+
     private AuthSessionItem withStoredSession(String sessionId) {
         authSessionExtension.addSession(sessionId);
         return authSessionExtension.getSession(sessionId).get();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -153,4 +153,10 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
                         .orElseThrow()
                         .incrementCodeRequestCount(notificationType, journeyType));
     }
+
+    public void updateSessionPasskeyAssertionRequest(
+            String sessionId, String assertionRequestJsonToStore) {
+        authSessionService.updateSessionPasskeyAssertionRequest(
+                sessionId, assertionRequestJsonToStore);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -6,6 +6,8 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
@@ -176,6 +178,37 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         } catch (Exception e) {
             logAndThrowAuthSessionException(
                     "Failed to update Auth session item", sessionItem.getSessionId(), e);
+        }
+    }
+
+    public void updateSessionPasskeyAssertionRequest(
+            String sessionId, String assertionRequestJsonToStore) {
+        var authSessionTableName = dynamoTable.tableName();
+        try {
+            update(
+                    UpdateItemRequest.builder()
+                            .tableName(authSessionTableName)
+                            .key(
+                                    Map.of(
+                                            AuthSessionItem.ATTRIBUTE_SESSION_ID,
+                                            AttributeValue.fromS(sessionId)))
+                            .updateExpression(
+                                    "SET #PasskeyAssertionRequest = :PasskeyAssertionRequest")
+                            .conditionExpression("attribute_exists(#SessionId)")
+                            .expressionAttributeNames(
+                                    Map.of(
+                                            "#PasskeyAssertionRequest",
+                                                    AuthSessionItem
+                                                            .ATTRIBUTE_PASSKEY_ASSERTION_REQUEST,
+                                            "#SessionId", AuthSessionItem.ATTRIBUTE_SESSION_ID))
+                            .expressionAttributeValues(
+                                    Map.of(
+                                            ":PasskeyAssertionRequest",
+                                            AttributeValue.fromS(assertionRequestJsonToStore)))
+                            .build());
+        } catch (Exception e) {
+            logAndThrowAuthSessionException(
+                    "Failed to update Auth session passkey assertion request", sessionId, e);
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 
@@ -40,6 +41,10 @@ public class BaseDynamoService<T> {
 
     public void update(T item) {
         dynamoTable.updateItem(item);
+    }
+
+    public void update(UpdateItemRequest updateItemRequest) {
+        client.updateItem(updateItemRequest);
     }
 
     public void put(T item) {


### PR DESCRIPTION
## What

We were seeing issues in the StartPasskeyAssertionHandler where a duplicate request was causing the `hasVerifiedWithPasskey` attribute to be overwritten in the session even though the user successfully signed in with their passkey. This means they were not issued an auth code when they should have been. 

To fix this, I am only updating the relevant property on the session in the StartPasskeyAssertionHandler (rather than updating the full session) to prevent stale sessions causing issues.

## How to review

1. Code review

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->



<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->



<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->



## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
