### PR TITLE
AUT-5255: Remove legacy oidc Api from  production

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -196,3 +196,4 @@ lambda_max_concurrency = 10
 ipv_jwks_call_enabled          = true
 ipv_jwks_url                   = "https://api.identity.account.gov.uk/.well-known/jwks.json"
 deploy_oidc_api_gateway_domain = false
+deploy_orch_lambda_and_api     = false


### PR DESCRIPTION
## What

[AUT-5255] : Removing legacy Oidc Api from Production environment

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8856


[AUT-5255]: https://govukverify.atlassian.net/browse/AUT-5255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ