### PR TITLE
AUT-5821: Add lastSignedIn to IAD export timestamp candidates

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -137,6 +137,11 @@ public class InactiveAccountDataExportHelper {
                     new TimestampCandidate(
                             getTermsAndConditionsTimestamp(userProfileItem),
                             "UserProfile.termsAndConditions.timestamp"));
+            candidates.add(
+                    new TimestampCandidate(
+                            getStringAttribute(
+                                    userProfileItem, UserProfile.ATTRIBUTE_LAST_SIGNED_IN),
+                            "UserProfile.LastSignedIn"));
         }
 
         if (userCredentialsItem != null) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -50,7 +50,7 @@ public class InactiveAccountDataExportHandler
     private static final int BATCH_GET_ITEM_MAX_SIZE = 100;
 
     private static final String USER_PROFILE_PROJECTION_EXPRESSION =
-            "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt,PhoneNumberVerified,mfaMethodsMigrated";
+            "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt,PhoneNumberVerified,mfaMethodsMigrated,LastSignedIn";
     private static final Map<String, String> USER_PROFILE_EXPRESSION_ATTRIBUTE_NAMES =
             Map.of("#ts", "timestamp");
     private static final String USER_CREDENTIALS_PROJECTION_EXPRESSION =

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -476,6 +476,107 @@ class InactiveAccountDataExportHelperTest {
     }
 
     @Test
+    void calculateLastActiveDateShouldReturnLastSignedInWhenMostRecent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2023-05-10T14:30:00.222222").build(),
+                        UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS,
+                        AttributeValue.builder()
+                                .m(
+                                        Map.of(
+                                                "timestamp",
+                                                AttributeValue.builder()
+                                                        .s("2024-11-20T09:15:00.123456")
+                                                        .build()))
+                                .build(),
+                        UserProfile.ATTRIBUTE_LAST_SIGNED_IN,
+                        AttributeValue.builder().s("2025-08-01T12:00:00.444444").build());
+
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        UserCredentials.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        UserCredentials.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2024-06-01T08:00:00.333333").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2025-08-01T12:00:00.444444", result.timestamp());
+        assertEquals("UserProfile.LastSignedIn", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldNotReturnLastSignedInWhenNotMostRecent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2021-06-15T12:00:00.222222").build(),
+                        UserProfile.ATTRIBUTE_LAST_SIGNED_IN,
+                        AttributeValue.builder().s("2023-03-10T08:00:00.555555").build());
+
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        UserCredentials.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
+                        UserCredentials.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2025-03-20T16:45:00.552352138").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2025-03-20T16:45:00.552352138", result.timestamp());
+        assertEquals("UserCredentials.Updated", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnLastSignedInWhenOnlyTimestampPresent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_LAST_SIGNED_IN,
+                        AttributeValue.builder().s("2024-09-15T11:30:00.123456").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+
+        assertEquals("2024-09-15T11:30:00.123456", result.timestamp());
+        assertEquals("UserProfile.LastSignedIn", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldHandleLastSignedInNotPresent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        UserProfile.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        UserProfile.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2023-05-10T14:30:00.222222").build(),
+                        UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS,
+                        AttributeValue.builder()
+                                .m(
+                                        Map.of(
+                                                "timestamp",
+                                                AttributeValue.builder()
+                                                        .s("2024-11-20T09:15:00.123456")
+                                                        .build()))
+                                .build());
+
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        UserCredentials.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        UserCredentials.ATTRIBUTE_UPDATED,
+                        AttributeValue.builder().s("2024-06-01T08:00:00.333333").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2024-11-20T09:15:00.123456", result.timestamp());
+        assertEquals("UserProfile.termsAndConditions.timestamp", result.source());
+    }
+
+    @Test
     void calculateDateForDeletionShouldAddFiveYearsToDate() {
         assertEquals("2029-03-15", calculateDateForDeletion("2024-03-15T10:30:00.000000"));
     }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Since the IAD export Lambda was developed, the `lastSignedIn` attribute has been added to the user profile, this should be considered alongside the other timestamps when determining the initial* last active date of the account.

[* Initial as home will need to replay the audit events on top of this data whenever this is run (rarely).]

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Canary deploy safe

Changes across multiple lambdas may not be safe with our canary deployments, particularly if they make session changes etc.

Consider the impact of a user journey which may hit the new version of one lambda, and the old version of another. Could it go wrong? Think about whether you need to split further.

-->

- [x] PR is canary deploy safe

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes