### PR TITLE
AUT-5469:Remove legacy Auth internal api endpoint from Integration env

### DIFF
--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -150,3 +150,4 @@ ipv_jwks_call_enabled          = true
 ipv_jwks_url                   = "https://api.identity.integration.account.gov.uk/.well-known/jwks.json"
 deploy_oidc_api_gateway_domain = false
 deploy_orch_lambda_and_api     = false
+deploy_frontend_api            = false


### PR DESCRIPTION
## What

[ AUT-5469 ] :Remove legacy Auth internal api endpoint from Integration env

## How to review


1. Code Review
