### PR TITLE
AUT-5729: Emit metric when IAD guardrail hit

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandler.java
@@ -22,20 +22,27 @@ import uk.gov.di.authentication.shared.helpers.InactiveAccountFailsafeCheckHelpe
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.GUARDRAIL_TYPE;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.GUARDRAIL_PREVENTED_INACTIVE_ACCOUNT_DELETION;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceId;
+import static uk.gov.di.authentication.shared.services.CloudwatchMetricsService.HOME_READ_ONLY_NAMESPACE;
 
 public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDeletionHandler.class);
+    private static final String GUARDRAIL_TYPE_VALUE = "AuthUserActivityCheck";
 
     private final Json objectMapper = SerializationService.getInstance();
     private final InactiveAccountDeletionTokenService tokenService;
@@ -43,6 +50,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
     private final DynamoService dynamoService;
     private final StructuredAuditService structuredAuditService;
     private final ConfigurationService configurationService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
     private final Clock clock;
 
     public InactiveAccountDeletionHandler() {
@@ -58,6 +66,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
         this.dynamoService = new DynamoService(configurationService);
         this.structuredAuditService = new StructuredAuditService(configurationService);
         this.configurationService = configurationService;
+        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.clock = Clock.systemUTC();
     }
 
@@ -67,12 +76,14 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
             DynamoService dynamoService,
             StructuredAuditService structuredAuditService,
             ConfigurationService configurationService,
+            CloudwatchMetricsService cloudwatchMetricsService,
             Clock clock) {
         this.tokenService = tokenService;
         this.accountDeletionService = accountDeletionService;
         this.dynamoService = dynamoService;
         this.structuredAuditService = structuredAuditService;
         this.configurationService = configurationService;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.clock = clock;
     }
 
@@ -137,6 +148,7 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                 InactiveAccountFailsafeCheckHelper.checkForRecentActivity(
                         userProfile, userCredentials, clock);
         if (activityCheck.recentlyActive()) {
+            emitGuardrailMetric();
             throw new RecentlyActiveAccountException(
                     String.format(
                             "Skipping deletion for publicSubjectId: %s. Account has recent activity on attribute: %s",
@@ -202,6 +214,21 @@ public class InactiveAccountDeletionHandler implements RequestHandler<SQSEvent, 
                     "Failed to submit AUTH_DELETE_ACCOUNT audit event for publicSubjectId: {}",
                     userProfile.getPublicSubjectID(),
                     e);
+        }
+    }
+
+    private void emitGuardrailMetric() {
+        try {
+            cloudwatchMetricsService.incrementCounter(
+                    GUARDRAIL_PREVENTED_INACTIVE_ACCOUNT_DELETION.getValue(),
+                    Map.of(
+                            GUARDRAIL_TYPE.getValue(),
+                            GUARDRAIL_TYPE_VALUE,
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment()),
+                    HOME_READ_ONLY_NAMESPACE);
+        } catch (Exception e) {
+            LOG.error("Failed to emit guardrail hit metric", e);
         }
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/InactiveAccountDeletionHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
@@ -26,6 +27,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +45,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.GUARDRAIL_TYPE;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.GUARDRAIL_PREVENTED_INACTIVE_ACCOUNT_DELETION;
 
 class InactiveAccountDeletionHandlerTest {
 
@@ -51,6 +56,7 @@ class InactiveAccountDeletionHandlerTest {
     private static final String EMAIL = "test@example.com";
     private static final String TOKEN_VALUE = "test-bearer-token";
     private static final String INTERNAL_SECTOR_URI = "https://identity.test.account.gov.uk";
+    private static final String TEST_ENVIRONMENT = "test";
 
     private static final Clock FIXED_CLOCK =
             Clock.fixed(Instant.parse("2026-09-04T14:00:00Z"), ZoneOffset.UTC);
@@ -67,6 +73,8 @@ class InactiveAccountDeletionHandlerTest {
     private final StructuredAuditService structuredAuditService =
             mock(StructuredAuditService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
     private InactiveAccountDeletionHandler handler;
 
     @BeforeEach
@@ -78,6 +86,7 @@ class InactiveAccountDeletionHandlerTest {
                         dynamoService,
                         structuredAuditService,
                         configurationService,
+                        cloudwatchMetricsService,
                         FIXED_CLOCK);
         when(tokenService.createAccountDataApiAccessToken(any()))
                 .thenReturn(Result.success(new BearerAccessToken(TOKEN_VALUE)));
@@ -86,6 +95,7 @@ class InactiveAccountDeletionHandlerTest {
         when(dynamoService.getUserCredentialsFromEmail(any()))
                 .thenReturn(inactiveUserCredentials());
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(configurationService.getEnvironment()).thenReturn(TEST_ENVIRONMENT);
         when(dynamoService.getOrGenerateSalt(any())).thenReturn(new byte[] {0x1});
     }
 
@@ -415,6 +425,70 @@ class InactiveAccountDeletionHandlerTest {
             verify(accountDeletionService).deleteAccountViaDataApi(eq("inactive-sub"), any());
             verify(accountDeletionService, never())
                     .deleteAccountViaDataApi(eq("active-sub"), any());
+        }
+
+        @Test
+        void shouldEmitGuardrailMetricWhenAccountHasRecentActivity() {
+            var recentProfile = inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL);
+            recentProfile.setUpdated(RECENT_TIMESTAMP);
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.of(recentProfile));
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            handler.handleRequest(event, context);
+
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            GUARDRAIL_PREVENTED_INACTIVE_ACCOUNT_DELETION.getValue(),
+                            Map.of(
+                                    GUARDRAIL_TYPE.getValue(),
+                                    "AuthUserActivityCheck",
+                                    ENVIRONMENT.getValue(),
+                                    TEST_ENVIRONMENT),
+                            CloudwatchMetricsService.HOME_READ_ONLY_NAMESPACE);
+        }
+
+        @Test
+        void shouldNotEmitGuardrailMetricWhenAccountIsInactive() {
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            handler.handleRequest(event, context);
+
+            verifyNoInteractions(cloudwatchMetricsService);
+        }
+
+        @Test
+        void shouldNotEmitGuardrailMetricWhenUserProfileNotFound() {
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.empty());
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            handler.handleRequest(event, context);
+
+            verifyNoInteractions(cloudwatchMetricsService);
+        }
+
+        @Test
+        void shouldStillThrowRecentlyActiveAccountExceptionWhenMetricEmissionFails() {
+            var recentProfile = inactiveUserProfile(PUBLIC_SUBJECT_ID, EMAIL);
+            recentProfile.setUpdated(RECENT_TIMESTAMP);
+            when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                    .thenReturn(Optional.of(recentProfile));
+            doThrow(new RuntimeException("CloudWatch error"))
+                    .when(cloudwatchMetricsService)
+                    .incrementCounter(any(), any(Map.class), any());
+
+            var event =
+                    createSQSEventWithBody("{\"publicSubjectId\": \"" + PUBLIC_SUBJECT_ID + "\"}");
+
+            SQSBatchResponse response = handler.handleRequest(event, context);
+
+            assertThat(response.getBatchItemFailures(), hasSize(1));
+            verifyNoInteractions(accountDeletionService);
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -33,7 +33,8 @@ public enum CloudwatchMetricDimensions {
     OLD_PARALLELISM("OldParallelism"),
     NEW_MEMORY("NewMemory"),
     NEW_ITERATIONS("NewIterations"),
-    NEW_PARALLELISM("NewParallelism");
+    NEW_PARALLELISM("NewParallelism"),
+    GUARDRAIL_TYPE("GuardrailType");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -45,7 +45,8 @@ public enum CloudwatchMetrics {
     PASSKEY_DELETION_FAILED("PasskeyDeletionFailed"),
     PASSWORD_REHASH_COMPLETED("PasswordRehashCompleted"),
     AUTH_CODE_ISSUED("AuthCodeIssued"),
-    ENHANCED_AUTH_CODE_BLOCKED("EnhancedAuthCodeBlocked");
+    ENHANCED_AUTH_CODE_BLOCKED("EnhancedAuthCodeBlocked"),
+    GUARDRAIL_PREVENTED_INACTIVE_ACCOUNT_DELETION("GuardrailPreventedInactiveAccountDeletion");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -57,6 +57,8 @@ public class CloudwatchMetricsService {
     public static final String INTERNATIONAL_SMS_DESTINATION = "INTERNATIONAL";
     public static final String DOMESTIC_SMS_DESTINATION = "DOMESTIC";
     public static final String UNKNOWN_VALUE = "unknown";
+    public static final String AUTHENTICATION_NAMESPACE = "Authentication";
+    public static final String HOME_READ_ONLY_NAMESPACE = "Home-ReadOnly";
 
     private final ConfigurationService configurationService;
 
@@ -73,14 +75,30 @@ public class CloudwatchMetricsService {
                 "Metrics::EMF", () -> emitMetric(name, value, dimensions, new MetricsLogger()));
     }
 
+    public void putEmbeddedValue(
+            String name, double value, Map<String, String> dimensions, String namespace) {
+        segmentedFunctionCall(
+                "Metrics::EMF",
+                () -> emitMetric(name, value, dimensions, new MetricsLogger(), namespace));
+    }
+
     protected void emitMetric(
             String name, double value, Map<String, String> dimensions, MetricsLogger metrics) {
+        emitMetric(name, value, dimensions, metrics, AUTHENTICATION_NAMESPACE);
+    }
+
+    protected void emitMetric(
+            String name,
+            double value,
+            Map<String, String> dimensions,
+            MetricsLogger metrics,
+            String namespace) {
         try {
             var dimensionsSet = new DimensionSet();
 
             dimensions.forEach(dimensionsSet::addDimension);
 
-            metrics.setNamespace("Authentication");
+            metrics.setNamespace(namespace);
             metrics.putDimensions(dimensionsSet);
             metrics.putMetric(name, value, Unit.NONE);
             metrics.flush();
@@ -95,6 +113,10 @@ public class CloudwatchMetricsService {
 
     public void incrementCounter(CloudwatchMetrics name, Map<String, String> dimensions) {
         putEmbeddedValue(name.getValue(), 1, dimensions);
+    }
+
+    public void incrementCounter(String name, Map<String, String> dimensions, String namespace) {
+        putEmbeddedValue(name, 1, dimensions, namespace);
     }
 
     public void incrementMfaMethodCounter(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/MetricsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/MetricsTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
+import static uk.gov.di.authentication.shared.services.CloudwatchMetricsService.AUTHENTICATION_NAMESPACE;
+import static uk.gov.di.authentication.shared.services.CloudwatchMetricsService.HOME_READ_ONLY_NAMESPACE;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class MetricsTest {
@@ -61,7 +63,18 @@ class MetricsTest {
 
             service.emitMetric("Metric", 1, Collections.emptyMap(), metricsLogger);
 
-            verify(metricsLogger).setNamespace("Authentication");
+            verify(metricsLogger).setNamespace(AUTHENTICATION_NAMESPACE);
+        }
+
+        @Test
+        void shouldEmitMetricWithCustomNamespace() {
+            var service = new CloudwatchMetricsService(configurationWithEnvironment("test"));
+            var metricsLogger = Mockito.mock(MetricsLogger.class);
+            var namespace = HOME_READ_ONLY_NAMESPACE;
+
+            service.emitMetric("Metric", 1, Collections.emptyMap(), metricsLogger, namespace);
+
+            verify(metricsLogger).setNamespace(namespace);
         }
 
         @Test


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Emit `GuardrailPreventedInactiveAccountDeletion` metric when the IAD guardrails (added in AUT-5615) are hit (i.e., an account flagged for deletion has had recent activity).

Longer term (outside the scope of this ticket), either we (AUT-5820) or the home team (AUT-5819) will alarm on this metric which will trigger a circuit breaker, preventing additional deletion requests from being queued until the issue is reviewed.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env and locate the stub queue (not the DLQ!), and determine a public subject ID for an account which would be an invalid deletion (last activity <5y) and add a message of the format `{"publicSubjectId": "ID_HERE"}` to the stub queue and send. The deletion should fail and the Lambda logs should confirm this failure. The failsafe metric should be emitted and visible in CloudWatch with the correct namespace and dimensions.

## Testing

I deployed to authdev3 then:
- Found a public subject ID for an account which would be an invalid deletion (last activity <5y) and added a message of the format `{"publicSubjectId": "ID_HERE"}` to the stub queue and sent. Account deletion failed (as expected). Confirmed the metric was emitted with the expected namespace and dimensions:

<img width="1496" height="629" alt="Metric emitted in dev env" src="https://github.com/user-attachments/assets/a94088e7-ad67-4261-8da1-980996d30f33" />

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [x] PR is canary deploy safe **- utils Lambda only**

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- utils Lambda only**
