### PR TITLE
AUT-5255: Remove legacy oidc Api from integration

### DIFF
--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -149,3 +149,4 @@ performance_tuning = {
 ipv_jwks_call_enabled          = true
 ipv_jwks_url                   = "https://api.identity.integration.account.gov.uk/.well-known/jwks.json"
 deploy_oidc_api_gateway_domain = false
+deploy_orch_lambda_and_api     = false


### PR DESCRIPTION
## What

AUT-5255 : Removing legacy oidc Api from integration environment

## How to review


1. Code Review


## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8856
