### PR TITLE
AUT-5255: Remove legacy oidc Api from staging

### DIFF
--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -167,3 +167,4 @@ use_strongly_consistent_reads = true
 ipv_jwks_call_enabled          = true
 ipv_jwks_url                   = "https://api.identity.staging.account.gov.uk/.well-known/jwks.json"
 deploy_oidc_api_gateway_domain = false
+deploy_orch_lambda_and_api     = false


### PR DESCRIPTION
## What

AUT-5255 : Removing legacy oidc Api from Staging environment

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8856