### PR TITLE
AUT-5469: Remove legacy Auth internal api lambda integration from Staging env

### DIFF
--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -168,3 +168,4 @@ ipv_jwks_call_enabled          = true
 ipv_jwks_url                   = "https://api.identity.staging.account.gov.uk/.well-known/jwks.json"
 deploy_oidc_api_gateway_domain = false
 deploy_orch_lambda_and_api     = false
+deploy_frontend_api            = false


### PR DESCRIPTION
## What

[AUT-5469](https://govukverify.atlassian.net/browse/AUT-5469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) removing legacy api lambda integration form Auth Internal Api in Staging, stage 1 PR of Deleting legacy Frontend Api resource

## How to review

1. Code Review


[AUT-5469]: https://govukverify.atlassian.net/browse/AUT-5469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ